### PR TITLE
Pin GitHub action versions and use dependabot to update them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
 registries:
   github:
     type: git

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint JavaScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: false
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -48,7 +48,7 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: alphagov/govuk-chat
           ref: ${{ inputs.ref || github.ref }}
@@ -56,7 +56,7 @@ jobs:
           token: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Checkout govuk_chat_private
         if: inputs.govukChatPrivateRef != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: alphagov/govuk_chat_private
           ref: ${{ inputs.govukChatPrivateRef }}
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           bundler-cache: true
         env:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,8 +52,6 @@ jobs:
         with:
           repository: alphagov/govuk-chat
           ref: ${{ inputs.ref || github.ref }}
-          # TODO: remove this when we've open sourced govuk-chat
-          token: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
 
       - name: Checkout Publishing API (for Content Schemas)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Off the back of the drama of the tj-actions hijacked action [1]. This
updates our GitHub actions to follow the GDS Way guidance [2] of using a
SHA hash.

This also configures Dependabot to keep these up to date.

[1]: https://nvd.nist.gov/vuln/detail/CVE-2025-30066
[2]: https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/use-github.html#using-github-actions-and-workflows
@[kevindew](https://github.com/alphagov/govuk-chat/commits?author=kevindew)
kevindew committed 5 minutes ago