### PR TITLE
Claude: question routing

### DIFF
--- a/lib/answer_composition/composer.rb
+++ b/lib/answer_composition/composer.rb
@@ -55,6 +55,7 @@ module AnswerComposition
       when "claude_structured_answer"
         PipelineRunner.call(question:, pipeline: [
           Pipeline::QuestionRephraser.new(llm_provider: :claude),
+          Pipeline::Claude::QuestionRouter,
           Pipeline::SearchResultFetcher,
           Pipeline::Claude::StructuredAnswerComposer,
         ])

--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -1,0 +1,174 @@
+module AnswerComposition::Pipeline
+  module Claude
+    class QuestionRouter
+      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
+
+      def self.call(...) = new(...).call
+
+      def initialize(context)
+        @context = context
+      end
+
+      def call
+        start_time = Clock.monotonic_time
+
+        answer = context.answer
+        answer.assign_llm_response("question_routing", bedrock_response.to_h)
+
+        if genuine_rag?
+          answer.assign_attributes(
+            question_routing_label:,
+            question_routing_confidence_score: llm_classification_data["confidence"],
+          )
+        else
+          answer.assign_attributes(
+            message: use_llm_answer? ? llm_answer : Answer::CannedResponses.response_for_question_routing_label(question_routing_label),
+            status: answer_status,
+            question_routing_label:,
+            question_routing_confidence_score: llm_classification_data["confidence"],
+          )
+
+          context.abort_pipeline unless use_llm_answer?
+        end
+
+        answer.assign_metrics("question_routing", build_metrics(start_time))
+      end
+
+    private
+
+      attr_reader :context
+
+      def label_config
+        Rails.configuration.question_routing_labels.fetch(question_routing_label)
+      end
+
+      def use_llm_answer?
+        return false if token_limit_reached?
+
+        label_config[:use_answer]
+      end
+
+      def token_limit_reached?
+        bedrock_response["stop_reason"] == "max_tokens"
+      end
+
+      def answer_status
+        label_config[:answer_status]
+      end
+
+      def llm_answer
+        llm_classification_data["answer"]
+      end
+
+      def genuine_rag?
+        question_routing_label == "genuine_rag"
+      end
+
+      def question_routing_label
+        llm_classification_function["name"]
+      end
+
+      def llm_classification_function
+        @llm_classification_function ||= bedrock_response.dig(
+          "output", "message", "content", 0, "tool_use"
+        )
+      end
+
+      def llm_classification_data
+        llm_classification_function["input"]
+      end
+
+      def bedrock_client
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+      end
+
+      def bedrock_response
+        @bedrock_response ||= bedrock_client.converse(
+          system: [{ text: prompt_config[:system_prompt] }],
+          model_id: BEDROCK_MODEL,
+          messages:,
+          inference_config:,
+          tool_config:,
+        )
+      end
+
+      def inference_config
+        {
+          max_tokens: 160, # A small limit here removes the risk of the LLM returning the whole prompt verbatim
+          temperature: 0.0,
+        }
+      end
+
+      def messages
+        [
+          { role: "user", content: [{ text: context.question_message }] },
+        ]
+      end
+
+      def prompt_config
+        Claude.prompt_config.question_routing
+      end
+
+      def tool_config
+        {
+          tools:,
+          tool_choice: { any: {} },
+        }
+      end
+
+      def tools
+        prompt_config[:classifications].map do |classification|
+          properties = {
+            confidence: prompt_config[:confidence_property],
+          }
+          required = %w[confidence]
+
+          if classification[:properties].present?
+            required.concat(classification[:required])
+            properties.merge!(classification[:properties])
+          end
+
+          {
+            tool_spec: {
+              name: classification[:name],
+              description: build_description(classification),
+              input_schema: {
+                json: {
+                  type: "object",
+                  properties:,
+                  required:,
+                },
+              },
+            },
+          }
+        end
+      end
+
+      def build_description(classification)
+        description = [classification[:description].strip]
+
+        examples = {
+          positive_examples: Array(classification[:examples]),
+          negative_examples: Array(classification[:negative_examples]),
+        }
+
+        examples.each do |key, value|
+          next unless value.any?
+
+          example_string = value.map { "'#{it}'" }.join(", ")
+          description << prompt_config["description_#{key}_template"].sub("{examples}", example_string).strip
+        end
+
+        description.compact.join(" ")
+      end
+
+      def build_metrics(start_time)
+        {
+          duration: Clock.monotonic_time - start_time,
+          llm_prompt_tokens: bedrock_response.dig("usage", "input_tokens"),
+          llm_completion_tokens: bedrock_response.dig("usage", "output_tokens"),
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/answer_composition/composer_spec.rb
+++ b/spec/lib/answer_composition/composer_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe AnswerComposition::Composer do
 
         expected_pipeline = [
           AnswerComposition::Pipeline::QuestionRephraser.new(llm_provider: :claude),
+          AnswerComposition::Pipeline::Claude::QuestionRouter,
           AnswerComposition::Pipeline::SearchResultFetcher,
           AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
         ]

--- a/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
@@ -1,0 +1,237 @@
+RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRouter do
+  let(:classification_attributes) do
+    {
+      name: "greetings",
+      description: "A classification description",
+      properties: {
+        answer: {
+          type: "string",
+          description: "Answer the question.",
+        },
+      },
+      required: %w[answer],
+    }
+  end
+  let(:classification) do
+    classification_attributes
+  end
+
+  let(:tools) do
+    properties = classification[:properties] || {}
+    confidence_property = Rails.configuration.govuk_chat_private.llm_prompts.claude.question_routing[:confidence_property]
+
+    [
+      {
+        tool_spec: {
+          name: "greetings",
+          description: "A classification description",
+          input_schema: {
+            json: {
+              type: "object",
+              properties: properties.merge({
+                confidence: confidence_property,
+              }),
+              required: %w[confidence] + properties.keys.map(&:to_s),
+            },
+          },
+        },
+      },
+    ]
+  end
+
+  let(:classification_response) do
+    { "answer" => "Hello!", "confidence" => 0.85 }
+  end
+
+  let(:expected_message_history) do
+    [
+      { role: "user", content: question.message },
+    ]
+  end
+
+  before do
+    config = Rails.configuration.govuk_chat_private.llm_prompts.claude
+    allow(config).to receive(:question_routing).and_return(
+      classifications: [classification],
+      system_prompt: "The system prompt",
+      confidence_property: {
+        title: "Confidence",
+        type: "number",
+        description: "The confidence that you have correctly identified the user's request",
+      },
+    )
+  end
+
+  describe ".call" do
+    let(:question) { build :question }
+    let(:context) { build(:answer_pipeline_context, question:) }
+
+    it "calls Bedrock with with the right prompt and tool config" do
+      client = stub_bedrock_converse(
+        bedrock_claude_tool_response(
+          classification_response,
+          tool_name: "greetings",
+          requested_tools: tools,
+        ),
+      )
+
+      described_class.call(context)
+      expect(client.api_requests.size).to eq(1)
+    end
+
+    it "assigns the llm response to the answer" do
+      response = bedrock_claude_tool_response(
+        classification_response,
+        tool_name: "greetings",
+      )
+      stub_bedrock_converse(response)
+
+      described_class.call(context)
+
+      expect(context.answer.llm_responses["question_routing"]).to match(response)
+    end
+
+    it "assigns metrics to the context's answer" do
+      response = bedrock_claude_tool_response(
+        classification_response,
+        tool_name: "greetings",
+      )
+      stub_bedrock_converse(response)
+      allow(Clock).to receive(:monotonic_time).and_return(100.0, 101.5)
+
+      described_class.call(context)
+
+      expect(context.answer.metrics["question_routing"]).to eq({
+        duration: 1.5,
+        llm_prompt_tokens: 10,
+        llm_completion_tokens: 20,
+      })
+    end
+
+    context "when the question routing label is genuine_rag" do
+      before do
+        response = bedrock_claude_tool_response(
+          classification_response,
+          tool_name: "genuine_rag",
+        )
+        stub_bedrock_converse(response)
+      end
+
+      it "assigns the question routing label and confidence" do
+        described_class.call(context)
+
+        expect(context.answer).to have_attributes(
+          question_routing_label: "genuine_rag",
+          question_routing_confidence_score: 0.85,
+        )
+      end
+
+      it "doesn't assign a message" do
+        described_class.call(context)
+
+        expect(context.answer.message).to be_nil
+      end
+
+      it "doesn't abort the pipeline" do
+        expect { described_class.call(context) }
+          .not_to change(context, :aborted?).from(false)
+      end
+    end
+
+    context "when the tokens returned by Bedrock exceeds the limit" do
+      before do
+        response = bedrock_claude_tool_response(
+          classification_response,
+          tool_name: "vague_acronym_grammar",
+          stop_reason: "max_tokens",
+        )
+        stub_bedrock_converse(response)
+      end
+
+      it "assigns a canned response message" do
+        canned_response = "Canned response"
+
+        # This method returns a random value
+        allow(Answer::CannedResponses)
+          .to receive(:response_for_question_routing_label)
+          .with("vague_acronym_grammar")
+          .and_return(canned_response)
+
+        described_class.call(context)
+
+        expect(context.answer).to have_attributes(
+          message: canned_response,
+          status: "clarification",
+          question_routing_label: "vague_acronym_grammar",
+        )
+      end
+
+      it "aborts the pipeline" do
+        expect { described_class.call(context) }
+          .to change(context, :aborted?).to(true)
+      end
+    end
+
+    context "when the question routing label is one where we use the answer" do
+      let(:answer_message) { "This content was not found on GOV.UK" }
+
+      before do
+        response = bedrock_claude_tool_response(
+          { "answer" => answer_message, "confidence" => 0.9 },
+          tool_name: "multi_questions",
+        )
+        stub_bedrock_converse(response)
+      end
+
+      it "assigns the answer message, status and question routing metadata" do
+        described_class.call(context)
+
+        expect(context.answer).to have_attributes(
+          message: answer_message,
+          status: "clarification",
+          question_routing_label: "multi_questions",
+          question_routing_confidence_score: 0.9,
+        )
+      end
+
+      it "doesn't abort the pipeline" do
+        expect { described_class.call(context) }
+          .not_to change(context, :aborted?).from(false)
+      end
+    end
+
+    context "when the question routing label is one where we ignore the answer" do
+      before do
+        response = bedrock_claude_tool_response(
+          { "answer" => "Ignored", "confidence" => 0.9 },
+          tool_name: "harmful_vulgar_controversy",
+        )
+        stub_bedrock_converse(response)
+      end
+
+      it "assigns a canned response message with a status and question routing metadata" do
+        canned_response = "Canned response"
+
+        # This method returns a random value
+        allow(Answer::CannedResponses)
+          .to receive(:response_for_question_routing_label)
+          .with("harmful_vulgar_controversy")
+          .and_return(canned_response)
+
+        described_class.call(context)
+
+        expect(context.answer).to have_attributes(
+          message: canned_response,
+          status: "unanswerable_question_routing",
+          question_routing_label: "harmful_vulgar_controversy",
+          question_routing_confidence_score: 0.9,
+        )
+      end
+
+      it "aborts the pipeline" do
+        expect { described_class.call(context) }
+          .to change(context, :aborted?).to(true)
+      end
+    end
+  end
+end

--- a/spec/system/conversation_with_claude_structured_answer_spec.rb
+++ b/spec/system/conversation_with_claude_structured_answer_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "Conversation with Claude with a structured answer", :chunked_con
 
     @first_answer = "Lots of tax."
     stub_bedrock_converse(
+      bedrock_claude_question_routing_response(@first_question),
       bedrock_claude_structured_answer_response(@first_question, @first_answer),
     )
     execute_queued_sidekiq_jobs
@@ -75,6 +76,7 @@ RSpec.describe "Conversation with Claude with a structured answer", :chunked_con
     @second_answer = "Even more tax."
     stub_bedrock_converse(
       bedrock_claude_text_response(rephrased_question, user_message: Regexp.new(@second_question)),
+      bedrock_claude_question_routing_response(rephrased_question),
       bedrock_claude_structured_answer_response(rephrased_question, @second_answer),
     )
     execute_queued_sidekiq_jobs


### PR DESCRIPTION
Adds a question routing step into the pipeline used for questions using
the Claude answer strategy.

It's mostly a direct port of the OpenAI one, and behaves in exactly the
same way, i.e. creates a tool from each of the classifications in the
config and gets the LLM to use one of those tools when responding.
