### PR TITLE
Rename AdminUser to SignonUser

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,5 @@
 class Admin::BaseController < ApplicationController
   layout "admin"
-  before_action { authorise_user!(AdminUser::Permissions::ADMIN_AREA) }
-  before_action { Current.admin_user = current_user }
+  before_action { authorise_user!(SignonUser::Permissions::ADMIN_AREA) }
+  before_action { Current.signon_user = current_user }
 end

--- a/app/controllers/admin/early_access_users_controller.rb
+++ b/app/controllers/admin/early_access_users_controller.rb
@@ -53,7 +53,7 @@ class Admin::EarlyAccessUsersController < Admin::BaseController
 
   def destroy
     EarlyAccessUser.find(params[:id])
-                   .destroy_with_audit(deletion_type: :admin, deleted_by_admin_user_id: current_user.id)
+                   .destroy_with_audit(deletion_type: :admin, deleted_by_signon_user_id: current_user.id)
 
     redirect_to admin_early_access_users_path, notice: "User deleted"
   end

--- a/app/controllers/admin/waiting_list_users_controller.rb
+++ b/app/controllers/admin/waiting_list_users_controller.rb
@@ -57,7 +57,7 @@ class Admin::WaitingListUsersController < Admin::BaseController
 
   def destroy
     WaitingListUser.find(params[:id])
-                   .destroy_with_audit(deletion_type: "admin", deleted_by_admin_user_id: current_user.id)
+                   .destroy_with_audit(deletion_type: "admin", deleted_by_signon_user_id: current_user.id)
 
     redirect_to admin_waiting_list_users_path, notice: "User deleted"
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :admin_user
+  attribute :signon_user
 end

--- a/app/models/early_access_user.rb
+++ b/app/models/early_access_user.rb
@@ -75,11 +75,11 @@ class EarlyAccessUser < ApplicationRecord
     hash
   end
 
-  def destroy_with_audit(deletion_type:, deleted_by_admin_user_id: nil)
+  def destroy_with_audit(deletion_type:, deleted_by_signon_user_id: nil)
     transaction do
       destroy!
       DeletedEarlyAccessUser.create!(id:,
-                                     deleted_by_admin_user_id:,
+                                     deleted_by_signon_user_id:,
                                      deletion_type:,
                                      login_count:,
                                      user_source: source,

--- a/app/models/settings_audit.rb
+++ b/app/models/settings_audit.rb
@@ -1,3 +1,3 @@
 class SettingsAudit < ApplicationRecord
-  belongs_to :user, optional: true, class_name: "AdminUser"
+  belongs_to :user, optional: true, class_name: "SignonUser"
 end

--- a/app/models/signon_user.rb
+++ b/app/models/signon_user.rb
@@ -1,4 +1,4 @@
-class AdminUser < ApplicationRecord
+class SignonUser < ApplicationRecord
   include GDS::SSO::User
 
   module Permissions

--- a/app/models/waiting_list_user.rb
+++ b/app/models/waiting_list_user.rb
@@ -35,11 +35,11 @@ class WaitingListUser < ApplicationRecord
     hash
   end
 
-  def destroy_with_audit(deletion_type:, deleted_by_admin_user_id: nil)
+  def destroy_with_audit(deletion_type:, deleted_by_signon_user_id: nil)
     transaction do
       destroy!
       DeletedWaitingListUser.create!(id:,
-                                     deleted_by_admin_user_id:,
+                                     deleted_by_signon_user_id:,
                                      deletion_type:,
                                      user_source: source,
                                      user_created_at: created_at)

--- a/app/views/admin/homepage/index.html.erb
+++ b/app/views/admin/homepage/index.html.erb
@@ -1,6 +1,6 @@
 <%
 content_for(:title, "GOV.UK Chat Admin")
-has_developer_tools_permission = Current.admin_user.has_permission?(AdminUser::Permissions::DEVELOPER_TOOLS)
+has_developer_tools_permission = Current.signon_user.has_permission?(SignonUser::Permissions::DEVELOPER_TOOLS)
 settings = Settings.instance
 
 dashboard_link_items = []

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,7 +14,7 @@
       ["Early access users", admin_early_access_users_path],
       ["Waiting list users", admin_waiting_list_users_path],
       ["Settings", admin_settings_path],
-      [Current.admin_user.name, href: Plek.external_url_for("signon")],
+      [Current.signon_user.name, href: Plek.external_url_for("signon")],
       ["Log out", gds_sign_out_path],
     ]
   %>

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,4 +1,4 @@
 GDS::SSO.config do |config|
   config.intercept_401_responses = false
-  config.user_model = "AdminUser"
+  config.user_model = "SignonUser"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
     match "/500" => "errors#internal_server_error"
   end
 
-  constraints(GDS::SSO::AuthorisedUserConstraint.new(AdminUser::Permissions::DEVELOPER_TOOLS)) do
+  constraints(GDS::SSO::AuthorisedUserConstraint.new(SignonUser::Permissions::DEVELOPER_TOOLS)) do
     mount Sidekiq::Web => "/sidekiq"
 
     mount GovukPublishingComponents::Engine, at: "/component-guide"

--- a/db/migrate/20241023143335_add_deleted_by_admin_id_to_deleted_early_access_users.rb
+++ b/db/migrate/20241023143335_add_deleted_by_admin_id_to_deleted_early_access_users.rb
@@ -1,5 +1,5 @@
 class AddDeletedByAdminIdToDeletedEarlyAccessUsers < ActiveRecord::Migration[7.2]
   def change
-    add_column :deleted_early_access_users, :deleted_by_admin_user_id, :uuid, null: true
+    add_column :deleted_early_access_users, :deleted_by_signon_user_id, :uuid, null: true
   end
 end

--- a/db/migrate/20241023143358_add_deleted_by_admin_id_to_deleted_waiting_list_users.rb
+++ b/db/migrate/20241023143358_add_deleted_by_admin_id_to_deleted_waiting_list_users.rb
@@ -1,5 +1,5 @@
 class AddDeletedByAdminIdToDeletedWaitingListUsers < ActiveRecord::Migration[7.2]
   def change
-    add_column :deleted_waiting_list_users, :deleted_by_admin_user_id, :uuid, null: true
+    add_column :deleted_waiting_list_users, :deleted_by_signon_user_id, :uuid, null: true
   end
 end

--- a/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
+++ b/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
@@ -1,0 +1,7 @@
+class RenameAdminUserToSignonUser < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :admin_users, :signon_users
+    rename_column :deleted_early_access_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
+    rename_column :deleted_waiting_list_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
+  end
+end

--- a/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
+++ b/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
@@ -1,7 +1,7 @@
 class RenameAdminUserToSignonUser < ActiveRecord::Migration[8.0]
   def change
     rename_table :admin_users, :signon_users
-    rename_column :deleted_early_access_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
-    rename_column :deleted_waiting_list_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
+    rename_column :deleted_early_access_users, :deleted_by_signon_user_id, :deleted_by_signon_user_id
+    rename_column :deleted_waiting_list_users, :deleted_by_signon_user_id, :deleted_by_signon_user_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,7 +107,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
     t.datetime "user_created_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "deleted_by_admin_user_id"
+    t.uuid "deleted_by_signon_user_id"
   end
 
   create_table "deleted_waiting_list_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -116,7 +116,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
     t.datetime "user_created_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "deleted_by_admin_user_id"
+    t.uuid "deleted_by_signon_user_id"
   end
 
   create_table "early_access_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_04_092504) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -29,20 +29,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_04_092504) do
   create_enum "ur_question_reason_for_visit", ["find_specific_answer", "complete_task", "understand_process", "research_topic", "other"]
   create_enum "ur_question_user_description", ["business_owner_or_self_employed", "starting_business_or_becoming_self_employed", "business_advisor", "business_administrator", "none"]
   create_enum "waiting_list_users_source", ["admin_added", "insufficient_instant_places"]
-
-  create_table "admin_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "uid"
-    t.string "organisation_slug"
-    t.string "organisation_content_id"
-    t.string "app_name"
-    t.string "permissions", default: [], array: true
-    t.boolean "remotely_signed_out", default: false
-    t.boolean "disabled", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "answer_feedback", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "answer_id", null: false
@@ -207,6 +193,20 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_04_092504) do
     t.index ["user_id"], name: "index_settings_audits_on_user_id"
   end
 
+  create_table "signon_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "uid"
+    t.string "organisation_slug"
+    t.string "organisation_content_id"
+    t.string "app_name"
+    t.string "permissions", default: [], array: true
+    t.boolean "remotely_signed_out", default: false
+    t.boolean "disabled", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "waiting_list_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.citext "email", null: false
     t.enum "user_description", enum_type: "ur_question_user_description"
@@ -224,5 +224,5 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_04_092504) do
   add_foreign_key "answer_sources", "answers", on_delete: :cascade
   add_foreign_key "answers", "questions", on_delete: :cascade
   add_foreign_key "questions", "conversations"
-  add_foreign_key "settings_audits", "admin_users", column: "user_id", on_delete: :nullify
+  add_foreign_key "settings_audits", "signon_users", column: "user_id", on_delete: :nullify
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,1 @@
-AdminUser.find_or_create_by!(name: "chat_user", email: "chat.user@dev.gov.uk").update!(uid: SecureRandom.uuid, permissions: %w[developer-tools admin-area])
+SignonUser.find_or_create_by!(name: "chat_user", email: "chat.user@dev.gov.uk").update!(uid: SecureRandom.uuid, permissions: %w[developer-tools admin-area])

--- a/spec/factories/settings_audits_factory.rb
+++ b/spec/factories/settings_audits_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :settings_audit do
-    user { build :admin_user }
+    user { build :signon_user }
     action { "Instant access places increased by 10." }
     author_comment { "We ran out of places." }
   end

--- a/spec/factories/signon_user_factory.rb
+++ b/spec/factories/signon_user_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :admin_user do
+  factory :signon_user do
     sequence(:email) { |n| "admin.user#{n}@dev.gov.uk" }
 
     trait :admin do

--- a/spec/models/admin/form/settings/delayed_access_places_form_spec.rb
+++ b/spec/models/admin/form/settings/delayed_access_places_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::Form::Settings::DelayedAccessPlacesForm do
     end
 
     it "creates a settings audit with the correct attributes on successful save" do
-      form = described_class.new(places: 5, author_comment: "More places.", user: build(:admin_user))
+      form = described_class.new(places: 5, author_comment: "More places.", user: build(:signon_user))
 
       expect { form.submit }.to change(SettingsAudit, :count).by(1)
       expect(SettingsAudit.includes(:user).last)

--- a/spec/models/admin/form/settings/instant_access_places_form_spec.rb
+++ b/spec/models/admin/form/settings/instant_access_places_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::Form::Settings::InstantAccessPlacesForm do
     end
 
     it "creates a settings audit with the correct attributes on successful save" do
-      form = described_class.new(places: 5, author_comment: "More places.", user: build(:admin_user))
+      form = described_class.new(places: 5, author_comment: "More places.", user: build(:signon_user))
 
       expect { form.submit }.to change(SettingsAudit, :count).by(1)
       expect(SettingsAudit.includes(:user).last)

--- a/spec/models/admin/form/settings/max_waiting_list_places_form_spec.rb
+++ b/spec/models/admin/form/settings/max_waiting_list_places_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::Form::Settings::MaxWaitingListPlacesForm do
     end
 
     it "creates a settings audit with the correct attributes on successful save" do
-      form = described_class.new(max_places: 15, author_comment: "More places.", user: build(:admin_user))
+      form = described_class.new(max_places: 15, author_comment: "More places.", user: build(:signon_user))
 
       expect { form.submit }.to change(SettingsAudit, :count).by(1)
       expect(SettingsAudit.includes(:user).last)

--- a/spec/models/admin/form/settings/sign_up_enabled_form_spec.rb
+++ b/spec/models/admin/form/settings/sign_up_enabled_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::Form::Settings::SignUpEnabledForm do
     end
 
     it "creates a settings audit with the correct attributes on successful save" do
-      form = described_class.new(enabled: true, author_comment: "Turning sign ups on.", user: build(:admin_user))
+      form = described_class.new(enabled: true, author_comment: "Turning sign ups on.", user: build(:signon_user))
 
       expect { form.submit }.to change(SettingsAudit, :count).by(1)
       expect(SettingsAudit.includes(:user).last)

--- a/spec/models/admin/form/settings/waiting_list_promotions_per_run_form_spec.rb
+++ b/spec/models/admin/form/settings/waiting_list_promotions_per_run_form_spec.rb
@@ -29,15 +29,15 @@ RSpec.describe Admin::Form::Settings::WaitingListPromotionsPerRunForm do
     end
 
     it "creates a settings audit with the correct attributes on successful save" do
-      admin_user = build(:admin_user)
+      signon_user = build(:signon_user)
       form = described_class.new(promotions_per_run: 15,
                                  author_comment: "Less promotions please.",
-                                 user: admin_user)
+                                 user: signon_user)
 
       expect { form.submit }.to change(SettingsAudit, :count).by(1)
       expect(SettingsAudit.includes(:user).last)
         .to have_attributes(
-          user: admin_user,
+          user: signon_user,
           author_comment: "Less promotions please.",
           action: "Updated waiting list promotions per run to 15",
         )

--- a/spec/models/early_access_user_spec.rb
+++ b/spec/models/early_access_user_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe EarlyAccessUser do
 
     it "records the user id of the admin that deleted the user if passed one" do
       instance = create(:early_access_user, login_count: 3)
-      admin_user_id = SecureRandom.uuid
+      signon_user_id = SecureRandom.uuid
 
-      expect { instance.destroy_with_audit(deletion_type: :admin, deleted_by_admin_user_id: admin_user_id) }
+      expect { instance.destroy_with_audit(deletion_type: :admin, deleted_by_signon_user_id: signon_user_id) }
         .to change(described_class, :count).by(-1)
         .and change(DeletedEarlyAccessUser, :count).by(1)
 
@@ -153,7 +153,7 @@ RSpec.describe EarlyAccessUser do
         user_source: instance.source,
         user_created_at: instance.created_at,
         deletion_type: "admin",
-        deleted_by_admin_user_id: admin_user_id,
+        deleted_by_signon_user_id: signon_user_id,
       )
     end
   end

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Settings do
   end
 
   describe "#locked_audited_update" do
-    let(:audit_user) { build(:admin_user) }
+    let(:audit_user) { build(:signon_user) }
     let(:audit_action) { "Added 5 instant access places." }
     let(:audit_comment) { "We've run out of places so it's time to add more." }
     let(:call_locked_audit_update) do

--- a/spec/models/waiting_list_user_spec.rb
+++ b/spec/models/waiting_list_user_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WaitingListUser do
       instance = create(:waiting_list_user)
       admin_user_id = SecureRandom.uuid
 
-      expect { instance.destroy_with_audit(deletion_type: :admin, deleted_by_admin_user_id: admin_user_id) }
+      expect { instance.destroy_with_audit(deletion_type: :admin, deleted_by_signon_user_id: admin_user_id) }
         .to change(described_class, :count).by(-1)
         .and change(DeletedWaitingListUser, :count).by(1)
 
@@ -44,7 +44,7 @@ RSpec.describe WaitingListUser do
         user_source: instance.source,
         user_created_at: instance.created_at,
         deletion_type: "admin",
-        deleted_by_admin_user_id: admin_user_id,
+        deleted_by_signon_user_id: admin_user_id,
       )
     end
   end

--- a/spec/requests/admin/early_access_users_spec.rb
+++ b/spec/requests/admin/early_access_users_spec.rb
@@ -506,13 +506,13 @@ RSpec.describe "Admin::EarlyAccessUsersController" do
 
     it "creates a DeletedEarlyAccessUser with 'admin' as deletion_type and records the admin id" do
       user = create(:early_access_user)
-      admin_user = create(:admin_user, :admin)
+      admin_user = create(:signon_user, :admin)
       login_as(admin_user)
 
       expect { delete admin_early_access_user_path(user) }
       .to change { DeletedEarlyAccessUser.where(deletion_type: :admin).count }.by(1)
 
-      expect(DeletedEarlyAccessUser.last.deleted_by_admin_user_id).to eq admin_user.id
+      expect(DeletedEarlyAccessUser.last.deleted_by_signon_user_id).to eq admin_user.id
     end
 
     it "keeps the user's conversations" do

--- a/spec/requests/admin/homepage_spec.rb
+++ b/spec/requests/admin/homepage_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe "Admin::HomepageController" do
     context "when a user has the developer tools permission" do
       before do
         user = create(
-          :admin_user,
-          permissions: [AdminUser::Permissions::ADMIN_AREA,
-                        AdminUser::Permissions::DEVELOPER_TOOLS],
+          :signon_user,
+          permissions: [SignonUser::Permissions::ADMIN_AREA,
+                        SignonUser::Permissions::DEVELOPER_TOOLS],
         )
         login_as(user)
       end

--- a/spec/requests/admin/waiting_list_users_spec.rb
+++ b/spec/requests/admin/waiting_list_users_spec.rb
@@ -343,13 +343,13 @@ RSpec.describe "Admin::WaitingListUsersController" do
 
     it "creates a DeletedWaitingListUser with 'admin' as deletion_type and records the admin id" do
       user = create(:waiting_list_user)
-      admin_user = create(:admin_user, :admin)
+      admin_user = create(:signon_user, :admin)
       login_as(admin_user)
 
       expect { delete admin_waiting_list_user_path(user) }
         .to change { DeletedWaitingListUser.where(deletion_type: :admin).count }.by(1)
 
-      expect(DeletedWaitingListUser.last.deleted_by_admin_user_id).to eq admin_user.id
+      expect(DeletedWaitingListUser.last.deleted_by_signon_user_id).to eq admin_user.id
     end
   end
 

--- a/spec/requests/admin_area_access_spec.rb
+++ b/spec/requests/admin_area_access_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Admin area access" do
   describe "GET /admin" do
     context "when a signed in user has 'admin-area' permission" do
       it "returns a successful response" do
-        user = create(:admin_user, :admin)
+        user = create(:signon_user, :admin)
         login_as(user)
 
         get "/admin"
@@ -13,7 +13,7 @@ RSpec.describe "Admin area access" do
 
     context "when the user does not have the 'admin-area' permission" do
       it "returns a forbidden response" do
-        user = create(:admin_user)
+        user = create(:signon_user)
         login_as(user)
 
         get "/admin"

--- a/spec/requests/developer_tools_access_spec.rb
+++ b/spec/requests/developer_tools_access_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Developer Tools Access" do
       end
 
       context "when the user lacks the permission" do
-        before { AdminUser.first.update!(permissions: []) }
+        before { SignonUser.first.update!(permissions: []) }
 
         it "returns a forbidden response" do
           get path

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -28,7 +28,7 @@ module SystemSpecHelpers
   end
 
   def given_i_am_an_admin
-    login_as(create(:admin_user, :admin))
+    login_as(create(:signon_user, :admin))
   end
 
   def extract_links_from_last_email


### PR DESCRIPTION
## Description

We're going to have multiple types of users arriving from Signon. Admin users who have full Signon accounts and API users who have a bearer token which they'll use when hitting our API endpoints.

AdminUser doesn't reflect this new use case since they won't be admin and shouldn't have admin permissions. I've proposed we update it to SignonUser rather than just User because we've got a bunch of user types still knocking about (WaitingListUser, EarlyAccessUser etc.)

Since we're not live i've not worried about renaming the columns and doing the usual:

- add new columns
- update code to write to both
- backfill
- switch over to new column 
- delete old table/columns

Since we shouldn't experience any issues as we're extremely unlikely to creating new AdminUsers during the deploy as no-one is using the application in the near future.

## Trello card

https://trello.com/c/zsmJJZfa/2420-chat-api-update-adminuser-to-signonuser