### PR TITLE
Implement basic RAG with Claude

### DIFF
--- a/lib/answer_composition/composer.rb
+++ b/lib/answer_composition/composer.rb
@@ -55,6 +55,7 @@ module AnswerComposition
       when "claude_structured_answer"
         PipelineRunner.call(question:, pipeline: [
           Pipeline::QuestionRephraser.new(llm_provider: :claude),
+          Pipeline::SearchResultFetcher,
           Pipeline::Claude::StructuredAnswerComposer,
         ])
       else

--- a/lib/answer_composition/composer.rb
+++ b/lib/answer_composition/composer.rb
@@ -49,7 +49,7 @@ module AnswerComposition
           Pipeline::QuestionRouter,
           Pipeline::QuestionRoutingGuardrails,
           Pipeline::SearchResultFetcher,
-          Pipeline::OpenAIStructuredAnswerComposer,
+          Pipeline::OpenAI::StructuredAnswerComposer,
           Pipeline::AnswerGuardrails,
         ])
       when "claude_structured_answer"

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -51,19 +51,10 @@ module AnswerComposition::Pipeline
       end
 
       def system_prompt
-        sprintf(prompt_config[:system_prompt], context: system_prompt_context)
-      end
-
-      def system_prompt_context
-        context.search_results.map do |result|
-          {
-            page_url: link_token_mapper.map_link_to_token(result.exact_path),
-            page_title: result.title,
-            page_description: result.description,
-            context_headings: result.heading_hierarchy,
-            context_content: link_token_mapper.map_links_to_tokens(result.html_content, result.exact_path),
-          }
-        end
+        sprintf(
+          prompt_config[:system_prompt],
+          context: context.search_results_prompt_formatted(link_token_mapper),
+        )
       end
 
       def prompt_config

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -1,99 +1,109 @@
-module AnswerComposition::Pipeline::Claude
-  class StructuredAnswerComposer
-    BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
+module AnswerComposition::Pipeline
+  module Claude
+    class StructuredAnswerComposer
+      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
 
-    def self.call(...) = new(...).call
+      def self.call(...) = new(...).call
 
-    def initialize(context)
-      @context = context
-    end
+      def initialize(context)
+        @context = context
+        @link_token_mapper = AnswerComposition::LinkTokenMapper.new
+      end
 
-    def call
-      start_time = Clock.monotonic_time
+      def call
+        start_time = Clock.monotonic_time
 
-      response = bedrock_client.converse(
-        system: [{ text: system_prompt }],
-        model_id: BEDROCK_MODEL,
-        messages:,
-        inference_config:,
-        tool_config:,
-      )
+        response = bedrock_client.converse(
+          system: [{ text: system_prompt }],
+          model_id: BEDROCK_MODEL,
+          messages:,
+          inference_config:,
+          tool_config:,
+        )
 
-      context.answer.assign_llm_response("structured_answer", response.to_h)
-      message = response.dig("output", "message", "content", 0, "tool_use", "input", "answer")
-      context.answer.assign_attributes(message:, status: "answered")
-      context.answer.assign_metrics("structured_answer", build_metrics(start_time, response))
-    end
+        tool_output = response.dig("output", "message", "content", 0, "tool_use", "input")
+        set_context_sources(tool_output["sources_used"])
 
-  private
+        context.answer.assign_llm_response("structured_answer", response.to_h)
+        message = link_token_mapper.replace_tokens_with_links(tool_output["answer"])
+        context.answer.assign_attributes(message:, status: "answered")
+        context.answer.assign_metrics("structured_answer", build_metrics(start_time, response))
+      end
 
-    attr_reader :context
+    private
 
-    def messages
-      [
-        {
-          role: "user",
-          content: [{ text: context.question_message }],
-        },
-      ]
-    end
+      attr_reader :context, :link_token_mapper
 
-    def inference_config
-      {
-        max_tokens: 1000,
-        temperature: 0.0,
-      }
-    end
-
-    def system_prompt
-      <<~PROMPT
-        You are a chat assistant for the UK government, designed to provide helpful and contextually relevant responses to user queries.
-        Provide concise responses based on the content on the GOV.UK website.
-      PROMPT
-    end
-
-    def bedrock_client
-      @bedrock_client ||= Aws::BedrockRuntime::Client.new
-    end
-
-    def build_metrics(start_time, response)
-      {
-        duration: Clock.monotonic_time - start_time,
-        llm_prompt_tokens: response.dig("usage", "input_tokens"),
-        llm_completion_tokens: response.dig("usage", "output_tokens"),
-      }
-    end
-
-    def tool_config
-      {
-        tools: tools,
-        tool_choice: {
-          tool: {
-            name: "answer_confidence",
+      def messages
+        [
+          {
+            role: "user",
+            content: [{ text: context.question_message }],
           },
-        },
-      }
-    end
+        ]
+      end
 
-    def tools
-      [
+      def inference_config
         {
-          tool_spec: {
-            name: "answer_confidence",
-            description: "Prints the answer of a given question with a confidence score.",
-            input_schema: {
-              json: {
-                type: "object",
-                properties: {
-                  answer: { description: "Your answer to the question in markdown format", title: "Answer", type: "string" },
-                  confidence: { description: "Your confidence in the answer provided, ranging from 0.0 to 1.0", title: "Confidence", type: "number" },
-                },
-                required: %w[answer confidence],
-              },
+          max_tokens: 4096,
+          temperature: 0.0,
+        }
+      end
+
+      def system_prompt
+        sprintf(prompt_config[:system_prompt], context: system_prompt_context)
+      end
+
+      def system_prompt_context
+        context.search_results.map do |result|
+          {
+            page_url: link_token_mapper.map_link_to_token(result.exact_path),
+            page_title: result.title,
+            page_description: result.description,
+            context_headings: result.heading_hierarchy,
+            context_content: link_token_mapper.map_links_to_tokens(result.html_content, result.exact_path),
+          }
+        end
+      end
+
+      def prompt_config
+        Claude.prompt_config[:structured_answer]
+      end
+
+      def bedrock_client
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+      end
+
+      def set_context_sources(sources_used)
+        source_urls = sources_used.map do |source_link_token|
+          link_token_mapper.link_for_token(source_link_token)
+        end
+
+        context.update_sources_from_exact_paths_used(source_urls)
+      end
+
+      def build_metrics(start_time, response)
+        {
+          duration: Clock.monotonic_time - start_time,
+          llm_prompt_tokens: response.dig("usage", "input_tokens"),
+          llm_completion_tokens: response.dig("usage", "output_tokens"),
+        }
+      end
+
+      def tool_config
+        {
+          tools: tools,
+          tool_choice: {
+            tool: {
+              name: "output_schema",
             },
           },
-        },
-      ]
+        }
+      end
+
+      def tools
+        [{ tool_spec: prompt_config[:tool_spec] }]
+      end
     end
   end
 end

--- a/lib/answer_composition/pipeline/context.rb
+++ b/lib/answer_composition/pipeline/context.rb
@@ -68,5 +68,20 @@ module AnswerComposition::Pipeline
 
       answer.sources = used_sources + unused_sources
     end
+
+    def search_results_prompt_formatted(link_token_mapper)
+      search_results.map do |result|
+        {
+          page_url: link_token_mapper.map_link_to_token(result.exact_path),
+          page_title: result.title,
+          page_description: result.description,
+          context_headings: result.heading_hierarchy,
+          context_content: link_token_mapper.map_links_to_tokens(
+            result.html_content,
+            result.exact_path,
+          ),
+        }
+      end
+    end
   end
 end

--- a/lib/answer_composition/pipeline/openai/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/openai/structured_answer_composer.rb
@@ -1,5 +1,5 @@
-module AnswerComposition::Pipeline
-  class OpenAIStructuredAnswerComposer
+module AnswerComposition::Pipeline::OpenAI
+  class StructuredAnswerComposer
     OPENAI_MODEL = "gpt-4o-2024-08-06".freeze
 
     def self.call(...) = new(...).call

--- a/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
@@ -79,26 +79,17 @@ module AnswerComposition::Pipeline
     end
 
     def system_prompt
-      sprintf(llm_prompts[:system_prompt], context: system_prompt_context)
-    end
-
-    def system_prompt_context
-      context.search_results.map do |result|
-        {
-          page_url: link_token_mapper.map_link_to_token(result.exact_path),
-          page_title: result.title,
-          page_description: result.description,
-          context_headings: result.heading_hierarchy,
-          context_content: link_token_mapper.map_links_to_tokens(result.html_content, result.exact_path),
-        }
-      end
+      sprintf(
+        openai_prompts[:system_prompt],
+        context: context.search_results_prompt_formatted(link_token_mapper),
+      )
     end
 
     def output_schema
-      llm_prompts[:output_schema]
+      openai_prompts[:output_schema]
     end
 
-    def llm_prompts
+    def openai_prompts
       Rails.configuration.govuk_chat_private.llm_prompts.openai.structured_answer
     end
 

--- a/spec/lib/answer_composition/composer_spec.rb
+++ b/spec/lib/answer_composition/composer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AnswerComposition::Composer do
           AnswerComposition::Pipeline::QuestionRouter,
           AnswerComposition::Pipeline::QuestionRoutingGuardrails,
           AnswerComposition::Pipeline::SearchResultFetcher,
-          AnswerComposition::Pipeline::OpenAIStructuredAnswerComposer,
+          AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer,
           AnswerComposition::Pipeline::AnswerGuardrails,
         ]
         expected_pipeline.each do |pipeline|

--- a/spec/lib/answer_composition/composer_spec.rb
+++ b/spec/lib/answer_composition/composer_spec.rb
@@ -69,9 +69,13 @@ RSpec.describe AnswerComposition::Composer do
         rephraser = instance_double(AnswerComposition::Pipeline::QuestionRephraser)
         allow(AnswerComposition::Pipeline::QuestionRephraser)
           .to receive(:new).with(llm_provider: :claude).and_return(rephraser)
+        search_result_fetcher = instance_double(AnswerComposition::Pipeline::SearchResultFetcher)
+        allow(AnswerComposition::Pipeline::SearchResultFetcher)
+          .to receive(:new).with(llm_provider: :claude).and_return(search_result_fetcher)
 
         expected_pipeline = [
           AnswerComposition::Pipeline::QuestionRephraser.new(llm_provider: :claude),
+          AnswerComposition::Pipeline::SearchResultFetcher,
           AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
         ]
         expected_pipeline.each do |pipeline|

--- a/spec/lib/answer_composition/pipeline/context_spec.rb
+++ b/spec/lib/answer_composition/pipeline/context_spec.rb
@@ -203,4 +203,28 @@ RSpec.describe AnswerComposition::Pipeline::Context do
       expect(unused_source.relevancy).to eq(1)
     end
   end
+
+  describe "#search_results_prompt_formatted" do
+    it "returns an array of hashes with the correct structure" do
+      instance = described_class.new(build(:question))
+      instance.search_results = build_list(:chunked_content_search_result, 2)
+      link_token_mapper = AnswerComposition::LinkTokenMapper.new
+
+      formatted = instance.search_results_prompt_formatted(link_token_mapper)
+
+      formatted.each_with_index do |hash, index|
+        result = instance.search_results[index]
+        expect(hash).to include(
+          page_url: link_token_mapper.map_link_to_token(result.exact_path),
+          page_title: result.title,
+          page_description: result.description,
+          context_headings: result.heading_hierarchy,
+          context_content: link_token_mapper.map_links_to_tokens(
+            result.html_content,
+            result.exact_path,
+          ),
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/answer_composition/pipeline/openai/structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai/structured_answer_composer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AnswerComposition::Pipeline::OpenAIStructuredAnswerComposer, :chunked_content_index do # rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer, :chunked_content_index do # rubocop:disable RSpec/SpecFilePathFormat
   describe ".call" do
     let(:question) { build :question }
     let(:context) { build(:answer_pipeline_context, question:) }

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -37,8 +37,8 @@ module StubBedrock
       end
 
       bedrock_claude_tool_response(
-        { "answer" => answer, "confidence" => 0.9 },
-        tool_name: "answer_confidence",
+        { "answer" => answer, "answered" => true, "sources_used" => %w[link_1] },
+        tool_name: "output_schema",
       )
     end
   end

--- a/spec/support/stub_openai_chat.rb
+++ b/spec/support/stub_openai_chat.rb
@@ -40,7 +40,7 @@ module StubOpenAIChat
 
     structured_generation_chat_options = chat_options.merge(
       {
-        model: AnswerComposition::Pipeline::OpenAIStructuredAnswerComposer::OPENAI_MODEL,
+        model: AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer::OPENAI_MODEL,
         tools: [
           {
             type: "function",

--- a/spec/system/conversation_with_claude_structured_answer_spec.rb
+++ b/spec/system/conversation_with_claude_structured_answer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Conversation with Claude with a structured answer" do
+RSpec.describe "Conversation with Claude with a structured answer", :chunked_content_index do
   scenario do
     given_i_am_using_the_claude_structured_answer_strategy
     and_i_am_a_signed_in_early_access_user
@@ -37,6 +37,14 @@ RSpec.describe "Conversation with Claude with a structured answer" do
   end
 
   def when_the_first_answer_is_generated
+    openai_embedding = mock_openai_embedding(@first_question)
+    allow(Search::TextToEmbedding)
+      .to receive(:call)
+      .and_return(openai_embedding)
+    populate_chunked_content_index([
+      build(:chunked_content_record, openai_embedding:, exact_path: "/pay-more-tax#yes-really"),
+    ])
+
     @first_answer = "Lots of tax."
     stub_bedrock_converse(
       bedrock_claude_structured_answer_response(@first_question, @first_answer),


### PR DESCRIPTION
This PR iterates on the Claude answer strategy to add fetching search results to the Pipeline and then replicating the structured answer approach used for OpenAI.

The Claude `structured_answer_composer` now provides the retrieved sources in the request to Claude, incorporates links in the answer, and marks sources as used or unused.