### PR TITLE
Add a rake task to fetch jailbreak guardrails results

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -43,4 +43,17 @@ namespace :evaluation do
     answer = AnswerComposition::Composer.call(question)
     puts({ message: answer.message }.to_json)
   end
+
+  desc "Produce the output of the jailbreak response for a user input"
+  task :generate_jailbreak_guardrail_response, %i[provider] => :environment do |_, args|
+    raise "Requires an INPUT env var" if ENV["INPUT"].blank?
+    raise "Requires a provider" if args[:provider].blank?
+
+    # TODO: Update once we support providers other than OpenAI
+    raise "Unsupported provider: #{args[:provider]}" unless args[:provider] == "openai"
+
+    response = Guardrails::JailbreakChecker.call(ENV["INPUT"])
+
+    puts(response.to_json)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/XhrF9Kin/2346-spike-jailbreak-guardrail-evaluator-in-new-repo

This rake task is expected to be used as part of an auto evaluation pipeline where it is called to generate responses [1].

We expect to add similar tasks like this as we progress with work to integrate an evaluation framework.

This task is wrote based on the expectation that we will soon have another provider (claude) and will need amending [2].

This task is rather slow to execute, as rake tasks often are. My timing of it comes out at: 3.8s (0.89s user 0.75s system 43% cpu 3.805 total).

I did find that by using the spring gem we can make it faster at 1.6s (0.21s user 0.13s system 21% cpu 1.607 total). However I was worried that adding spring would cause problems with auto-reloading prompts so I didn't opt to add that in now.

[1]: https://github.com/kevindew/govuk-chat-evaluation-prototype/pull/2
[2]: https://github.com/alphagov/govuk-chat/pull/110