### PR TITLE
Add question rephrasing to Claude pipeline

### DIFF
--- a/lib/answer_composition/composer.rb
+++ b/lib/answer_composition/composer.rb
@@ -45,7 +45,7 @@ module AnswerComposition
       when "openai_structured_answer"
         PipelineRunner.call(question:, pipeline: [
           Pipeline::JailbreakGuardrails,
-          Pipeline::QuestionRephraser,
+          Pipeline::QuestionRephraser.new(llm_provider: :openai),
           Pipeline::QuestionRouter,
           Pipeline::QuestionRoutingGuardrails,
           Pipeline::SearchResultFetcher,
@@ -54,6 +54,7 @@ module AnswerComposition
         ])
       when "claude_structured_answer"
         PipelineRunner.call(question:, pipeline: [
+          Pipeline::QuestionRephraser.new(llm_provider: :claude),
           Pipeline::Claude::StructuredAnswerComposer,
         ])
       else

--- a/lib/answer_composition/pipeline/claude.rb
+++ b/lib/answer_composition/pipeline/claude.rb
@@ -1,0 +1,5 @@
+module AnswerComposition::Pipeline::Claude
+  def self.prompt_config
+    Rails.configuration.govuk_chat_private.llm_prompts.claude
+  end
+end

--- a/lib/answer_composition/pipeline/claude/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/claude/question_rephraser.rb
@@ -1,0 +1,83 @@
+module AnswerComposition::Pipeline
+  module Claude
+    class QuestionRephraser
+      # TODO: change this to a more basic model
+      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
+
+      def self.call(...) = new(...).call
+
+      def initialize(question_message, message_records)
+        @question_message = question_message
+        @message_records = message_records
+      end
+
+      def call
+        response = bedrock_client.converse(
+          system: [{ text: config[:system_prompt] }],
+          model_id: BEDROCK_MODEL,
+          messages:,
+          inference_config:,
+        )
+
+        AnswerComposition::Pipeline::QuestionRephraser::Result.new(
+          llm_response: response.to_h,
+          rephrased_question: response.dig("output", "message", "content", 0, "text"),
+          metrics: build_metrics(response),
+        )
+      end
+
+    private
+
+      attr_reader :question_message, :message_records
+
+      def bedrock_client
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+      end
+
+      def build_metrics(response)
+        {
+          llm_prompt_tokens: response.dig("usage", "input_tokens"),
+          llm_completion_tokens: response.dig("usage", "output_tokens"),
+        }
+      end
+
+      def config
+        Claude.prompt_config[:question_rephraser]
+      end
+
+      def inference_config
+        {
+          max_tokens: 4096,
+          temperature: 0.0,
+        }
+      end
+
+      def user_prompt
+        config[:user_prompt]
+          .sub("{question}", question_message)
+          .sub("{message_history}", message_history)
+      end
+
+      def messages
+        [{ role: "user", content: [{ text: user_prompt }] }]
+      end
+
+      def message_history
+        message_records.flat_map(&method(:map_question)).join("\n")
+      end
+
+      def map_question(question)
+        question_message = question.answer.rephrased_question || question.message
+
+        [
+          format_messsage("user", question_message),
+          format_messsage("assistant", question.answer.message),
+        ]
+      end
+
+      def format_messsage(actor, message)
+        ["#{actor}:", '"""', message, '"""'].join("\n")
+      end
+    end
+  end
+end

--- a/lib/answer_composition/pipeline/openai/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/openai/question_rephraser.rb
@@ -1,0 +1,84 @@
+module AnswerComposition::Pipeline::OpenAI
+  class QuestionRephraser
+    OPENAI_MODEL = "gpt-4o-mini".freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(question_message, question_records)
+      @question_message = question_message
+      @question_records = question_records
+    end
+
+    def call
+      AnswerComposition::Pipeline::QuestionRephraser::Result.new(
+        llm_response: openai_response_choice,
+        rephrased_question: openai_response_choice.dig("message", "content"),
+        metrics:,
+      )
+    end
+
+  private
+
+    attr_reader :question_message, :question_records
+
+    def openai_response
+      @openai_response ||= openai_client.chat(
+        parameters: {
+          model: OPENAI_MODEL,
+          messages:,
+          temperature: 0.0,
+        },
+      )
+    end
+
+    def openai_response_choice
+      @openai_response_choice ||= openai_response.dig("choices", 0)
+    end
+
+    def messages
+      [
+        { role: "system", content: config[:system_prompt] },
+        { role: "user", content: user_prompt },
+      ]
+    end
+
+    def user_prompt
+      config[:user_prompt]
+        .sub("{question}", question_message)
+        .sub("{message_history}", message_history)
+    end
+
+    def openai_client
+      @openai_client ||= OpenAIClient.build
+    end
+
+    def message_history
+      question_records.flat_map(&method(:map_question)).join("\n")
+    end
+
+    def map_question(question)
+      question_message = question.answer.rephrased_question || question.message
+
+      [
+        format_messsage("user", question_message),
+        format_messsage("assistant", question.answer.message),
+      ]
+    end
+
+    def config
+      Rails.configuration.govuk_chat_private.llm_prompts.openai.question_rephraser
+    end
+
+    def format_messsage(actor, message)
+      ["#{actor}:", '"""', message, '"""'].join("\n")
+    end
+
+    def metrics
+      {
+        llm_prompt_tokens: openai_response.dig("usage", "prompt_tokens"),
+        llm_completion_tokens: openai_response.dig("usage", "completion_tokens"),
+        llm_cached_tokens: openai_response.dig("usage", "prompt_tokens_details", "cached_tokens"),
+      }
+    end
+  end
+end

--- a/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRephraser do
+  let(:conversation) { create :conversation, :with_history }
+  let(:question) { conversation.questions.strict_loading(false).last }
+  let(:context) { build(:answer_pipeline_context, question:) }
+  let(:question_records) { conversation.questions.joins(:answer) }
+
+  context "when there is a valid response from Claude" do
+    let(:expected_user_prompt) do
+      message_history = <<~HISTORY.strip
+        user:
+        """
+        How do I pay my tax
+        """
+        assistant:
+        """
+        What type of tax
+        """
+        user:
+        """
+        What types are there
+        """
+        assistant:
+        """
+        Self-assessment, PAYE, Corporation tax
+        """
+      HISTORY
+
+      config[:user_prompt]
+        .sub("{message_history}", message_history)
+        .sub("{question}", "corporation tax")
+    end
+    let(:rephrased) { "How do I pay my corporation tax" }
+
+    before do
+      stub_bedrock_converse(
+        bedrock_claude_text_response(rephrased, user_message: expected_user_prompt),
+      )
+    end
+
+    it "returns a result object" do
+      result = described_class.call(question.message, question_records)
+
+      llm_response = result.llm_response
+      expect(llm_response[:stop_reason]).to eq("end_turn")
+      expect(llm_response.dig(:output, :message, :content, 0, :text)).to eq(rephrased)
+
+      expect(result.rephrased_question).to eq(rephrased)
+      expect(result.metrics).to eq({
+        llm_prompt_tokens: 10,
+        llm_completion_tokens: 20,
+      })
+    end
+  end
+
+  context "when a question has been rephrased" do
+    let(:conversation) { create(:conversation) }
+    let(:question) { create(:question, conversation:) }
+    let(:context) { build(:answer_pipeline_context, question:) }
+    let(:answer) { build(:answer, rephrased_question: "A rephrased question") }
+
+    before { create(:question, conversation:, answer:) }
+
+    it "includes the rephrased question in the history" do # rubocop:disable RSpec/NoExpectationExample
+      message_history = <<~HISTORY.strip
+        user:
+        """
+        A rephrased question
+        """
+        assistant:
+        """
+        #{answer.message}
+        """
+      HISTORY
+
+      expected_user_prompt = config[:user_prompt]
+        .sub("{message_history}", message_history)
+        .sub("{question}", question.message)
+
+      stub_bedrock_converse(
+        bedrock_claude_text_response("A second rephrased question", user_message: expected_user_prompt),
+      )
+
+      described_class.call(question.message, conversation.questions.joins(:answer))
+    end
+  end
+end
+
+def config
+  Rails.configuration.govuk_chat_private.llm_prompts.claude.question_rephraser
+end

--- a/spec/lib/answer_composition/pipeline/open_ai/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/open_ai/question_rephraser_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRephraser do
+  let(:conversation) { create :conversation, :with_history }
+  let(:question) { conversation.questions.strict_loading(false).last }
+  let(:question_records) { conversation.questions.joins(:answer) }
+
+  context "when there is a valid response from OpenAI" do
+    let(:expected_messages) do
+      message_history = <<~HISTORY.strip
+        user:
+        """
+        How do I pay my tax
+        """
+        assistant:
+        """
+        What type of tax
+        """
+        user:
+        """
+        What types are there
+        """
+        assistant:
+        """
+        Self-assessment, PAYE, Corporation tax
+        """
+      HISTORY
+
+      user_prompt = config[:user_prompt]
+                    .sub("{message_history}", message_history)
+                    .sub("{question}", "corporation tax")
+
+      [
+        { role: "system", content: config[:system_prompt] },
+        { role: "user", content: user_prompt },
+      ]
+    end
+    let(:rephrased) { "How do I pay my corporation tax" }
+
+    before do
+      stub_openai_chat_completion(expected_messages, answer: rephrased)
+    end
+
+    it "returns a result object" do
+      result = described_class.call(question.message, question_records)
+
+      expect(result.llm_response).to match(
+        a_hash_including(
+          "finish_reason" => "stop",
+          "message" => a_hash_including({ "content" => rephrased }),
+        ),
+      )
+
+      expect(result.rephrased_question).to eq(rephrased)
+
+      expect(result.metrics).to eq({
+        llm_prompt_tokens: 13,
+        llm_completion_tokens: 7,
+        llm_cached_tokens: 10,
+      })
+    end
+  end
+
+  context "when a question has been rephrased" do
+    let(:conversation) { create(:conversation) }
+    let(:question) { create(:question, conversation:) }
+    let(:answer) { build(:answer, rephrased_question: "A rephrased question") }
+
+    before { create(:question, conversation:, answer:) }
+
+    it "includes the rephrased question in the history" do
+      request = stub_openai_question_rephrasing(answer.rephrased_question, "Answer from OpenAI")
+      described_class.call(question.message, conversation.questions.joins(:answer))
+      expect(request).to have_been_made
+    end
+  end
+end
+
+def config
+  Rails.configuration.govuk_chat_private.llm_prompts.openai.question_rephraser
+end

--- a/spec/system/conversation_with_claude_structured_answer_spec.rb
+++ b/spec/system/conversation_with_claude_structured_answer_spec.rb
@@ -63,9 +63,11 @@ RSpec.describe "Conversation with Claude with a structured answer" do
   end
 
   def when_the_second_answer_is_generated
+    rephrased_question = "Rephrased #{@second_question}"
     @second_answer = "Even more tax."
     stub_bedrock_converse(
-      bedrock_claude_structured_answer_response(@second_question, @second_answer),
+      bedrock_claude_text_response(rephrased_question, user_message: Regexp.new(@second_question)),
+      bedrock_claude_structured_answer_response(rephrased_question, @second_answer),
     )
     execute_queued_sidekiq_jobs
   end


### PR DESCRIPTION
https://trello.com/c/ny9WP4yD/2301

This adds a question rephrasing step to the Claude pipeline which
mirrors the existing OpenAI rephrasing.

Rather than just copying the existing implementation into the
`Claude` namespace and updating the API calls, instead we keep the
existing `Pipeline::QuestionRephraser` class and instead makes the
changes in that class to call provider-specific implementations instead.

The reason for this is that there's some logic in this step which is
applied before we actually make the API calls; namely that of:

* returning early if this is the first question in the conversation
* plucking out the last 5 relevant questions from the conversation to
  include in the prompt

So it makes sense to perform this logic in the
`Pipeline::QuestionRephraser` class before calling the provider APIs. To
that end, we now do the early return logic and find the relevant
`Question` records, then pass those records into provider-specific
classes.

Aside from that the implementation is relatively straightforward. We use
the same prompt and interpolate the same values into it.

In terms of the tests, I've added a new method: `bedrock_claude_text_response`. This
simply stubs a call to Bedrock with a specified text response. We didn't
have this previously as the structured answer call stubs the tool call
and tool call response, rather than a non-tool call text response.

Additionally, it optionally asserts on the "user" messages within the
`messages` array we pass to the Bedrock `converse` method. If the
`user_messages` argument is present (be it a string or a Regex), then an
element in the `messages` array must have a role of `"user"` and must
match the value in the argument, otherwise an error is raised.

This is similar to how the current OpenAI stubbing works, in that we
make assertions on the request body as well. It's trickier to make these
same assertions with the Bedrock library because we don't have the same
control over the request body.

With question rephrasing it's quite important that we make some
assertions on the request body (i.e. the messages) as some specs are
testing that the rephrased question is used in the prompt.