### PR TITLE
Implement initial Chat API endpoint GET answer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
 gem "rails", "8.0.2"
 
 gem "aws-sdk-bedrockruntime"
+gem "blueprinter"
 gem "bootsnap"
 gem "chartkick"
 gem "csv"

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "committee"
   gem "dotenv"
   gem "erb_lint", require: false
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.1.9)
+    blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (7.0.2)
@@ -909,6 +910,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-bedrockruntime
+  blueprinter
   bootsnap
   brakeman
   chartkick
@@ -982,6 +984,7 @@ CHECKSUMS
   benchmark (0.4.0) sha256=0f12f8c495545e3710c3e4f0480f63f06b4c842cc94cec7f33a956f5180e874a
   better_html (2.1.1) sha256=046c3551d1488a3f2939a7cac6fabf2bde08c32e135c91fcd683380118e5af55
   bigdecimal (3.1.9) sha256=2ffc742031521ad69c2dfc815a98e426a230a3d22aeac1995826a75dabfad8cc
+  blueprinter (1.1.2) sha256=e09945686d13539f9e911403b4f13cf4dcb83c951abd188bfca8754afbfb2249
   bootsnap (1.18.4) sha256=ac4c42af397f7ee15521820198daeff545e4c360d2772c601fbdc2c07d92af55
   brakeman (7.0.2) sha256=b602d91bcec6c5ce4d4bc9e081e01f621c304b7a69f227d1e58784135f333786
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,10 @@ GEM
     chartkick (5.1.5)
     climate_control (1.2.0)
     coderay (1.1.3)
+    committee (5.5.3)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5, < 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.1)
     crack (1.0.0)
@@ -316,6 +320,7 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    json_schema (0.21.0)
     jwt (2.10.1)
       base64
     kaminari (1.2.2)
@@ -416,6 +421,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    openapi_parser (2.2.6)
     opensearch-ruby (3.4.0)
       faraday (>= 1.0, < 3)
       multi_json (>= 1.0)
@@ -915,6 +921,7 @@ DEPENDENCIES
   brakeman
   chartkick
   climate_control
+  committee
   csv
   dalli
   dartsass-rails
@@ -994,6 +1001,7 @@ CHECKSUMS
   chartkick (5.1.5) sha256=368f7fa61a3c1d731c9f5b3ebf7c49e552a5f5798776fb1811fe744f1cdbf34e
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  committee (5.5.3) sha256=434d6f040e905f636d91a7bbfe8dc5292917b91b5ff55b192569740c67a920ca
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
   connection_pool (2.5.1) sha256=ae802a90a4b5a081101b39d618e69921a9a50bea9ac3420a5b8c71f1befa3e9c
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
@@ -1060,6 +1068,7 @@ CHECKSUMS
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.10.2) sha256=34e0eada93022b2a0a3345bb0b5efddb6e9ff5be7c48e409cfb54ff8a36a8b06
   json-schema (5.1.1) sha256=b3829ad9bcdfc5010d8a160c4c2bebb8fed8d05d22de65648f6ba646b071f9bf
+  json_schema (0.21.0) sha256=d6e1eaf004a5185b7679eee34286a79d48e467d794ff68981d72ad23d3b2ec5b
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -1106,6 +1115,7 @@ CHECKSUMS
   oauth2 (2.0.9) sha256=b21f9defcf52dc1610e0dfab4c868342173dcd707fd15c777d9f4f04e153f7fb
   omniauth (2.1.3) sha256=8d24e2e55c41926c96e4a93fd566bc026dfd6f2c850408748e89945a565956c2
   omniauth-oauth2 (1.8.0) sha256=b2f8e9559cc7e2d4efba57607691d6d2b634b879fc5b5b6ccfefa3da85089e78
+  openapi_parser (2.2.6) sha256=10ca80caa40997f6a6dc4412c0c0f6890b835c276e7ece4f0e4f25a45c19c584
   opensearch-ruby (3.4.0) sha256=0a8621686bed3c59b4c23e08cbaef873685a3fe4568e9d2703155ca92b8ca05d
   opentelemetry-api (1.5.0) sha256=8dcc33e7aba70b1da630065ce0db3d6f50cb8ebd2017383209739439025ea997
   opentelemetry-common (0.22.0) sha256=ce5e96a0f838d67eb70a1d32e02bdbe7b8f41767bc71994d73b299a8b0c5878d

--- a/app/blueprints/answer_blueprint.rb
+++ b/app/blueprints/answer_blueprint.rb
@@ -1,0 +1,17 @@
+class AnswerBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :message
+  field :created_at do |answer, _options|
+    answer.created_at.iso8601
+  end
+  field :useful, if: ->(_field_name, answer, _options) { answer.feedback.present? } do |answer, _options|
+    answer.feedback.useful
+  end
+
+  field :sources, if: ->(_field_name, answer, _options) { answer.sources.used.present? } do |answer, _options|
+    answer.group_used_answer_sources_by_base_path.map do |source|
+      { url: source[:href], title: source[:title] }
+    end
+  end
+end

--- a/app/blueprints/generic_error_blueprint.rb
+++ b/app/blueprints/generic_error_blueprint.rb
@@ -1,0 +1,3 @@
+class GenericErrorBlueprint < Blueprinter::Base
+  field :message
+end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,0 +1,17 @@
+class Api::V0::ConversationsController < ApplicationController
+  before_action :find_conversation
+  before_action :find_question
+
+  def answer
+    conversation = Conversation.includes(questions: { answer: %i[sources feedback] })
+                               .find(params[:conversation_id])
+    question = conversation.questions.find(params[:question_id])
+    answer = question.answer
+
+    if answer.present?
+      render json: AnswerBlueprint.render(answer), status: :ok
+    else
+      render json: {}, status: :accepted
+    end
+  end
+end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,6 +1,5 @@
 class Api::V0::ConversationsController < ApplicationController
-  before_action :find_conversation
-  before_action :find_question
+  before_action { authorise_user!(SignonUser::Permissions::CONVERSATION_API) }
 
   def answer
     conversation = Conversation.includes(questions: { answer: %i[sources feedback] })

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -10,23 +10,6 @@ module AnswersHelper
     end
   end
 
-  def group_used_answer_sources_by_base_path(answer)
-    sources_by_base_path = answer.sources.used.group_by(&:base_path)
-
-    sources_by_base_path.map do |base_path, group|
-      result = group.first
-      path = group.count == 1 ? result.exact_path : base_path
-
-      title = result.title
-      title += ": #{result.heading}" if group.count == 1 && result.heading.present?
-
-      {
-        href: "#{Plek.website_root}#{path}",
-        title:,
-      }
-    end
-  end
-
   def show_question_limit_system_message?(user)
     return false if user.nil?
     return false if user.unlimited_question_allowance?

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -174,4 +174,21 @@ class Answer < ApplicationRecord
   def set_sources_as_unused
     sources.each { |source| source.used = false }
   end
+
+  def group_used_answer_sources_by_base_path
+    sources_by_base_path = sources.used.group_by(&:base_path)
+
+    sources_by_base_path.map do |base_path, group|
+      result = group.first
+      path = group.count == 1 ? result.exact_path : base_path
+
+      title = result.title
+      title += ": #{result.heading}" if group.count == 1 && result.heading.present?
+
+      {
+        href: "#{Plek.website_root}#{path}",
+        title:,
+      }
+    end
+  end
 end

--- a/app/models/signon_user.rb
+++ b/app/models/signon_user.rb
@@ -3,6 +3,7 @@ class SignonUser < ApplicationRecord
 
   module Permissions
     ADMIN_AREA = "admin-area".freeze
+    CONVERSATION_API = "conversation-api".freeze
     DEVELOPER_TOOLS = "developer-tools".freeze
   end
 end

--- a/app/views/conversations/_answer.html.erb
+++ b/app/views/conversations/_answer.html.erb
@@ -1,6 +1,6 @@
 <%= render "components/conversation_message", {
   id: dom_id(answer),
-  sources: group_used_answer_sources_by_base_path(answer),
+  sources: answer.group_used_answer_sources_by_base_path,
   message: answer.message,
   question_message: answer.question.message,
   feedback_url: (answer_feedback_path(answer) if answer.feedback.blank?),

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,7 @@ module GovukChat
     config.action_dispatch.rescue_responses.merge!(
       "Search::ChunkedContentRepository::NotFound" => :not_found,
       "ThrottledRequest" => :too_many_requests,
+      "Committee::InvalidResponse" => :internal_server_error,
     )
 
     config.exceptions_app = routes

--- a/config/initializers/committee.rb
+++ b/config/initializers/committee.rb
@@ -1,0 +1,7 @@
+require "committee"
+
+Rails.application.config.middleware.use Committee::Middleware::ResponseValidation,
+                                        schema_path: "docs/api_openapi_specification.yml",
+                                        prefix: "/api/v0",
+                                        strict_reference_validation: true,
+                                        raise: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :api, format: false, defaults: { format: "json" } do
+    namespace :v0 do
+      get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
+    end
+  end
+
   scope via: :all do
     match "/400" => "errors#bad_request"
     match "/403" => "errors#forbidden"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,7 @@
-SignonUser.find_or_create_by!(name: "chat_user", email: "chat.user@dev.gov.uk").update!(uid: SecureRandom.uuid, permissions: %w[developer-tools admin-area])
+SignonUser.find_or_create_by!(
+  name: "chat_user",
+  email: "chat.user@dev.gov.uk",
+).update!(
+  uid: SecureRandom.uuid,
+  permissions: %w[developer-tools admin-area conversation-api],
+)

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -1,0 +1,336 @@
+openapi: "3.0.4"
+info:
+  title: GOV.UK Chat API
+  description: |
+    Initial, proof of concept of documenting what an API for GOV.UK Chat
+    could be that reflects current system modelling.
+    It is intended to help shape chats with the app team about capabilities
+    of chat in app and inform design decisions.
+
+    Worth noting that onboarding aspects of conversation (Informing user of
+    limitations and accepting) are not included as within GOV.UK Chat these
+    are a UI construct and not a part of core domain constructs.
+  version: "0.1.0"
+servers:
+  - url: https://chat.publishing.service.gov.uk/api/v0
+paths:
+  /conversation:
+    post:
+      summary: Start conversation
+      description: Create a conversation by posting an initial question
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserQuestion"
+      responses:
+        "201":
+          description: Successfully created first question in a conversation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PendingQuestion"
+        "422":
+          description: |
+            Validation error on question submission (such as PII in question)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+
+  /conversation/{conversation_id}:
+    get:
+      summary: Retrieve a conversation
+      description: |
+        Accesses the questions of a conversation should a conversation with
+        the id be available.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: |
+            Returns a list of AnsweredQuestions with potentially one PendingQuestion.
+            Is limited to returning 500 questions for a conversation and only
+            questions asked within last 30 days.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+        "404":
+          description: |
+            Either a conversation never existed with this id or has now expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+    put:
+      summary: Update a conversation with a new question
+      description: |
+        Add an additional question to a conversation, requires a conversation
+        to not have a pending question.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserQuestion"
+      responses:
+        "201":
+          description: Successfully added a new question
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PendingQuestion"
+        "422":
+          description: |
+            Validation error on question submission (such as PII in question
+            or user already has a pending question)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+
+  /conversation/{conversation_id}/questions/{question_id}/answer:
+    get:
+      summary: Look up the answer to a question
+      description:
+        This endpoint is intended to be polled while awaiting an answer to a
+        question
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The answer is available and is returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Answer"
+        "202":
+          description: The answer is still being generated
+        "404":
+          description: Conversation or question do not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+  /conversation/{conversation_id}/answers/{answer_id}/feedback:
+    post:
+      summary: Provide user feedback on an individual answer
+      description: |
+        A user can provide feedback on an answer defining it as useful or not,
+        once a user has set this it cannot be changed or removed
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: answer_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - useful
+              properties:
+                useful:
+                  type: boolean
+      responses:
+        "201":
+          description: Feedback successfully submitted
+        "422":
+          description: Validation error processing the feedback
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "404":
+          description: Conversation or answer does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: |
+        GOV.UK Signon issued bearer token which is used to authenticate the
+        client application (e.g. GOV.UK App) and not an individual end user
+      scheme: bearer
+  schemas:
+    UserQuestion:
+      type: object
+      required:
+        - user_question
+      properties:
+        user_question:
+          type: string
+    Conversation:
+      type: object
+      required:
+        - id
+        - answered_questions
+        - created_at
+      properties:
+        answered_questions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnsweredQuestion"
+        pending_question:
+          $ref: "#/components/schemas/PendingQuestion"
+        created_at:
+          type: string
+          format: date-time
+    AnsweredQuestion:
+      type: object
+      required:
+        - id
+        - conversation_id
+        - message
+        - answer
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        conversation_id:
+          type: string
+          format: uuid
+        message:
+          description: The question the user provided in plain text
+          type: string
+        answer:
+          $ref: "#/components/schemas/Answer"
+        created_at:
+          type: string
+          format: date-time
+    PendingQuestion:
+      type: object
+      required:
+        - id
+        - conversation_id
+        - message
+        - answer_url
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        conversation_id:
+          type: string
+          format: uuid
+        message:
+          description: The question the user provided in plain text
+          type: string
+        answer_url:
+          description: |
+            A URL that can be polled to check whether the answer is available
+          type: string
+          format: uri
+        created_at:
+          type: string
+          format: date-time
+    Answer:
+      type: object
+      required:
+        - id
+        - created_at
+        - message
+      properties:
+        id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        message:
+          description: |
+            The LLM generated answer returned in markdown format.
+          type: string
+        useful:
+          description: |
+            Whether a user has flagged this answer as useful or not
+          type: boolean
+        sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnswerSource"
+    AnswerSource:
+      type: object
+      required:
+        - title
+        - url
+      properties:
+        title:
+          description: Title of the GOV.UK document used
+          type: string
+        heading:
+          description: Heading of the section used for content
+          type: string
+        url:
+          description: |
+            URL of the page on GOV.UK that was used to generate answer
+            with potentially a fragment to appropriate section
+          type: string
+          format: uri
+    GenericError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+    ValidationError:
+      type: object
+      required:
+        - message
+        - fields
+      properties:
+        message:
+          type: string
+        fields:
+          description: |
+            an object structure of field name to an array of errors
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string

--- a/spec/blueprints/answer_blueprint_spec.rb
+++ b/spec/blueprints/answer_blueprint_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe AnswerBlueprint do
+  let(:answer) { create(:answer) }
+
+  describe ".render_as_json" do
+    it "generates the correct JSON for an Answer with no sources" do
+      expected_json = {
+        id: answer.id,
+        created_at: answer.created_at.iso8601,
+        message: answer.message,
+      }.as_json
+      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+      expect(output_json).to eq(expected_json)
+    end
+
+    it "generates the correct JSON for an Answer with used sources" do
+      answer_source = create(:answer_source, answer:)
+
+      expected_json = {
+        id: answer.id,
+        created_at: answer.created_at.iso8601,
+        message: answer.message,
+        sources: [
+          {
+            title: "#{answer_source.title}: #{answer_source.heading}",
+            url: answer_source.url,
+          },
+        ],
+      }.as_json
+      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+      expect(output_json).to eq(expected_json)
+    end
+
+    it "does not include unused sources in the JSON" do
+      create(:answer_source, answer:, used: false)
+      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+      expect(output_json.keys).not_to include("sources")
+    end
+
+    context "when answer feedback is present" do
+      it "includes it in the JSON" do
+        create(:answer_feedback, answer:)
+        expected_json = {
+          id: answer.id,
+          created_at: answer.created_at.iso8601,
+          message: answer.message,
+          useful: true,
+        }.as_json
+        output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+
+        expect(output_json).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/blueprints/generic_error_blueprint_spec.rb
+++ b/spec/blueprints/generic_error_blueprint_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe GenericErrorBlueprint do
+  describe ".render_as_json" do
+    it "renders the correct JSON based on the message passed in" do
+      expect(described_class.render_as_json(message: "test-message"))
+        .to eq({ message: "test-message" }.as_json)
+    end
+  end
+end

--- a/spec/factories/signon_user_factory.rb
+++ b/spec/factories/signon_user_factory.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     trait :admin do
       permissions { %w[admin-area] }
     end
+
+    trait :conversation_api do
+      permissions { %w[conversation-api] }
+    end
   end
 end

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -23,67 +23,6 @@ RSpec.describe AnswersHelper do
     end
   end
 
-  describe "#group_used_answer_sources_by_base_path" do
-    context "when there is one source per base path" do
-      let(:answer) do
-        create(:answer, sources: [
-          create(
-            :answer_source,
-            base_path: "/childcare-provider",
-            exact_path: "/childcare-provider/how-to-get-a-childcare-provider",
-            title: "Childcare providers",
-            heading: "How to get a childcare provider",
-          ),
-        ])
-      end
-
-      it "builds the sources using the exact path and including the heading" do
-        expect(helper.group_used_answer_sources_by_base_path(answer)).to contain_exactly(
-          {
-            href: "#{Plek.website_root}/childcare-provider/how-to-get-a-childcare-provider",
-            title: "Childcare providers: How to get a childcare provider",
-          },
-        )
-      end
-
-      it "filters out unused sources" do
-        answer.sources << create(:answer_source, used: false, answer:)
-
-        expect(helper.group_used_answer_sources_by_base_path(answer).length).to eq 1
-      end
-    end
-
-    context "when there are multiple sources per base path" do
-      let(:answer) do
-        create(:answer, sources: [
-          create(
-            :answer_source,
-            base_path: "/childcare-provider",
-            exact_path: "/childcare-provider/how-to-get-a-childcare-provider",
-            title: "Childcare providers",
-            heading: "How to get a childcare provider",
-          ),
-          create(
-            :answer_source,
-            base_path: "/childcare-provider",
-            exact_path: "/childcare-provider/how-much-it-costs",
-            title: "Childcare providers",
-            heading: "How much it costs",
-          ),
-        ])
-      end
-
-      it "builds the sources using the base path and excluding the heading" do
-        expect(helper.group_used_answer_sources_by_base_path(answer)).to contain_exactly(
-          {
-            href: "#{Plek.website_root}/childcare-provider",
-            title: "Childcare providers",
-          },
-        )
-      end
-    end
-  end
-
   describe "#show_question_limit_system_message?" do
     it "returns false when no user is present" do
       expect(helper.show_question_limit_system_message?(nil)).to be(false)

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -244,4 +244,65 @@ RSpec.describe Answer do
       expect(answer.sources.all?(&:used?)).to be(false)
     end
   end
+
+  describe "#group_used_answer_sources_by_base_path" do
+    context "when there is one source per base path" do
+      let(:answer) do
+        create(:answer, sources: [
+          create(
+            :answer_source,
+            base_path: "/childcare-provider",
+            exact_path: "/childcare-provider/how-to-get-a-childcare-provider",
+            title: "Childcare providers",
+            heading: "How to get a childcare provider",
+          ),
+        ])
+      end
+
+      it "builds the sources using the exact path and including the heading" do
+        expect(answer.group_used_answer_sources_by_base_path).to contain_exactly(
+          {
+            href: "#{Plek.website_root}/childcare-provider/how-to-get-a-childcare-provider",
+            title: "Childcare providers: How to get a childcare provider",
+          },
+        )
+      end
+
+      it "filters out unused sources" do
+        answer.sources << create(:answer_source, used: false, answer:)
+
+        expect(answer.group_used_answer_sources_by_base_path.length).to eq 1
+      end
+    end
+
+    context "when there are multiple sources per base path" do
+      let(:answer) do
+        create(:answer, sources: [
+          create(
+            :answer_source,
+            base_path: "/childcare-provider",
+            exact_path: "/childcare-provider/how-to-get-a-childcare-provider",
+            title: "Childcare providers",
+            heading: "How to get a childcare provider",
+          ),
+          create(
+            :answer_source,
+            base_path: "/childcare-provider",
+            exact_path: "/childcare-provider/how-much-it-costs",
+            title: "Childcare providers",
+            heading: "How much it costs",
+          ),
+        ])
+      end
+
+      it "builds the sources using the base path and excluding the heading" do
+        expect(answer.group_used_answer_sources_by_base_path).to contain_exactly(
+          {
+            href: "#{Plek.website_root}/childcare-provider",
+            title: "Childcare providers",
+          },
+        )
+      end
+    end
+  end
 end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe "Api::V0::ConversationsController" do
     end
   end
 
+  describe "middleware ensures adherance to the OpenAPI specification" do
+    context "when the response returned does not conform to the OpenAPI specification" do
+      it "raises an error and returns the invalid params in the error message" do
+        create(:answer, question:)
+        allow(AnswerBlueprint).to receive(:render).and_return({}.to_json)
+
+        get api_v0_answer_question_path(conversation, question)
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.body).to include("Sorry, there is a problem with GOV.UK Chat")
+      end
+    end
+  end
+
   describe "GET :answer" do
     it_behaves_like "responds with forbidden if user doesn't have conversation-api permission",
                     :api_v0_answer_question_path,

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -2,7 +2,31 @@ RSpec.describe "Api::V0::ConversationsController" do
   let(:conversation) { create(:conversation) }
   let(:question) { create(:question, conversation:) }
 
+  before do
+    login_as(create(:signon_user, :conversation_api))
+  end
+
+  shared_examples "responds with forbidden if user doesn't have conversation-api permission" do |path, method|
+    let(:route_params) { {} }
+    let(:params) { {} }
+
+    describe "responds with forbidden if user doesn't have conversation-api permission" do
+      it "returns with 403 for #{path}" do
+        login_as(create(:signon_user))
+        process(method.to_sym, public_send(path.to_sym, *route_params), params:, as: :json)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
   describe "GET :answer" do
+    it_behaves_like "responds with forbidden if user doesn't have conversation-api permission",
+                    :api_v0_answer_question_path,
+                    :get do
+      let(:route_params) { [create(:conversation), create(:question)] }
+    end
+
     context "when an answer has been generated for the question" do
       let!(:answer) { create(:answer, question:) }
 

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Api::V0::ConversationsController" do
+  let(:conversation) { create(:conversation) }
+  let(:question) { create(:question, conversation:) }
+
+  describe "GET :answer" do
+    context "when an answer has been generated for the question" do
+      let!(:answer) { create(:answer, question:) }
+
+      it "returns a success status" do
+        get api_v0_answer_question_path(conversation, question)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the expected JSON" do
+        get api_v0_answer_question_path(conversation, question)
+
+        eager_loaded_answer = Answer.includes(:sources, :feedback).find(answer.id)
+        expected_response = AnswerBlueprint.render_as_json(eager_loaded_answer)
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+
+      it "returns the correct JSON for answer sources" do
+        source = create(:answer_source, answer:)
+
+        get api_v0_answer_question_path(conversation, question)
+
+        expect(JSON.parse(response.body)["sources"])
+          .to eq([{ url: source.url, title: "#{source.title}: #{source.heading}" }.as_json])
+      end
+    end
+
+    context "when an answer has not been generated for the question" do
+      it "returns an accepted status" do
+        get api_v0_answer_question_path(conversation, question)
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it "returns an empty JSON response" do
+        get api_v0_answer_question_path(conversation, question)
+        expect(JSON.parse(response.body)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR introduces the initial implementation of the `GET /answer` endpoint for the GOV.UK Chat API. It: 

- Adds the OpenAI specification based on Kev's [Gist](https://gist.github.com/kevindew/9ee643132182ab4dc927c4c8ca46d8eb)
- Adds `blueprinter` as a dependency and adds the required blueprints for the endpoint (answer, answer source and generic error)
- Adds the endpoint (controller, route etc.)
- Adds `committee` and configured it to validate API responses at runtime
- Adds an `api-user` permission to the AdminUser model and auths the API endpoints based on the presence of the permission

For now you can access the API endpoints locally by adding the permission to the first admin user in your local DB. It's been added to the seeds though so when the db is reset it will work as expected.

A few things to note:

- I know we will need to rename the `AdminUser` model since we will have people who auth via a token to use the API who are not admins (currently when they use the token for the first time they will be persisted to the DB as an AdminUser)

I've carded up doing this as a separate bit of work [here](https://trello.com/c/zsmJJZfa/2420-chat-api-update-adminuser-to-signonuser), but am trying to get the rest of the cards for this unblocked first. 

- I've tried as much as possible to mirror our implementation for Chat where possible. Are couple of examples are:
  - using a single `ConversationsController` with shared functionality rather than `AnswerContoller#show` 
  - consistent error messaging (using `Conversation not found` rather than using `error.message` within the rescue

Im going to leave a couple of comments on bit's i'm less sure on and would appreciate feedback on.

## Trello card

https://trello.com/c/fTlGZAtH/2421-chat-api-add-initial-api-endpoint-get-answer

## Useful resources 

- We’re using the OpenAPI spec defined by Kev in this [Gist](https://gist.github.com/kevindew/9ee643132182ab4dc927c4c8ca46d8eb)

- We’ve decided on using [Blueprinter](https://github.com/procore-oss/blueprinter/blob/main/README.md) for serialisation. It was spiked out in this [PR](https://github.com/alphagov/govuk-chat/pull/153/files)

- We’re using [Committee](https://github.com/interagent/committee) to ensure we keep our responses in sync with the OpenAPI specification

- This [ADR](https://github.com/alphagov/govuk-chat/pull/167) discusses why we’re using them