### PR TITLE
Pin OpenSearch to 2.18.0 for GitHub Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,9 @@ jobs:
   run-rspec:
     services:
       opensearch-2:
-        image: opensearchproject/opensearch:2
+        # TODO: Loosen the pin back to opensearch:2 - set to exact version
+        # because 2.19.0 seems to hang and rspec process never completes
+        image: opensearchproject/opensearch:2.18.0
         env:
           discovery.type: single-node
           OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g


### PR DESCRIPTION
Since OpenSearch 2.19.0 was released yesterday we've not been able to have a successful CI run. Our tests had froze at the point in the code that interfaces with OpenSearch [1].

I've not been able to find reference to this being a confirmed OpenSearch bug, nor been able to replicate it locally with 2.19.0 so I think will pin for now to see if it's resolved soon with a future release.

[1]: https://github.com/alphagov/govuk-chat/blob/0067666dd4f271f79afc91a023d5791b0f10cb7f/spec/spec_helper.rb#L45