### PR TITLE
Fix Dependabot registries syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    registries: "github"
+    registries:
+      - github
     insecure-external-code-execution: allow
     directory: /
     schedule:


### PR DESCRIPTION

Looks like this `registries` property needs to be an array rather than a
string.
