### PR TITLE
Update ErrorsController to handle JSON requests

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,26 +6,62 @@ class ErrorsController < BaseController
   after_action { response.headers["No-Fallback"] = "true" }
 
   def bad_request
-    render status: :bad_request, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Bad request"),
+               status: :bad_request
+      end
+      format.any { render status: :bad_request, formats: :html }
+    end
   end
 
   def forbidden
-    render status: :forbidden, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Forbidden"),
+               status: :forbidden
+      end
+      format.any { render status: :forbidden, formats: :html }
+    end
   end
 
   def not_found
-    render status: :not_found, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Not found"),
+               status: :not_found
+      end
+      format.any { render status: :not_found, formats: :html }
+    end
   end
 
   def unprocessable_entity
-    render status: :unprocessable_entity, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Unprocessable entity"),
+               status: :unprocessable_entity
+      end
+      format.any { render status: :unprocessable_entity, formats: :html }
+    end
   end
 
   def too_many_requests
-    render status: :too_many_requests, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Too many requests"),
+               status: :too_many_requests
+      end
+      format.any { render status: :too_many_requests, formats: :html }
+    end
   end
 
   def internal_server_error
-    render status: :internal_server_error, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: GenericErrorBlueprint.render(message: "Internal server error"),
+               status: :internal_server_error
+      end
+      format.any { render status: :internal_server_error, formats: :html }
+    end
   end
 end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Api::V0::ConversationsController" do
 
         get api_v0_answer_question_path(conversation, question)
         expect(response).to have_http_status(:internal_server_error)
-        expect(response.body).to include("Sorry, there is a problem with GOV.UK Chat")
+        expect(JSON.parse(response.body)).to eq({ "message" => "Internal server error" })
       end
     end
   end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "ErrorController" do
-  shared_examples "an error response" do |code, status, page_title|
+  shared_examples "an error response" do |code, status, page_title, json_message: page_title|
     title = "code #{status.to_s.titleize}"
     it "returns a #{title} response" do
       get "/#{code}"
@@ -7,29 +7,65 @@ RSpec.describe "ErrorController" do
       expect(response.body).to have_selector("h1", text: page_title)
       expect(response.headers["No-Fallback"]).to eq "true"
     end
+
+    context "when the request format is JSON" do
+      it "returns a JSON response with a #{title} status code" do
+        get "/#{code}", params: { format: :json }
+        expect(response).to have_http_status(status)
+      end
+
+      it "returns a JSON response with the correct error message" do
+        get "/#{code}", params: { format: :json }
+        expect(JSON.parse(response.body)).to eq({ "message" => json_message })
+      end
+    end
   end
 
   describe "/400" do
-    it_behaves_like "an error response", 400, :bad_request, "Sorry, there is a problem"
+    it_behaves_like "an error response",
+                    400,
+                    :bad_request,
+                    "Sorry, there is a problem",
+                    json_message: "Bad request"
   end
 
   describe "/403" do
-    it_behaves_like "an error response", 403, :forbidden, "Sorry, you do not have access to the page"
+    it_behaves_like "an error response",
+                    403,
+                    :forbidden,
+                    "Sorry, you do not have access to the page",
+                    json_message: "Forbidden"
   end
 
   describe "/404" do
-    it_behaves_like "an error response", 404, :not_found, "Page not found"
+    it_behaves_like "an error response",
+                    404,
+                    :not_found,
+                    "Page not found",
+                    json_message: "Not found"
   end
 
   describe "/422" do
-    it_behaves_like "an error response", 422, :unprocessable_entity, "Sorry, there is a problem"
+    it_behaves_like "an error response",
+                    422,
+                    :unprocessable_entity,
+                    "Sorry, there is a problem",
+                    json_message: "Unprocessable entity"
   end
 
   describe "/429" do
-    it_behaves_like "an error response", 429, :too_many_requests, "Sorry, there is a problem"
+    it_behaves_like "an error response",
+                    429,
+                    :too_many_requests,
+                    "Sorry, there is a problem",
+                    json_message: "Too many requests"
   end
 
   describe "/500" do
-    it_behaves_like "an error response", 500, :internal_server_error, "Sorry, there is a problem with GOV.UK Chat"
+    it_behaves_like "an error response",
+                    500,
+                    :internal_server_error,
+                    "Sorry, there is a problem with GOV.UK Chat",
+                    json_message: "Internal server error"
   end
 end


### PR DESCRIPTION
We don't want to render back our HTML error pages when the requests content type is JSON.

This updates the controller to respond with a JSON error message when the request is made with a JSON content type.