### PR TITLE
Show question's answer strategy on admin show page

### DIFF
--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -109,6 +109,10 @@ module Admin
                       ),
                   },
                   {
+                    field: "Answer strategy",
+                    value: question.answer_strategy.humanize,
+                  },
+                  {
                     field: "Jailbreak guardrails status",
                     value: answer.jailbreak_guardrails_status,
                   },

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Admin::QuestionsHelper do
         "Status",
         "Answer created at",
         "Answer",
+        "Answer strategy",
         "Jailbreak guardrails status",
         "Question routing label",
         "Question routing confidence score",


### PR DESCRIPTION
Now that we're starting to use Bedrock, it's useful when developing to
know which answer strategy was used.

<img width="756" alt="Screenshot 2025-02-07 at 15 13 27" src="https://github.com/user-attachments/assets/3844c180-7e1e-4ae5-b42c-29c6a98b8303" />

