### PR TITLE
Use namespaced LLM prompt config files

### DIFF
--- a/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/openai_structured_answer_composer.rb
@@ -99,7 +99,7 @@ module AnswerComposition::Pipeline
     end
 
     def llm_prompts
-      Rails.configuration.govuk_chat_private.llm_prompts.openai_structured_answer
+      Rails.configuration.govuk_chat_private.llm_prompts.openai.structured_answer
     end
 
     def openai_client

--- a/lib/answer_composition/pipeline/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/question_rephraser.rb
@@ -79,7 +79,7 @@ module AnswerComposition
       end
 
       def config
-        Rails.configuration.govuk_chat_private.llm_prompts.question_rephraser
+        Rails.configuration.govuk_chat_private.llm_prompts.openai.question_rephraser
       end
 
       def user_prompt

--- a/lib/answer_composition/pipeline/question_router.rb
+++ b/lib/answer_composition/pipeline/question_router.rb
@@ -111,7 +111,7 @@ module AnswerComposition
       end
 
       def config
-        Rails.configuration.govuk_chat_private.llm_prompts.question_routing
+        Rails.configuration.govuk_chat_private.llm_prompts.openai.question_routing
       end
 
       def openai_client

--- a/lib/guardrails/jailbreak_checker.rb
+++ b/lib/guardrails/jailbreak_checker.rb
@@ -31,7 +31,7 @@ module Guardrails
     end
 
     def self.guardrails_llm_prompts
-      Rails.configuration.govuk_chat_private.llm_prompts.jailbreak_guardrails
+      Rails.configuration.govuk_chat_private.llm_prompts.openai.jailbreak_guardrails
     end
 
     def self.call(...) = new(...).call

--- a/lib/guardrails/multiple_checker.rb
+++ b/lib/guardrails/multiple_checker.rb
@@ -17,7 +17,7 @@ module Guardrails
       Guardrail = Data.define(:key, :name, :content)
 
       def initialize(prompt_name)
-        prompts = Rails.configuration.govuk_chat_private.llm_prompts[prompt_name]
+        prompts = Rails.configuration.govuk_chat_private.llm_prompts.openai[prompt_name]
         raise "No LLM prompts found for #{prompt_name}" unless prompts
 
         @prompts = prompts

--- a/spec/config/question_routing_labels_spec.rb
+++ b/spec/config/question_routing_labels_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Question routing labels" do
   it "has a human-readable label for each question routing label in the LLM config" do
-    llm_config = Rails.configuration.govuk_chat_private.llm_prompts.question_routing
+    llm_config = Rails.configuration.govuk_chat_private.llm_prompts.openai.question_routing
     llm_labels = llm_config[:classifications].map { |classification| classification[:name] }
 
     label_config = Rails.configuration.question_routing_labels

--- a/spec/lib/answer_composition/pipeline/openai_structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai_structured_answer_composer_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAIStructuredAnswerComposer, :chu
     end
 
     def llm_prompts
-      Rails.configuration.govuk_chat_private.llm_prompts.openai_structured_answer
+      Rails.configuration.govuk_chat_private.llm_prompts.openai.structured_answer
     end
   end
 end

--- a/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
@@ -164,6 +164,6 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser do
   end
 
   def config
-    Rails.configuration.govuk_chat_private.llm_prompts.question_rephraser
+    Rails.configuration.govuk_chat_private.llm_prompts.openai.question_rephraser
   end
 end

--- a/spec/lib/answer_composition/pipeline/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_router_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter do
   end
 
   before do
-    allow(Rails.configuration.govuk_chat_private.llm_prompts.question_routing).to receive(:[]).and_call_original
-    allow(Rails.configuration.govuk_chat_private.llm_prompts.question_routing)
+    allow(Rails.configuration.govuk_chat_private.llm_prompts.openai.question_routing).to receive(:[]).and_call_original
+    allow(Rails.configuration.govuk_chat_private.llm_prompts.openai.question_routing)
     .to receive(:[]).with(:classifications).and_return([classification])
   end
 
@@ -239,7 +239,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter do
     end
 
     def llm_prompts
-      Rails.configuration.govuk_chat_private.llm_prompts.question_routing
+      Rails.configuration.govuk_chat_private.llm_prompts.openai.question_routing
     end
   end
 end

--- a/spec/lib/guardrails/jailbreak_checker_spec.rb
+++ b/spec/lib/guardrails/jailbreak_checker_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe Guardrails::JailbreakChecker do
   let(:input) { "User question" }
 
   it "calls OpenAI to check for jailbreak attempts" do
-    system_prompt = Rails.configuration.govuk_chat_private.llm_prompts.jailbreak_guardrails[:system_prompt]
-    user_prompt = Rails.configuration.govuk_chat_private.llm_prompts.jailbreak_guardrails[:user_prompt].sub("{input}", input)
+    prompts = Rails.configuration.govuk_chat_private.llm_prompts.openai
+    system_prompt = prompts.jailbreak_guardrails[:system_prompt]
+    user_prompt = prompts.jailbreak_guardrails[:user_prompt].sub("{input}", input)
     messages = array_including(
       { "role" => "system", "content" => system_prompt },
       { "role" => "user", "content" => user_prompt },

--- a/spec/lib/guardrails/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/multiple_checker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Guardrails::MultipleChecker do
   describe ".call" do
     context "when the request is successful" do
       let(:llm_prompt_name) { :answer_guardrails }
-      let(:guardrails_config) { Rails.configuration.govuk_chat_private.llm_prompts.public_send(llm_prompt_name) }
+      let(:guardrails_config) { Rails.configuration.govuk_chat_private.llm_prompts.openai.public_send(llm_prompt_name) }
       let(:guardrail_definitions) do
         {
           "costs" => "This is a costs guardrail",
@@ -187,7 +187,7 @@ RSpec.describe Guardrails::MultipleChecker do
 
     before do
       guardrails_config = { system_prompt:, user_prompt:, guardrails:, guardrail_definitions: }.with_indifferent_access
-      allow(Rails.configuration.govuk_chat_private.llm_prompts).to receive(:[]).with(llm_prompt_name).and_return(guardrails_config)
+      allow(Rails.configuration.govuk_chat_private.llm_prompts.openai).to receive(:[]).with(llm_prompt_name).and_return(guardrails_config)
     end
 
     context "when the llm_prompt_name is :answer_guardrails" do

--- a/spec/support/stub_openai_chat.rb
+++ b/spec/support/stub_openai_chat.rb
@@ -36,7 +36,7 @@ module StubOpenAIChat
   end
 
   def stub_openai_chat_completion_structured_response(question_or_history, answer, chat_options: {})
-    output_schema = Rails.configuration.govuk_chat_private.llm_prompts.openai_structured_answer[:output_schema]
+    output_schema = Rails.configuration.govuk_chat_private.llm_prompts.openai.structured_answer[:output_schema]
 
     structured_generation_chat_options = chat_options.merge(
       {
@@ -103,7 +103,7 @@ module StubOpenAIChat
   end
 
   def stub_openai_question_rephrasing(original_question, rephrased_question)
-    config = Rails.configuration.govuk_chat_private.llm_prompts.question_rephraser
+    config = Rails.configuration.govuk_chat_private.llm_prompts.openai.question_rephraser
 
     stub_openai_chat_completion(
       array_including(


### PR DESCRIPTION
The govuk_chat_private gem has been modified to move the LLM prompts
into provider-specific namespaces, so we need to update the calls to the
config accordingly.
