### PR TITLE
[SPIKE] Add blueprinter gem and use it to build API endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
 gem "rails", "8.0.2"
 
 gem "aws-sdk-bedrockruntime"
+gem "blueprinter"
 gem "bootsnap"
 gem "chartkick"
 gem "csv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.1.9)
+    blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (7.0.2)
@@ -904,6 +905,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-bedrockruntime
+  blueprinter
   bootsnap
   brakeman
   chartkick
@@ -977,6 +979,7 @@ CHECKSUMS
   benchmark (0.4.0) sha256=0f12f8c495545e3710c3e4f0480f63f06b4c842cc94cec7f33a956f5180e874a
   better_html (2.1.1) sha256=046c3551d1488a3f2939a7cac6fabf2bde08c32e135c91fcd683380118e5af55
   bigdecimal (3.1.9) sha256=2ffc742031521ad69c2dfc815a98e426a230a3d22aeac1995826a75dabfad8cc
+  blueprinter (1.1.2) sha256=e09945686d13539f9e911403b4f13cf4dcb83c951abd188bfca8754afbfb2249
   bootsnap (1.18.4) sha256=ac4c42af397f7ee15521820198daeff545e4c360d2772c601fbdc2c07d92af55
   brakeman (7.0.2) sha256=b602d91bcec6c5ce4d4bc9e081e01f621c304b7a69f227d1e58784135f333786
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f

--- a/app/blueprints/answer_blueprint.rb
+++ b/app/blueprints/answer_blueprint.rb
@@ -1,0 +1,13 @@
+class AnswerBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :message
+  field :created_at do |answer, _options|
+    answer.created_at.iso8601
+  end
+  field :useful, if: ->(_field_name, answer, _options) { answer.feedback.present? } do |answer, _options|
+    answer.feedback.useful
+  end
+  association :sources, blueprint: AnswerSourceBlueprint,
+                        if: ->(_field_name, answer, _options) { answer.sources.present? }
+end

--- a/app/blueprints/answer_source_blueprint.rb
+++ b/app/blueprints/answer_source_blueprint.rb
@@ -1,0 +1,5 @@
+class AnswerSourceBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :title, :url
+end

--- a/app/blueprints/conversation_blueprint.rb
+++ b/app/blueprints/conversation_blueprint.rb
@@ -1,0 +1,16 @@
+class ConversationBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :created_at do |conversation, _options|
+    conversation.created_at.iso8601
+  end
+
+  association :answered_questions, blueprint: QuestionBlueprint, view: :answered do |_conversation, options|
+    options[:answered_questions] || []
+  end
+
+  association :pending_question, blueprint: QuestionBlueprint, view: :pending,
+                                 if: ->(_field_name, _conversation, options) { options[:pending_question].present? } do |_conversation, options|
+    options[:pending_question]
+  end
+end

--- a/app/blueprints/error_blueprint.rb
+++ b/app/blueprints/error_blueprint.rb
@@ -1,0 +1,3 @@
+class ErrorBlueprint < Blueprinter::Base
+  field :message
+end

--- a/app/blueprints/question_blueprint.rb
+++ b/app/blueprints/question_blueprint.rb
@@ -1,0 +1,20 @@
+class QuestionBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :message, :conversation_id
+
+  field :created_at do |question, _options|
+    question.created_at.iso8601
+  end
+
+  view :answered do
+    association :answer, blueprint: AnswerBlueprint
+  end
+
+  view :pending do
+    field :answer_url do |question|
+      path = Rails.application.routes.url_helpers.answer_question_path(question.conversation_id, question.id)
+      "#{Plek.website_root}#{path}"
+    end
+  end
+end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,0 +1,12 @@
+class Api::V0::ConversationsController < ApplicationController
+  def show
+    conversation = Conversation.includes(questions: { answer: %i[sources feedback] })
+                                .find(params[:id])
+    answered_questions = conversation.questions.joins(:answer)
+    pending_question = conversation.questions.unanswered.last
+
+    render json: ConversationBlueprint.render(conversation, answered_questions:, pending_question:), status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Conversation not found" }, status: :not_found
+  end
+end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -6,7 +6,7 @@ class Api::V0::ConversationsController < ApplicationController
     pending_question = conversation.questions.unanswered.last
 
     render json: ConversationBlueprint.render(conversation, answered_questions:, pending_question:), status: :ok
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Conversation not found" }, status: :not_found
+  rescue ActiveRecord::RecordNotFound => e
+    render json: { error: ErrorBlueprint.render_as_hash({ message: e.message }) }, status: :not_found
   end
 end

--- a/app/controllers/app_api/v0/conversations_controller.rb
+++ b/app/controllers/app_api/v0/conversations_controller.rb
@@ -1,9 +1,0 @@
-class AppApi::V0::ConversationsController < ApplicationController
-  def show
-    conversation = Conversation.includes(questions: { answer: %i[sources feedback] })
-                                .find(params[:id])
-    render json: ConversationBlueprint.render(conversation), status: :ok
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Conversation not found" }, status: :not_found
-  end
-end

--- a/app/controllers/app_api/v0/conversations_controller.rb
+++ b/app/controllers/app_api/v0/conversations_controller.rb
@@ -1,0 +1,9 @@
+class AppApi::V0::ConversationsController < ApplicationController
+  def show
+    conversation = Conversation.includes(questions: { answer: %i[sources feedback] })
+                                .find(params[:id])
+    render json: ConversationBlueprint.render(conversation), status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Conversation not found" }, status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :api, format: false, defaults: { format: "json" } do
+    scope :v0 do
+      get "/conversation/:id", to: "v0/conversations#show", as: :conversation
+    end
+  end
+
   scope via: :all do
     match "/400" => "errors#bad_request"
     match "/403" => "errors#forbidden"

--- a/spec/blueprints/answer_blueprint_spec.rb
+++ b/spec/blueprints/answer_blueprint_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe AnswerBlueprint do
+  let(:answer) { create(:answer) }
+
+  describe ".render_as_json"
+  it "generates the correct JSON for an Answer without sources" do
+    expected_json = {
+      id: answer.id,
+      created_at: answer.created_at.iso8601,
+      message: answer.message,
+    }.as_json
+    output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+    expect(output_json).to eq(expected_json)
+  end
+
+  it "generates the correct JSON for an Answer with sources" do
+    answer_source = create(:answer_source, answer:)
+    expected_json = {
+      id: answer.id,
+      created_at: answer.created_at.iso8601,
+      message: answer.message,
+      sources: [
+        AnswerSourceBlueprint.render_as_hash(answer_source),
+      ],
+    }.as_json
+    output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+    expect(output_json).to eq(expected_json)
+  end
+
+  context "when answer feedback is present" do
+    it "includes feedback in the JSON" do
+      create(:answer_feedback, answer:)
+      expected_json = {
+        id: answer.id,
+        created_at: answer.created_at.iso8601,
+        message: answer.message,
+        useful: true,
+      }.as_json
+      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+      expect(output_json).to eq(expected_json)
+    end
+  end
+end

--- a/spec/blueprints/answer_source_blueprint_spec.rb
+++ b/spec/blueprints/answer_source_blueprint_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe AnswerSourceBlueprint do
+  describe ".render_as_json" do
+    it "generates the correct JSON for an AnswerSource" do
+      answer_source = create(:answer_source)
+      expected_json = {
+        id: answer_source.id,
+        title: answer_source.title,
+        url: answer_source.url,
+      }.as_json
+
+      expect(described_class.render_as_json(answer_source)).to eq(expected_json)
+    end
+  end
+end

--- a/spec/blueprints/conversation_blueprint_spec.rb
+++ b/spec/blueprints/conversation_blueprint_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ConversationBlueprint do
         pending_question = create(:question, conversation:)
         expected_json = {
           id: conversation.id,
-          created_at: conversation.created_at,
+          created_at: conversation.created_at.iso8601,
           answered_questions: [],
           pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
         }.as_json
@@ -34,9 +34,9 @@ RSpec.describe ConversationBlueprint do
 
         expected_json = {
           id: conversation.id,
-          created_at: conversation.created_at,
-          answered_questions: answered_questions.map do |q|
-            QuestionBlueprint.render_as_hash(q, view: :answered)
+          created_at: conversation.created_at.iso8601,
+          answered_questions: answered_questions.map do |question|
+            QuestionBlueprint.render_as_hash(question, view: :answered)
           end,
           pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
         }.as_json
@@ -57,7 +57,7 @@ RSpec.describe ConversationBlueprint do
 
         expected_json = {
           id: conversation.id,
-          created_at: conversation.created_at,
+          created_at: conversation.created_at.iso8601,
           answered_questions: [],
           pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
         }.as_json
@@ -79,7 +79,7 @@ RSpec.describe ConversationBlueprint do
 
         expected_json = {
           id: conversation.id,
-          created_at: conversation.created_at,
+          created_at: conversation.created_at.iso8601,
           answered_questions: [
             QuestionBlueprint.render_as_hash(eager_loaded_answered, view: :answered),
           ],

--- a/spec/blueprints/conversation_blueprint_spec.rb
+++ b/spec/blueprints/conversation_blueprint_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe ConversationBlueprint do
+  let(:conversation) { create(:conversation) }
+
+  describe ".render_as_json" do
+    context "with only a pending question" do
+      it "generates the correct JSON" do
+        pending_question = create(:question, conversation:)
+        expected_json = {
+          id: conversation.id,
+          created_at: conversation.created_at,
+          answered_questions: [],
+          pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
+        }.as_json
+
+        output_json = described_class.render_as_json(
+          conversation,
+          answered_questions: [],
+          pending_question: pending_question,
+        )
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+
+    context "with answered questions and a pending question" do
+      it "generates the correct JSON" do
+        pending_question = create(:question, conversation:)
+        answered_question1 = create(:question, :with_answer, conversation:)
+        answered_question2 = create(:question, :with_answer, conversation:)
+
+        answered_questions = Question.where(id: [answered_question1.id, answered_question2.id])
+                                     .includes(answer: %i[sources feedback])
+        pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
+
+        expected_json = {
+          id: conversation.id,
+          created_at: conversation.created_at,
+          answered_questions: answered_questions.map do |q|
+            QuestionBlueprint.render_as_hash(q, view: :answered)
+          end,
+          pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
+        }.as_json
+
+        output_json = described_class.render_as_json(
+          conversation,
+          answered_questions: answered_questions,
+          pending_question: pending_question,
+        )
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+
+    context "with no answered questions passed in" do
+      it "renders an empty answered_questions array" do
+        pending_question = create(:question, conversation:)
+
+        expected_json = {
+          id: conversation.id,
+          created_at: conversation.created_at,
+          answered_questions: [],
+          pending_question: QuestionBlueprint.render_as_hash(pending_question, view: :pending),
+        }.as_json
+
+        output_json = described_class.render_as_json(
+          conversation,
+          answered_questions: [],
+          pending_question: pending_question,
+        )
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+
+    context "with no pending question passed in" do
+      it "omits pending_question from the output" do
+        answered_question = create(:question, :with_answer, conversation:)
+        eager_loaded_answered = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
+
+        expected_json = {
+          id: conversation.id,
+          created_at: conversation.created_at,
+          answered_questions: [
+            QuestionBlueprint.render_as_hash(eager_loaded_answered, view: :answered),
+          ],
+        }.as_json
+
+        output_json = described_class.render_as_json(
+          conversation,
+          answered_questions: [eager_loaded_answered],
+          pending_question: nil,
+        )
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/blueprints/error_blueprint_spec.rb
+++ b/spec/blueprints/error_blueprint_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ErrorBlueprint do
+  describe ".render_as_json" do
+    it "generates the correct JSON based on the message passed in" do
+      error_message = "An error occurred"
+      expect(described_class.render_as_json(message: error_message))
+        .to eq({ message: error_message }.as_json)
+    end
+
+    it "raises an error when no message is passed in" do
+      expect { described_class.render_as_json }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/blueprints/question_blueprint_spec.rb
+++ b/spec/blueprints/question_blueprint_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe QuestionBlueprint do
+  describe ".render_as_json" do
+    it "generates the correct JSON for a question" do
+      question = create(:question)
+
+      expected_json = {
+        id: question.id,
+        conversation_id: question.conversation_id,
+        created_at: question.created_at.iso8601,
+        message: question.message,
+      }.as_json
+
+      expect(described_class.render_as_json(question)).to eq(expected_json)
+    end
+
+    describe "view :answered" do
+      it "includes the answer" do
+        question = create(:question, :with_answer)
+        answer = Answer.includes(%i[sources feedback]).find(question.answer.id)
+
+        expected_json = {
+          id: question.id,
+          conversation_id: question.conversation_id,
+          created_at: question.created_at.iso8601,
+          message: question.message,
+          answer: AnswerBlueprint.render_as_hash(answer),
+        }.as_json
+        output_json = described_class.render_as_json(
+          Question.includes(answer: %i[sources feedback]).find(question.id),
+          view: :answered,
+        )
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+
+    describe "view :pending" do
+      it "includes the answer URL" do
+        question = create(:question)
+
+        path = Rails.application.routes.url_helpers.answer_question_path(question.conversation_id, question.id)
+        expected_json = {
+          id: question.id,
+          conversation_id: question.conversation_id,
+          created_at: question.created_at.iso8601,
+          message: question.message,
+          answer_url: "#{Plek.website_root}#{path}",
+        }.as_json
+
+        expect(described_class.render_as_json(question, view: :pending)).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Api::V0::ConversationsController" do
+  let(:conversation) { create(:conversation) }
+
+  describe "GET :show" do
+    context "when a conversation exists with the given ID" do
+      it "returns a 200 response" do
+        get api_conversation_path(conversation)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the expected JSON response" do
+        get api_conversation_path(conversation)
+        expect(response.body).to eq(ConversationBlueprint.render(conversation))
+      end
+
+      context "when the conversation has answered questions" do
+        it "returns the answered questions in the JSON response" do
+          answered_question = create(:question, :with_answer, conversation:)
+          eager_loaded_answered_question = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
+          get api_conversation_path(conversation)
+
+          expect(JSON.parse(response.body)["answered_questions"])
+            .to eq([QuestionBlueprint.render_as_json(eager_loaded_answered_question, view: :answered)])
+        end
+      end
+
+      context "when the conversation has a pending question" do
+        it "returns the pending question in the JSON response" do
+          pending_question = create(:question, conversation:)
+          eager_loaded_pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
+          get api_conversation_path(conversation)
+
+          expect(JSON.parse(response.body)["pending_question"])
+            .to eq(QuestionBlueprint.render_as_json(eager_loaded_pending_question, view: :pending))
+        end
+      end
+    end
+
+    context "when a conversation does not exist with the given ID" do
+      it "returns a 404 response" do
+        get api_conversation_path(id: "invalid-id")
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns an error message in JSON format" do
+        get api_conversation_path(id: "invalid-id")
+        expect(response.body).to eq({ error: "Conversation not found" }.to_json)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe "Api::V0::ConversationsController" do
 
       it "returns an error message in JSON format" do
         get api_conversation_path(id: "invalid-id")
-        expect(response.body).to eq({ error: "Conversation not found" }.to_json)
+        expect(response.body)
+          .to eq({ error: { message: "Couldn't find Conversation with 'id'=invalid-id" } }.to_json)
       end
     end
   end


### PR DESCRIPTION
## Description 

I thought i'd spike out using blueprinter for serialisation so we could discuss whether we want to use it.

This adds blueprints for the following models:

- AnswerSource
- Answer
- Question
- Conversation

Then adds a conversation show endpoint that returns a conversation with it's nested associations as JSON using ConversationBlueprint.

## Thoughts

- It was really easy and intuitive to use. The docs are great
- The `#view` functionality was really useful for being able to define the different types of questions there are (answered and pending)
- While there does seem to be a convention for the blueprints to sit in `app/blueprints`, If we want we can do `class AnswerSourceSerializer < Blueprinter::Base` and move stuff to `app/serializers` folder. It works fine.

For what we need it for which is a pretty basic use case it seems reasonable to use it to me. It'd be far easier than maintaining our own PORO serialisers we were to build them.

I've had a look into https://github.com/rails-api/active_model_serializers. There seem to be quite a few issues with limited support, release frequency and performance with many people recommending `blueprinter` and `jsonapi-serializer ` instead.

## Postman screenshots

### Answered question

<img width="770" alt="image" src="https://github.com/user-attachments/assets/f3b9595b-36c2-4a16-b9ea-8b0dd47510a7" />

### With feedback and no sources

<img width="666" alt="image" src="https://github.com/user-attachments/assets/e8b216a4-9b48-4a25-bca4-1cc34917fe10" />


## Pending question 

<img width="950" alt="image" src="https://github.com/user-attachments/assets/4f2ac559-fe6d-41ff-b705-528875d0b091" />

### Pending and answered question 

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/90b29288-b227-4677-8c67-6bdc77beb8a3" />
