### PR TITLE
Extend LinkTokenMapper to handle anchor tags

### DIFF
--- a/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
@@ -89,7 +89,7 @@ module AnswerComposition::Pipeline
           page_title: result.title,
           page_description: result.description,
           context_headings: result.heading_hierarchy,
-          context_content: link_token_mapper.map_links_to_tokens(result.html_content),
+          context_content: link_token_mapper.map_links_to_tokens(result.html_content, result.exact_path),
         }
       end
     end

--- a/spec/lib/answer_composition/link_token_mapper_spec.rb
+++ b/spec/lib/answer_composition/link_token_mapper_spec.rb
@@ -12,17 +12,18 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
         <li>prove you're self-employed, for example to claim Tax-Free Childcare</li>
         <li>make voluntary <a id="foo" href="https://www.gov.uk/national-insurance/what-national-insurance-is">National Insurance</a> payments</li>
         <li>fill in a <a href="/tax-returns">Tax return</a> each tax year.</li>
+        <li>this is <a href="#some-heading">an anchor tag</a>.</li>
       </ul>
     HTML
   end
 
   describe "#map_links_to_tokens" do
     it "replaces href attributes with tokens" do
-      amended_html = described_class.new.map_links_to_tokens(html)
+      amended_html = described_class.new.map_links_to_tokens(html, "/exact-path")
       parsed_html = Nokogiri::HTML::DocumentFragment.parse(amended_html)
       links = parsed_html.css("a")
 
-      expect(links.length).to eq(4)
+      expect(links.length).to eq(5)
 
       expect(links[0]["href"]).to eq("link_1")
       expect(links[0].text).to eq("Tax return")
@@ -33,9 +34,12 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
       expect(links[2]["href"]).to eq("link_3")
       expect(links[2].text).to eq("National Insurance")
 
-      #  Duplicate link, so gets the same token as the first link
+      # Duplicate link, so gets the same token as the first link
       expect(links[3]["href"]).to eq("link_1")
       expect(links[3].text).to eq("Tax return")
+
+      expect(links[4]["href"]).to eq("link_4")
+      expect(links[4].text).to eq("an anchor tag")
     end
   end
 
@@ -60,7 +64,7 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
   describe "#replace_tokens_with_links" do
     it "replaces token-based links with stored links that are absolute URIs" do
       mapper = described_class.new
-      mapper.map_links_to_tokens(html)
+      mapper.map_links_to_tokens(html, "/exact-path")
 
       source = <<~MARKDOWN
         # Tax
@@ -73,6 +77,7 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
 
         * prove you're self-employed, for example to claim Tax-Free Childcare
         * make voluntary [National Insurance](link_3) payments
+        * do something with an [anchor tag](link_4)
 
         [1]: link_2
       MARKDOWN
@@ -93,11 +98,15 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
       expect(output)
         .to include("[National Insurance][3]")
         .and include("[3]: https://www.gov.uk/national-insurance/what-national-insurance-is")
+
+      expect(output)
+        .to include("[anchor tag][4]")
+        .and include("[4]: https://www.test.gov.uk/exact-path#some-heading")
     end
 
     it "replaces link text that has not been substituted" do
       mapper = described_class.new
-      mapper.map_links_to_tokens(html)
+      mapper.map_links_to_tokens(html, "/exact-path")
 
       markdown = <<~MARKDOWN
         Send a tax return ([link_1][1])
@@ -112,7 +121,7 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
     it "handles invalid URIs" do
       html = '<p>Send a tax return to <a href="mailto:<user@example.com>">us</a></p>'
       mapper = described_class.new
-      mapper.map_links_to_tokens(html)
+      mapper.map_links_to_tokens(html, "/exact-path")
 
       markdown = <<~MARKDOWN
         You should send a tax return to [us](link_1)
@@ -140,9 +149,9 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
   describe "#link_for_token" do
     it "returns the link for a given token" do
       mapper = described_class.new
-      mapper.map_links_to_tokens(html)
+      mapper.map_links_to_tokens(html, "/exact-path")
 
-      expect(mapper.link_for_token("link_1")).to eq("/tax-returns")
+      expect(mapper.link_for_token("link_1")).to eq("https://www.test.gov.uk/tax-returns")
     end
 
     it "returns nil if the token is not in the mapping" do


### PR DESCRIPTION
https://trello.com/c/y327T4Dy/2270

We had an issue recently where the `LinkTokenMapper` returned an invalid
URL in an answer because the source URL was an anchor tag.

For context, the `LinkTokenMapper` will read some HTML and store the links
in a hash with a key of the URL and value of "link_x" where x is an
integer.

A method can then be called to pass in some markdown which contains
links in the form "link_x" and it rewrites those to the stored URLs.

However there's a bug when an anchor link is used. In this case, the
mapper will take a link like "#heading-1" and rewrite it to
"https://www.gov.uk/#heading-1".

This happens because we store the link's `href` in the mapping, then
when we come to replace the token with a link, it's seen as a relative
URL so we turn it into an absolute URL by prepending the website root to
it.

This works fine for relative URLs but not for anchor tags. In those
cases, we need to know the `exact_path` of the chunk we're using so we
can make it into a relative URL.

For example, if we have a chunk with the `exact_path` of
"/browse/business" and some HTML content of:

```
this is <a href="#anchor">an anchor</a>.
```

then when we come to replace the token with a link it needs to produce
the URL `https://www.gov.uk/browse/business#anchor`, rather than
`https://www.gov.uk/#anchor` which it does now.

To fix this we can pass the `exact_path` as a parameter in when mapping
the links to tokens. If the link is an anchor (i.e. starts with a "#")
then we store the exact path plus the anchor in the mapping.

The rest of the code doesn't need to change because when we replace the
tokens with links, all the stored links are either full relative links
or absolute links, there won't be any plain anchor tags.
