### PR TITLE
Don't try map links without a href attribute

### DIFF
--- a/lib/answer_composition/link_token_mapper.rb
+++ b/lib/answer_composition/link_token_mapper.rb
@@ -10,6 +10,8 @@ module AnswerComposition
       doc = Nokogiri::HTML::DocumentFragment.parse(html_content)
 
       doc.css("a").each do |link|
+        next unless link["href"]
+
         href = begin
           URI.join(ensure_absolute_govuk_url(exact_path), link["href"]).to_s
         rescue URI::InvalidURIError

--- a/spec/lib/answer_composition/link_token_mapper_spec.rb
+++ b/spec/lib/answer_composition/link_token_mapper_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
       expect(links[4]["href"]).to eq("link_4")
       expect(links[4].text).to eq("an anchor tag")
     end
+
+    it "ignores any links that are missing a href" do
+      html = "<p>This is text with a <a>missing href link</a></p>"
+      result = described_class.new.map_links_to_tokens(html, "/exact-path")
+
+      expect(result).to eq(html)
+    end
   end
 
   describe "#map_link_to_token" do


### PR DESCRIPTION
A bug has been spotted testing GOV.UK Chat where a particular question about visa needs has triggered an exception.

I've traced the source of that issue down to the following HTML in a chunk of ours:

```
<p>You may be able to visit on a family permit if you have a family member who is:    </p>
<ul>
  <li><a>a citizen of an EU country, Iceland, Liechtenstein, Norway or Switzerland</a></li>
  <li><a>a Person of Northern Ireland </a></li>
  <li><a>a British citizen </a></li>
</ul>
```

Where the anchor element lacks a href attribute. This bug actually appears to be of our own causing, as part of search parsing. As the actual HTML contains:

```
<p class="gem-c-step-nav__paragraph">You may be able to visit on a family permit if you have a family member who is:    </p>

<ul class="gem-c-step-nav__list gem-c-step-nav__list--choice" data-length="3">
  <li class="gem-c-step-nav__list-item js-list-item ">a citizen of an EU country, Iceland, Liechtenstein, Norway or Switzerland</li>
  <li class="gem-c-step-nav__list-item js-list-item ">a Person of Northern Ireland </li>
  <li class="gem-c-step-nav__list-item js-list-item ">a British citizen </li>
</ul>

```

But regardless we shouldn't crash if we encounter a link without a href attribute. This changes the code to ignore such an event.

[1]: https://www.gov.uk/visit-uk-holiday-family-friends