### PR TITLE
Move committee to be a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "aws-sdk-bedrockruntime"
 gem "blueprinter"
 gem "bootsnap"
 gem "chartkick"
+gem "committee"
 gem "csv"
 gem "dalli"
 gem "dartsass-rails"
@@ -54,7 +55,6 @@ group :test do
 end
 
 group :development, :test do
-  gem "committee"
   gem "dotenv"
   gem "erb_lint", require: false
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1286,4 +1286,4 @@ RUBY VERSION
    ruby 3.4.3p32
 
 BUNDLED WITH
-   2.6.2
+   2.6.8


### PR DESCRIPTION
We use committee for validating responses outside of the dev and test
environments and thus need it available to all environments.

This fixes the app failing to deploy with:

```
-----> Preparing app for Rails asset pipeline
cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead
       Running: rake assets:precompile
       rake aborted!
       LoadError: cannot load such file -- committee (LoadError)
       /tmp/build_9036a223/vendor/bundle/ruby/3.4.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in 'Kernel#require'
       /tmp/build_9036a223/vendor/bundle/ruby/3.4.0/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
       /tmp/build_9036a223/config/initializers/committee.rb:1:in '<main>'
```