### PR TITLE
Replace use of title component with heading

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -44,9 +44,11 @@
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <%= render "govuk_publishing_components/components/title", {
+            <%= render "govuk_publishing_components/components/heading", {
               context: yield(:title_context),
-              title: yield(:title),
+              text: yield(:title),
+              font_size: "xl",
+              heading_level: 1,
             } %>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -112,8 +112,10 @@
           <div class="govuk-width-container">
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
-                <%= render "govuk_publishing_components/components/title", {
-                  title: page_title,
+                <%= render "govuk_publishing_components/components/heading", {
+                  text: page_title,
+                  font_size: "xl",
+                  heading_level: 1,
                 } %>
               </div>
             </div>

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "ConversationsController" do
         expect(response).to have_http_status(:redirect)
         follow_redirect!
         expect(response.body)
-          .to have_selector(".gem-c-title__text", text: "GOV.UK Chat is generating an answer")
+          .to have_selector("h1", text: "GOV.UK Chat is generating an answer")
       end
 
       context "and the params are invalid while the last question is answered" do
@@ -435,7 +435,7 @@ RSpec.describe "ConversationsController" do
 
       expect(response).to have_http_status(:accepted)
       expect(response.body)
-        .to have_selector(".gem-c-title__text", text: "GOV.UK Chat is generating an answer")
+        .to have_selector("h1", text: "GOV.UK Chat is generating an answer")
         .and have_selector(".govuk-button[href='#{answer_question_path(question)}?refresh=true']",
                            text: "Check if an answer has been generated")
     end
@@ -637,7 +637,7 @@ RSpec.describe "ConversationsController" do
 
         expect(response).to have_http_status(:ok)
         expect(response.body)
-          .to have_selector(".gem-c-title__text", text: "Do you want to start a new chat?")
+          .to have_selector("h1", text: "Do you want to start a new chat?")
       end
     end
   end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "ErrorController" do
     it "returns a #{title} response" do
       get "/#{code}"
       expect(response).to have_http_status(status)
-      expect(response.body).to have_selector(".gem-c-title__text", text: page_title)
+      expect(response.body).to have_selector("h1", text: page_title)
       expect(response.headers["No-Fallback"]).to eq "true"
     end
   end


### PR DESCRIPTION
The title component has been removed from govuk_publishing_components [1] and thus we need to replace it. The heading component with an xl font-size is functionally equivalent.

I applied this by using Ashley's example [2], however I omitted setting a margin_bottom of 8 as that matches the margin already added to `govuk-heading-xl` and rendered identically.

[1]: https://github.com/alphagov/govuk_publishing_components/pull/4653
[2]: https://github.com/alphagov/collections/pull/3963/files