### PR TITLE
Add Post answer feedback endpoint

### DIFF
--- a/app/blueprints/validation_error_blueprint.rb
+++ b/app/blueprints/validation_error_blueprint.rb
@@ -1,0 +1,6 @@
+class ValidationErrorBlueprint < Blueprinter::Base
+  field :errors
+  field :message do
+    "Unprocessable entity"
+  end
+end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,6 +1,6 @@
 class Api::V0::ConversationsController < ApplicationController
   before_action { authorise_user!(SignonUser::Permissions::CONVERSATION_API) }
-  before_action :find_conversation, only: %i[show answer]
+  before_action :find_conversation, only: %i[show answer answer_feedback]
 
   def show
     answered_questions = @conversation.questions.joins(:answer)
@@ -23,11 +23,30 @@ class Api::V0::ConversationsController < ApplicationController
     end
   end
 
+  def answer_feedback
+    answer = @conversation.answers.includes(:feedback).find(params[:answer_id])
+    feedback_form = Form::CreateAnswerFeedback.new(answer_feedback_params.merge(answer:))
+
+    if feedback_form.valid?
+      feedback_form.submit
+
+      render json: {}, status: :created
+    else
+      render json: ValidationErrorBlueprint.render(
+        errors: feedback_form.errors.messages,
+      ), status: :unprocessable_entity
+    end
+  end
+
 private
 
   def find_conversation
     @conversation = Conversation
                     .includes(questions: { answer: %i[sources feedback] })
                     .find(params[:conversation_id])
+  end
+
+  def answer_feedback_params
+    params.permit(:useful)
   end
 end

--- a/app/models/form/create_answer_feedback.rb
+++ b/app/models/form/create_answer_feedback.rb
@@ -16,6 +16,6 @@ class Form::CreateAnswerFeedback
 private
 
   def no_feedback_present?
-    errors.add(:answer_feedback, "Feedback already provided") if answer.feedback.present?
+    errors.add(:base, "Feedback already provided for this answer") if answer.feedback.present?
   end
 end

--- a/config/initializers/committee.rb
+++ b/config/initializers/committee.rb
@@ -1,4 +1,12 @@
 require "committee"
+require "api/request_validation_error"
+
+Rails.application.config.middleware.use Committee::Middleware::RequestValidation,
+                                        schema_path: "docs/api_openapi_specification.yml",
+                                        coerce_date_times: true,
+                                        prefix: "/api/v0",
+                                        strict_reference_validation: true,
+                                        error_class: Api::RequestValidationError
 
 Rails.application.config.middleware.use Committee::Middleware::ResponseValidation,
                                         schema_path: "docs/api_openapi_specification.yml",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       get "/conversation/:conversation_id", to: "conversations#show", as: :show_conversation
       get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
+      post "/conversation/:conversation_id/answers/:answer_id/feedback", to: "conversations#answer_feedback", as: :answer_feedback
     end
   end
 

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -322,11 +322,11 @@ components:
       type: object
       required:
         - message
-        - fields
+        - errors
       properties:
         message:
           type: string
-        fields:
+        errors:
           description: |
             an object structure of field name to an array of errors
           type: object

--- a/lib/api/request_validation_error.rb
+++ b/lib/api/request_validation_error.rb
@@ -1,0 +1,7 @@
+module Api
+  class RequestValidationError < Committee::ValidationError
+    def error_body
+      GenericErrorBlueprint.render_as_hash(message:)
+    end
+  end
+end

--- a/spec/blueprints/validation_error_blueprint_spec.rb
+++ b/spec/blueprints/validation_error_blueprint_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ValidationErrorBlueprint do
+  describe ".render_as_json" do
+    it "renders the correct JSON based on the errors passed in" do
+      errors = {
+        user_question: ["Question must be 300 characters or less", "Personal data has been detected in your question. Please remove it and try asking again."],
+        base: ["Previous question pending. Please wait for a response"],
+      }
+
+      expect(described_class.render_as_json(errors:))
+        .to eq({ message: "Unprocessable entity", errors: }.as_json)
+    end
+  end
+end

--- a/spec/lib/api/request_validation_error_spec.rb
+++ b/spec/lib/api/request_validation_error_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Api::RequestValidationError do
+  describe "#render" do
+    it "returns an array which uses the GenericErrorBlueprint for the error body" do
+      request = double
+      error_message = "Bad request"
+      generic_error_blueprint = GenericErrorBlueprint.render(message: error_message)
+
+      error = described_class.new(400, :bad_request, error_message, request)
+      expect(error.render).to eq([400, { "Content-Type" => "application/json" }, [generic_error_blueprint]])
+    end
+  end
+end

--- a/spec/models/form/create_answer_feedback_spec.rb
+++ b/spec/models/form/create_answer_feedback_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Form::CreateAnswerFeedback do
       answer_with_feedback = build(:answer, :with_feedback)
       form = described_class.new(useful: true, answer: answer_with_feedback)
       expect(form).to be_invalid
-      expect(form.errors[:answer_feedback]).to eq(["Feedback already provided"])
+      expect(form.errors[:base]).to eq(["Feedback already provided for this answer"])
     end
   end
 

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Api::V0::ConversationsController" do
           post api_v0_answer_feedback_path(conversation, answer), params: { useful: true }, as: :json
 
           expect(JSON.parse(response.body))
-            .to eq({ "message" => "Unprocessable entity", "errors" => { "answer_feedback" => ["Feedback already provided"] } })
+            .to eq({ "message" => "Unprocessable entity", "errors" => { "base" => ["Feedback already provided for this answer"] } })
         end
       end
     end

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe "ConversationsController" do
         expect { post answer_feedback_path(answer), params: { create_answer_feedback: { useful: true }, format: :json } }
         .not_to change(AnswerFeedback, :count)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to eq({ "error_messages" => ["Feedback already provided"] })
+        expect(JSON.parse(response.body)).to eq({ "error_messages" => ["Feedback already provided for this answer"] })
       end
     end
   end


### PR DESCRIPTION
## Description 

This PR follows on from #170 which added the GET answer endpoint. This PR:

- adds the ValidationErrorBlueprint
- adds the POST answer feedback endpoint which
  - returns a 301 and creates the answer feedback if the params are valid and the answer doesn't already have feedback
  - returns a 422 if the answer already has feedback
  - returns a 400 if the request body doesn't have valid params
- adds and configures the Committee middleware for request validation

One thing we might want to discuss is whether we want to add our own custom validation errors for 400s raised by Committee. There's docs on how to do that [here](https://github.com/interagent/committee?tab=readme-ov-file#validation-errors). 

I had a play and it's pretty straight forward to do. The default returned is

```
{
  "id":"invalid_response",
  "message":"Missing keys in request : archived_at, buildpack_provided_description, created_at, git_url, id, maintenance, name, owner:email, owner:id, region:id, region:name, released_at, repo_size, slug_size, stack:id, stack:name, updated_at, web_url."
}
```

We may want to strip the id from the response to the client.

## Trello card

 https://trello.com/c/RPhj0REr/2425-chat-api-add-post-answer-feedback-endpoint