### PR TITLE
Allow docs/api_openapi_specification.yml in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,8 @@ Dockerfile
 Procfile
 README.md
 coverage
-docs
+docs/**
+!docs/api_openapi_specification.yml
 features
 log
 node_modules


### PR DESCRIPTION
The openapi specification is a runtime dependency so needs to be included in a docker build. I've taken the step of just allowing that one file so we don't put all the other data in, this might prove foolish as we'll hit another annoying issue if we add another openapi file or rename this one. Let's see.