### PR TITLE
Dependabot: specify insecure code execution for specific registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: bundler
-    registries: "*"
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: bundler
+    registries: "github"
     insecure-external-code-execution: allow
     directory: /
     schedule:


### PR DESCRIPTION

In order to get Dependabot to work with our govuk_chat_private private
repo, we needed to define a "github" registry in the config file with a
set of credentials which allows Dependabot to check out that repo.

Furthermore it wouldn't check out the repo unless we set the
`insecure-external-code-execution` option to `"allow"`. But it feels a
bit risky to be allowing insecure code execution for all of our gem
dependencies.

This commit is an attempt to tighten up this requirement by adding
another Bundler ecosystem that's references just the "github" registry
and sets the `insecure-external-code-execution` to `"allow"` hopefully
for just that registry.

The idea being that the other Bundler ecosystem doesn't have a registry
defined so perhaps Dependabot will use that one for all the public gems,
and use the "github" registry ecosystem for our private gem.
