### PR TITLE
Add AWS env vars to Heroku manifest

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,6 +42,15 @@
     },
     "REDIS_SSL_VERIFY_NONE": {
       "value": "true"
+    },
+    "AWS_REGION": {
+      "value": "eu-west-1"
+    },
+    "AWS_ACCESS_KEY_ID": {
+      "required": true
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+      "required": true
     }
   },
   "formation": {


### PR DESCRIPTION
Now that we support LLM calls to AWS bedrock this configures the environment variables for Heroku review apps.

We could decide that we want to set up an env var here of ANSWER_STRATEGY to force this to be Claude since most of our recent changes will be Claude specific.