### PR TITLE
[SPIKE] Test Signon integration via API User

### DIFF
--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::ConversationsController < ApplicationController
+  before_action :authorise_user
+
   def show
     conversation = Conversation.includes(questions: { answer: %i[sources feedback] })
                                 .find(params[:id])
@@ -8,5 +10,11 @@ class Api::V0::ConversationsController < ApplicationController
     render json: ConversationBlueprint.render(conversation, answered_questions:, pending_question:), status: :ok
   rescue ActiveRecord::RecordNotFound => e
     render json: { error: ErrorBlueprint.render_as_hash({ message: e.message }) }, status: :not_found
+  end
+
+private
+
+  def authorise_user
+    authorise_user!("api-user")
   end
 end

--- a/spec/factories/admin_user_factory.rb
+++ b/spec/factories/admin_user_factory.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     trait :admin do
       permissions { %w[admin-area] }
     end
+
+    trait :api_user do
+      permissions { %w[api-user] }
+    end
   end
 end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -2,50 +2,67 @@ RSpec.describe "Api::V0::ConversationsController" do
   let(:conversation) { create(:conversation) }
 
   describe "GET :show" do
-    context "when a conversation exists with the given ID" do
-      it "returns a 200 response" do
+    before do
+      login_as(create(:admin_user, :api_user))
+    end
+
+    context "when the user is not authorised" do
+      before do
+        login_as(create(:admin_user))
+      end
+
+      it "returns a 403 response" do
         get api_conversation_path(conversation)
-        expect(response).to have_http_status(:success)
-      end
-
-      it "returns the expected JSON response" do
-        get api_conversation_path(conversation)
-        expect(response.body).to eq(ConversationBlueprint.render(conversation))
-      end
-
-      context "when the conversation has answered questions" do
-        it "returns the answered questions in the JSON response" do
-          answered_question = create(:question, :with_answer, conversation:)
-          eager_loaded_answered_question = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
-          get api_conversation_path(conversation)
-
-          expect(JSON.parse(response.body)["answered_questions"])
-            .to eq([QuestionBlueprint.render_as_json(eager_loaded_answered_question, view: :answered)])
-        end
-      end
-
-      context "when the conversation has a pending question" do
-        it "returns the pending question in the JSON response" do
-          pending_question = create(:question, conversation:)
-          eager_loaded_pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
-          get api_conversation_path(conversation)
-
-          expect(JSON.parse(response.body)["pending_question"])
-            .to eq(QuestionBlueprint.render_as_json(eager_loaded_pending_question, view: :pending))
-        end
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
-    context "when a conversation does not exist with the given ID" do
-      it "returns a 404 response" do
-        get api_conversation_path(id: "invalid-id")
-        expect(response).to have_http_status(:not_found)
+    context "when the user is authorized" do
+      context "and a conversation exists with the given ID" do
+        it "returns a 200 response" do
+          get api_conversation_path(conversation)
+          expect(response).to have_http_status(:success)
+        end
+
+        it "returns the expected JSON response" do
+          get api_conversation_path(conversation)
+          expect(response.body).to eq(ConversationBlueprint.render(conversation))
+        end
+
+        context "when the conversation has answered questions" do
+          it "returns the answered questions in the JSON response" do
+            answered_question = create(:question, :with_answer, conversation:)
+            eager_loaded_answered_question = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
+            get api_conversation_path(conversation)
+
+            expect(JSON.parse(response.body)["answered_questions"])
+              .to eq([QuestionBlueprint.render_as_json(eager_loaded_answered_question, view: :answered)])
+          end
+        end
+
+        context "when the conversation has a pending question" do
+          it "returns the pending question in the JSON response" do
+            pending_question = create(:question, conversation:)
+            eager_loaded_pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
+            get api_conversation_path(conversation)
+
+            expect(JSON.parse(response.body)["pending_question"])
+              .to eq(QuestionBlueprint.render_as_json(eager_loaded_pending_question, view: :pending))
+          end
+        end
       end
 
-      it "returns an error message in JSON format" do
-        get api_conversation_path(id: "invalid-id")
-        expect(response.body)
-          .to eq({ error: { message: "Couldn't find Conversation with 'id'=invalid-id" } }.to_json)
+      context "when a conversation does not exist with the given ID" do
+        it "returns a 404 response" do
+          get api_conversation_path(id: "invalid-id")
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "returns an error message in JSON format" do
+          get api_conversation_path(id: "invalid-id")
+          expect(response.body)
+            .to eq({ error: { message: "Couldn't find Conversation with 'id'=invalid-id" } }.to_json)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Quick spike into adding auth to the API.

This is really straight forward to do. I spiked it out in this [branch](https://github.com/alphagov/govuk-chat/commit/4812166b41820ef9f8e690ede9810ce16185be08)

You have to:

1. add a new permission to chat via sign on. I’ve used “api-user” for this spike but it will need to be more specific when fully implemented
2. add an api user [here](https://signon.integration.publishing.service.gov.uk/api_users)
3. generate a token for chat (you need to note this down as it only will show it once)
4. add the api_user permission for the api user
5. set the auth header to use the new token i.e. in postman
<img width="910" alt="image" src="https://github.com/user-attachments/assets/adecf48c-6448-4542-ac30-1cd766d61c2a" />

6. auth the user for the relevant endpoints in chat (see [branch](https://github.com/alphagov/govuk-chat/commit/4812166b41820ef9f8e690ede9810ce16185be08) for how to do it)