### PR TITLE
Fix flaky rephrasing spec

### DIFF
--- a/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRephraser do
   let(:conversation) { create :conversation, :with_history }
   let(:question) { conversation.questions.strict_loading(false).last }
   let(:context) { build(:answer_pipeline_context, question:) }
-  let(:question_records) { conversation.questions.joins(:answer) }
+  let(:question_records) { conversation.questions.joins(:answer).order(created_at: :asc) }
 
   context "when there is a valid response from Claude" do
     let(:rephrased) { "How do I pay my corporation tax" }

--- a/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
@@ -94,12 +94,22 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser do
     before do
       (1..6).each do |n|
         answer = build(:answer, message: "Answer #{n}")
-        create(:question, answer:, conversation:, message: "Question #{n}")
+        create(
+          :question,
+          answer:,
+          conversation:,
+          message: "Question #{n}",
+          created_at: rand(0..10).days.ago,
+        )
       end
     end
 
     it "truncates the history to the last 5 Q/A pairs" do
-      question_records_for_rephrasing = conversation.questions.joins(:answer).last(5)
+      question_records_for_rephrasing = conversation
+                                        .questions
+                                        .joins(:answer)
+                                        .sort_by(&:created_at)
+                                        .last(5)
 
       expect(AnswerComposition::Pipeline::Claude::QuestionRephraser).to(
         receive(:call).with("Question 7", question_records_for_rephrasing),


### PR DESCRIPTION

We discovered spec fails sometimes due to an ordering of records.

Also improved another spec relating to the same querying of records.
