### PR TITLE
Remove data from the autoloading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module GovukChat
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets data tasks])
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
We no longer make use of a lib/data directory as the files are no longer stored in this repository.