### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: bundler
-    registries:
-      - github
+    registries: "*"
     insecure-external-code-execution: allow
     directory: /
     schedule:


### PR DESCRIPTION

The previous couple of commits were aimed at trying to tighten the
security of the Dependabot config by not allowing all dependencies to
allow insecure external code execution.

But it seems Dependabot only allows unique ecosystems in a file:

> Update configs must have a unique combination of 'package-ecosystem',
> 'directory', and 'target-branch'. Ecosystem 'bundler' has
> overlapping directories.

So we need to revert these changes to get Dependabot working again.
