### PR TITLE
[SPIKE] Add committee to ensure responses are inline with OpenAPI spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :test do
   gem "climate_control"
+  gem "committee"
   gem "govuk_schemas"
   gem "simplecov"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,10 @@ GEM
     chartkick (5.1.4)
     climate_control (1.2.0)
     coderay (1.1.3)
+    committee (5.5.3)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5, < 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crack (1.0.0)
@@ -316,6 +320,7 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    json_schema (0.21.0)
     jwt (2.10.1)
       base64
     kaminari (1.2.2)
@@ -416,6 +421,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    openapi_parser (2.2.6)
     opensearch-ruby (3.4.0)
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
@@ -910,6 +916,7 @@ DEPENDENCIES
   brakeman
   chartkick
   climate_control
+  committee
   csv
   dalli
   dartsass-rails
@@ -989,6 +996,7 @@ CHECKSUMS
   chartkick (5.1.4) sha256=893b2b5e6321a917f4ada2db082e0cb81a247cdad014e0b0a37aeb9287c10be5
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  committee (5.5.3) sha256=434d6f040e905f636d91a7bbfe8dc5292917b91b5ff55b192569740c67a920ca
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
   connection_pool (2.5.0) sha256=233b92f8d38e038c1349ccea65dd3772727d669d6d2e71f9897c8bf5cd53ebfc
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
@@ -1055,6 +1063,7 @@ CHECKSUMS
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.10.2) sha256=34e0eada93022b2a0a3345bb0b5efddb6e9ff5be7c48e409cfb54ff8a36a8b06
   json-schema (5.1.1) sha256=b3829ad9bcdfc5010d8a160c4c2bebb8fed8d05d22de65648f6ba646b071f9bf
+  json_schema (0.21.0) sha256=d6e1eaf004a5185b7679eee34286a79d48e467d794ff68981d72ad23d3b2ec5b
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -1101,6 +1110,7 @@ CHECKSUMS
   oauth2 (2.0.9) sha256=b21f9defcf52dc1610e0dfab4c868342173dcd707fd15c777d9f4f04e153f7fb
   omniauth (2.1.3) sha256=8d24e2e55c41926c96e4a93fd566bc026dfd6f2c850408748e89945a565956c2
   omniauth-oauth2 (1.8.0) sha256=b2f8e9559cc7e2d4efba57607691d6d2b634b879fc5b5b6ccfefa3da85089e78
+  openapi_parser (2.2.6) sha256=10ca80caa40997f6a6dc4412c0c0f6890b835c276e7ece4f0e4f25a45c19c584
   opensearch-ruby (3.4.0) sha256=0a8621686bed3c59b4c23e08cbaef873685a3fe4568e9d2703155ca92b8ca05d
   opentelemetry-api (1.5.0) sha256=8dcc33e7aba70b1da630065ce0db3d6f50cb8ebd2017383209739439025ea997
   opentelemetry-common (0.22.0) sha256=ce5e96a0f838d67eb70a1d32e02bdbe7b8f41767bc71994d73b299a8b0c5878d

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -7,6 +7,6 @@ class Api::V0::ConversationsController < ApplicationController
 
     render json: ConversationBlueprint.render(conversation, answered_questions:, pending_question:), status: :ok
   rescue ActiveRecord::RecordNotFound => e
-    render json: { error: ErrorBlueprint.render_as_hash({ message: e.message }) }, status: :not_found
+    render json: ErrorBlueprint.render_as_hash({ message: e.message }), status: :not_found
   end
 end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -9,4 +9,11 @@ class Api::V0::ConversationsController < ApplicationController
   rescue ActiveRecord::RecordNotFound => e
     render json: ErrorBlueprint.render_as_hash({ message: e.message }), status: :not_found
   end
+
+  def create
+    question = Question.new(message: params[:user_question], conversation: Conversation.new)
+    question.save!
+
+    render json: QuestionBlueprint.render(question, view: :pending), status: :created
+  end
 end

--- a/config/initializers/committee.rb
+++ b/config/initializers/committee.rb
@@ -1,0 +1,6 @@
+require "committee"
+
+Rails.application.config.middleware.use Committee::Middleware::ResponseValidation,
+                                        schema_path: "spec/support/api/openapi.yaml",
+                                        prefix: "/api/v0",
+                                        strict_reference_validation: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
 
   namespace :api, format: false, defaults: { format: "json" } do
     scope :v0 do
+      post "/conversation", to: "v0/conversations#create", as: :create_conversation
       get "/conversation/:id", to: "v0/conversations#show", as: :conversation
     end
   end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,32 +1,10 @@
 RSpec.describe "Api::V0::ConversationsController" do
-  include Committee::Test::Methods
   let(:conversation) { create(:conversation) }
-
-  let(:committee_options) do
-    schema = Committee::Drivers.load_from_file(
-      Rails.root.join("spec/support/api/openapi.yaml").to_s, parser_options: { strict_reference_validation: true }
-    )
-
-    {
-      schema: schema,
-      prefix: "/api/v0",
-      validate_success_only: true,
-    }
-  end
-
-  def request_object
-    response.request
-  end
-
-  def response_data
-    [response.status, response.headers, response.body]
-  end
 
   describe "GET :show" do
     context "when a conversation exists with the given ID" do
-      it "is valid against the OpenAPI spec" do
-        get api_conversation_path(conversation)
-        assert_response_schema_confirm(200)
+      it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path do
+        let(:route_params) { [create(:conversation)] }
       end
 
       it "returns a 200 response" do
@@ -40,8 +18,13 @@ RSpec.describe "Api::V0::ConversationsController" do
       end
 
       context "when the conversation has answered questions" do
+        let!(:answered_question) { create(:question, :with_answer, conversation:) }
+
+        it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path do
+          let(:route_params) { [create(:conversation)] }
+        end
+
         it "returns the answered questions in the JSON response" do
-          answered_question = create(:question, :with_answer, conversation:)
           eager_loaded_answered_question = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
           get api_conversation_path(conversation)
 
@@ -53,9 +36,8 @@ RSpec.describe "Api::V0::ConversationsController" do
       context "when the conversation has a pending question" do
         let!(:pending_question) { create(:question, conversation:) }
 
-        it "is valid against the OpenAPI spec" do
-          get api_conversation_path(conversation)
-          assert_response_schema_confirm(200)
+        it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path do
+          let(:route_params) { [create(:conversation)] }
         end
 
         it "returns the pending question in the JSON response" do
@@ -70,9 +52,8 @@ RSpec.describe "Api::V0::ConversationsController" do
     end
 
     context "when a conversation does not exist with the given ID" do
-      it "is valid against the OpenAPI spec" do
-        get api_conversation_path(id: "invalid-id")
-        assert_response_schema_confirm(404)
+      it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path, 404 do
+        let(:route_params) { %w[invalid_id] }
       end
 
       it "returns a 404 response" do

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -68,4 +68,19 @@ RSpec.describe "Api::V0::ConversationsController" do
       end
     end
   end
+
+  describe "POST :create" do
+    let(:user_question) { "What is the capital of France?" }
+
+    context "with valid user params" do
+      it "creates a conversation and question based on the question_message param" do
+        expect { post api_create_conversation_path, params: { user_question: } }
+          .to change { Question.count }.by(1)
+          .and change { Conversation.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(Question.last.message).to eq(user_question)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,8 +1,34 @@
 RSpec.describe "Api::V0::ConversationsController" do
+  include Committee::Test::Methods
   let(:conversation) { create(:conversation) }
+
+  let(:committee_options) do
+    schema = Committee::Drivers.load_from_file(
+      Rails.root.join("spec/support/api/openapi.yaml").to_s, parser_options: { strict_reference_validation: true }
+    )
+
+    {
+      schema: schema,
+      prefix: "/api/v0",
+      validate_success_only: true,
+    }
+  end
+
+  def request_object
+    response.request
+  end
+
+  def response_data
+    [response.status, response.headers, response.body]
+  end
 
   describe "GET :show" do
     context "when a conversation exists with the given ID" do
+      it "is valid against the OpenAPI spec" do
+        get api_conversation_path(conversation)
+        assert_response_schema_confirm(200)
+      end
+
       it "returns a 200 response" do
         get api_conversation_path(conversation)
         expect(response).to have_http_status(:success)
@@ -25,9 +51,16 @@ RSpec.describe "Api::V0::ConversationsController" do
       end
 
       context "when the conversation has a pending question" do
+        let!(:pending_question) { create(:question, conversation:) }
+
+        it "is valid against the OpenAPI spec" do
+          get api_conversation_path(conversation)
+          assert_response_schema_confirm(200)
+        end
+
         it "returns the pending question in the JSON response" do
-          pending_question = create(:question, conversation:)
           eager_loaded_pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
+
           get api_conversation_path(conversation)
 
           expect(JSON.parse(response.body)["pending_question"])
@@ -37,6 +70,11 @@ RSpec.describe "Api::V0::ConversationsController" do
     end
 
     context "when a conversation does not exist with the given ID" do
+      it "is valid against the OpenAPI spec" do
+        get api_conversation_path(id: "invalid-id")
+        assert_response_schema_confirm(404)
+      end
+
       it "returns a 404 response" do
         get api_conversation_path(id: "invalid-id")
         expect(response).to have_http_status(:not_found)
@@ -45,7 +83,7 @@ RSpec.describe "Api::V0::ConversationsController" do
       it "returns an error message in JSON format" do
         get api_conversation_path(id: "invalid-id")
         expect(response.body)
-          .to eq({ error: { message: "Couldn't find Conversation with 'id'=invalid-id" } }.to_json)
+          .to eq({ message: "Couldn't find Conversation with 'id'=invalid-id" }.to_json)
       end
     end
   end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Api::V0::ConversationsController" do
     end
 
     context "when a conversation does not exist with the given ID" do
-      it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path, 404 do
+      it_behaves_like "adheres to the OpenAPI specification", :api_conversation_path, status_code: 404 do
         let(:route_params) { %w[invalid_id] }
       end
 
@@ -73,10 +73,17 @@ RSpec.describe "Api::V0::ConversationsController" do
     let(:user_question) { "What is the capital of France?" }
 
     context "with valid user params" do
+      it_behaves_like "adheres to the OpenAPI specification",
+                      :api_create_conversation_path,
+                      http_method: :post,
+                      status_code: 201 do
+                        let(:params) { { user_question: } }
+                      end
+
       it "creates a conversation and question based on the question_message param" do
         expect { post api_create_conversation_path, params: { user_question: } }
-          .to change { Question.count }.by(1)
-          .and change { Conversation.count }.by(1)
+          .to change(Question, :count).by(1)
+          .and change(Conversation, :count).by(1)
 
         expect(response).to have_http_status(:created)
         expect(Question.last.message).to eq(user_question)

--- a/spec/support/api/openapi.yaml
+++ b/spec/support/api/openapi.yaml
@@ -1,0 +1,341 @@
+openapi: "3.0.4"
+info:
+  title: GOV.UK Chat API
+  description: |
+    Initial, sproof of concept of documenting what an API for GOV.UK Chat
+    could be that reflects current system modelling.
+    It is intended to help shape chats with the app team about capabilities
+    of chat in app and inform design decisions.
+
+    Worth noting that onboarding aspects of conversation (Informing user of
+    limitations and accepting) are not included as within GOV.UK Chat these
+    are a UI construct and not a part of core domain constructs.
+  version: "0.1.0"
+servers:
+  - url: https://chat.publishing.service.gov.uk/api/v0
+paths:
+  /conversation:
+    post:
+      summary: Start conversation
+      description: Create a conversation by posting an initial question
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserQuestion"
+      responses:
+        "201":
+          description: Successfully created first question in a conversation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PendingQuestion"
+        "422":
+          description: |
+            Validation error on question submission (such as PII in question)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+
+  /conversation/{conversation_id}:
+    get:
+      summary: Retrieve a conversation
+      description: |
+        Accesses the questions of a conversation should a conversation with
+        the id be available.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: |
+            Returns a list of AnsweredQuestions with potentially one PendingQuestion.
+            Is limited to returning 500 questions for a conversation and only
+            questions asked within last 30 days.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+        "404":
+          description: |
+            Either a conversation never existed with this id or has now expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+    put:
+      summary: Update a conversation with a new question
+      description: |
+        Add an additional question to a conversation, requires a conversation
+        to not have a pending question.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserQuestion"
+      responses:
+        "201":
+          description: Successfully added a new question
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PendingQuestion"
+        "422":
+          description: |
+            Validation error on question submission (such as PII in question
+            or user already has a pending question)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+
+  /conversation/{conversation_id}/questions/{question_id}/answer:
+    get:
+      summary: Look up the answer to a question
+      description:
+        This endpoint is intended to be polled while awaiting an answer to a
+        question
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The answer is available and is returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Answer"
+        "202":
+          description: The answer is still being generated
+        "404":
+          description: Conversation or question do not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+  /conversation/{conversation_id}/answers/{answer_id}/feedback:
+    post:
+      summary: Provide user feedback on an individual answer
+      description: |
+        A user can provide feedback on an answer defining it as useful or not,
+        once a user has set this it cannot be changed or removed
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: answer_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - useful
+              properties:
+                useful:
+                  type: boolean
+      responses:
+        "201":
+          description: Feedback successfully submitted
+        "422":
+          description: Validation error processing the feedback
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "404":
+          description: Conversation or answer does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: |
+        GOV.UK Signon issued bearer token which is used to authenticate the
+        client application (e.g. GOV.UK App) and not an individual end user
+      scheme: bearer
+  schemas:
+    UserQuestion:
+      type: object
+      required:
+        - user_question
+      properties:
+        user_question:
+          type: string
+    Conversation:
+      type: object
+      required:
+        - id
+        - answered_questions
+        - created_at
+      properties:
+        answered_questions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnsweredQuestion"
+        pending_question:
+          $ref: "#/components/schemas/PendingQuestion"
+        created_at:
+          type: string
+          format: date-time
+    AnsweredQuestion:
+      type: object
+      required:
+        - id
+        - conversation_id
+        - message
+        - answer
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        conversation_id:
+          type: string
+          format: uuid
+        message:
+          description: The question the user provided in plain text
+          type: string
+        answer:
+          $ref: "#/components/schemas/Answer"
+        created_at:
+          type: string
+          format: date-time
+    PendingQuestion:
+      type: object
+      required:
+        - id
+        - conversation_id
+        - message
+        - answer_url
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        conversation_id:
+          type: string
+          format: uuid
+        message:
+          description: The question the user provided in plain text
+          type: string
+        answer_url:
+          description: |
+            A URL that can be polled to check whether the answer is available
+          type: string
+          format: uri
+        created_at:
+          type: string
+          format: date-time
+    Answer:
+      type: object
+      required:
+        - id
+        - created_at
+        - message
+      properties:
+        id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        message:
+          description: |
+            The users answer, we can probably return this in either markdown
+            (with potential for HTML nasties to be in) or HTML (with any HTML
+            nasties removed)
+
+            App team specified they preferred markdown (3/4/2025) so we'll
+            start with that
+          type: string
+        useful:
+          description: |
+            Whether a user has flagged this answer as useful or not
+          type: boolean
+        sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnswerSource"
+    AnswerSource:
+      type: object
+      required:
+        - title
+        - url
+      properties:
+        title:
+          description: Title of the GOV.UK document used
+          type: string
+        heading:
+          description: Heading of the section used for content
+          type: string
+        url:
+          description: |
+            URL of the page on GOV.UK that was used to generate answer
+            with potentially a fragment to appropriate section
+          type: string
+          format: uri
+    GenericError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+    ValidationError:
+      type: object
+      required:
+        - message
+        - fields
+      properties:
+        message:
+          type: string
+        fields:
+          description: |
+            an object structure of field name to an array of errors
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string

--- a/spec/support/api_endpoint_open_api_specification_examples.rb
+++ b/spec/support/api_endpoint_open_api_specification_examples.rb
@@ -1,0 +1,31 @@
+module ApiEndpointOpenApiSpecificationExamples
+  shared_examples "adheres to the OpenAPI specification" do |path, http_method: :get, status_code: 200|
+    include Committee::Test::Methods
+    let(:route_params) { [] }
+    let(:params) { {} }
+
+    it "adheres to the OpenAPI specification" do
+      process(http_method, public_send(path.to_sym, *route_params), params:)
+      assert_response_schema_confirm(status_code)
+    end
+
+    def request_object
+      response.request
+    end
+
+    def response_data
+      [response.status, response.headers, response.body]
+    end
+
+    def committee_options
+      schema = Committee::Drivers.load_from_file(
+        Rails.root.join("spec/support/api/openapi.yaml").to_s, parser_options: { strict_reference_validation: true }
+      )
+
+      {
+        schema: schema,
+        prefix: "/api/v0",
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Description 

This spikes out adding [Committee](https://github.com/interagent/committee) to ensure API responses adhere to the documented OpenAPI 3.0 spec.

It:

- adds Committee as a dependency
- adds [Kevs OpenAPI spec](https://gist.github.com/kevindew/9ee643132182ab4dc927c4c8ca46d8eb) to `spec/support/api/openapi.yaml` (we're going to want a better name for this probably `conversation_api`).
- adds a shared example ensure that the response is valid against the schema for the current API endpoints
- adds a post conversation endpoint to flesh out the shared example 
- configures the middleware to catch invalid responses (we might want to raise here for alerting)

We can also use Committee to validate requests if we want but i think we would be better off reusing our form objects and returning more detailed errors to API users.

## Screenshots

### When valid 

<img width="480" alt="image" src="https://github.com/user-attachments/assets/d5595edb-824c-4e5f-9b73-e1e14f107f0d" />

### Without setting `raise: true` on the middleware 

<img width="662" alt="image" src="https://github.com/user-attachments/assets/8aec03e1-a60e-4610-8aa3-24bf33f1b4bb" />

### With `raise: true`

<img width="947" alt="image" src="https://github.com/user-attachments/assets/3a4d44e1-414d-4a67-a177-33e77a2357ca" />

If we don't set raise to true, our response will be logged but silently fail so we would need a user to inform us there's an issue. 

We can customise the errors we return using [this](https://github.com/interagent/committee?tab=readme-ov-file#validation-errors). We will want to think about doing this as part of implementation.
