### PR TITLE
Add POST /api/v0/conversation endpoint 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
 
   namespace :api, format: false, defaults: { format: "json" } do
     namespace :v0 do
+      post "/conversation", to: "conversations#create", as: :create_conversation
       get "/conversation/:conversation_id", to: "conversations#show", as: :show_conversation
       get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
       post "/conversation/:conversation_id/answers/:answer_id/feedback", to: "conversations#answer_feedback", as: :answer_feedback


### PR DESCRIPTION
Trello: https://trello.com/c/INvwAr2v/2423-chat-api-add-post-conversation-endpoint

We’re building an API endpoint that the app team will use to integrate with GOV.UK Chat; this PR adds a POST /api/v0/conversation action in Api::V0::ConversationsController so that when a user asks their first question, we persist a new Conversation and Question in our database and return a JSON payload (via the QuestionBlueprint pending view). All validation is delegated to the existing Form::CreateQuestion to avoid duplicating logic. I introduced a question_params method, and wired up the new route in routes.rb. New request specs cover question validity, ensuring the endpoint behaves exactly as expected.