### PR TITLE
Add guardrail names to output guardrail evaluation task

### DIFF
--- a/lib/answer_composition/pipeline/answer_guardrails.rb
+++ b/lib/answer_composition/pipeline/answer_guardrails.rb
@@ -9,7 +9,7 @@ module AnswerComposition
           context.abort_pipeline!(
             message: Answer::CannedResponses::ANSWER_GUARDRAILS_FAILED_MESSAGE,
             status: "guardrails_answer",
-            answer_guardrails_failures: response.guardrails,
+            answer_guardrails_failures: response.triggered_guardrails,
             answer_guardrails_status: :fail,
             metrics: { guardrail_name => build_metrics(start_time, response) },
           )

--- a/lib/answer_composition/pipeline/question_routing_guardrails.rb
+++ b/lib/answer_composition/pipeline/question_routing_guardrails.rb
@@ -11,7 +11,7 @@ module AnswerComposition
           context.answer.assign_attributes(
             message: Answer::CannedResponses::QUESTION_ROUTING_GUARDRAILS_FAILED_MESSAGE,
             status: "guardrails_question_routing",
-            question_routing_guardrails_failures: response.guardrails,
+            question_routing_guardrails_failures: response.triggered_guardrails,
           )
         end
 

--- a/spec/factories/output_guardrail_result_factory.rb
+++ b/spec/factories/output_guardrail_result_factory.rb
@@ -18,13 +18,13 @@ FactoryBot.define do
 
     trait :pass do
       triggered { false }
-      guardrails { [] }
+      guardrails { { political: false, appropriate_language: false } }
       llm_guardrail_result { "False | None" }
     end
 
     trait :fail do
       triggered { true }
-      guardrails { %w[political] }
+      guardrails { { political: true, appropriate_language: false } }
       llm_guardrail_result { 'True | "3"' }
     end
   end

--- a/spec/lib/guardrails/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/multiple_checker_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Guardrails::MultipleChecker do
     let(:guardrail_response_hash) do
       {
         llm_response: {
-          "message" => {
-            "role" => "assistant",
-            "content" => "False | None",
+          message: {
+            role: "assistant",
+            content: "False | None",
           },
-          "finish_reason" => "stop",
+          finish_reason: "stop",
         },
         llm_guardrail_result: "False | None",
         llm_prompt_tokens: 13,
@@ -20,6 +20,7 @@ RSpec.describe Guardrails::MultipleChecker do
         llm_cached_tokens: 10,
       }
     end
+    let(:guardrail_result) { build(:guardrails_multiple_checker_result, :pass) }
 
     it "raises an error if the llm_provider is unknown" do
       expect { described_class.call(input, llm_prompt_name, :unknown_provider) }
@@ -33,11 +34,10 @@ RSpec.describe Guardrails::MultipleChecker do
         guardrails_config = {
           system_prompt: "{guardrails} {date}",
           user_prompt: "{input}",
-          guardrails: %w[costs personal unique_answer_guardrail],
+          guardrails: %w[political appropriate_language],
           guardrail_definitions: {
-            "costs" => "This is a costs guardrail",
-            "personal" => "This is a personal guardrail",
-            "unique_answer_guardrail" => "This is a unique answer guardrail",
+            "political" => "This is a political guardrail",
+            "appropriate_language" => "This is an appropriate language guardrail",
           },
         }.with_indifferent_access
 
@@ -49,6 +49,11 @@ RSpec.describe Guardrails::MultipleChecker do
         described_class.call(input, llm_prompt_name, llm_provider)
         expect(Guardrails::OpenAI::MultipleChecker).to have_received(:call).with(input, instance_of(Guardrails::MultipleChecker::Prompt))
       end
+
+      it "returns the guardrail result" do
+        result = described_class.call(input, llm_prompt_name, llm_provider)
+        expect(result).to eq(guardrail_result)
+      end
     end
 
     context "when the llm_provider is :claude" do
@@ -58,11 +63,10 @@ RSpec.describe Guardrails::MultipleChecker do
         guardrails_config = {
           system_prompt: "{guardrails} {date}",
           user_prompt: "{input}",
-          guardrails: %w[costs personal unique_answer_guardrail],
+          guardrails: %w[political appropriate_language],
           guardrail_definitions: {
-            "costs" => "This is a costs guardrail",
-            "personal" => "This is a personal guardrail",
-            "unique_answer_guardrail" => "This is a unique answer guardrail",
+            "political" => "This is a political guardrail",
+            "appropriate_language" => "This is an appropriate language guardrail",
           },
         }.with_indifferent_access
 
@@ -73,6 +77,11 @@ RSpec.describe Guardrails::MultipleChecker do
       it "calls the Claude multiple checker" do
         described_class.call(input, llm_prompt_name, llm_provider)
         expect(Guardrails::Claude::MultipleChecker).to have_received(:call).with(input, instance_of(Guardrails::MultipleChecker::Prompt))
+      end
+
+      it "returns the guardrail result" do
+        result = described_class.call(input, llm_prompt_name, llm_provider)
+        expect(result).to eq(guardrail_result)
       end
 
       context "when the response format is incorrect" do


### PR DESCRIPTION
Connected to Trello: https://trello.com/c/0ssf3xuh/2376-port-output-guardrail-evaluations-to-the-python-evaluation-framework

Output guardrail results now include a hash keyed by guardrail name with
a boolean pass/fail flag, rather than an array that only contained the
names of guardrails that failed.

This is in order to provide the exact number of guardrail definitions,
as well as their names to the evaluation tool (1). Without providing
these details they must be hardcoded in the evaluation codebase,
resulting in potential discrepancies if guardrail definitions are
updated. It will also save the evaluation tool from having to duplicate
the effort of parsing the raw LLM response.

1: https://github.com/alphagov/govuk-chat-evaluation-prototype/pull/24