### PR TITLE
Fix failing SignonUser migration

### DIFF
--- a/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
+++ b/db/migrate/20250415120236_rename_admin_user_to_signon_user.rb
@@ -1,7 +1,7 @@
 class RenameAdminUserToSignonUser < ActiveRecord::Migration[8.0]
   def change
     rename_table :admin_users, :signon_users
-    rename_column :deleted_early_access_users, :deleted_by_signon_user_id, :deleted_by_signon_user_id
-    rename_column :deleted_waiting_list_users, :deleted_by_signon_user_id, :deleted_by_signon_user_id
+    rename_column :deleted_early_access_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
+    rename_column :deleted_waiting_list_users, :deleted_by_admin_user_id, :deleted_by_signon_user_id
   end
 end


### PR DESCRIPTION
## Description 

The columns were meant to be renamed in the migration, but both the current and new column name were the same which caused the migration to fail.