### PR TITLE
Check for signon access before chat offline

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,7 +1,7 @@
 class BaseController < ApplicationController
   include Passwordless::ControllerHelpers
-  before_action :check_chat_public_access
   before_action :ensure_signon_user_if_required
+  before_action :check_chat_public_access
   before_action :ensure_early_access_user_if_required
   helper_method :current_early_access_user, :settings
 


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

This modifies the ordering of these before actions so that if chat requires signon for access then you will be authenticated for that before the check for whether the application is offline or not.

The motivation for this is deintegrating chat from www.gov.uk and switching back to requiring signon for chat access. As chat is currently offline it surprised me that visiting
chat.integration.publishing.service.gov.uk showed the offline page rather than signon. Thus I felt we should these round.