### PR TITLE
Add PUT conversation endpoint

### DIFF
--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -10,7 +10,7 @@ class Api::V0::ConversationsController < ApplicationController
       question = form.submit
       render json: QuestionBlueprint.render(question, view: :pending), status: :created
     else
-      render json: ValidationErrorBlueprint.render(message: "Could not create question", errors: form.errors.messages), status: :unprocessable_entity
+      render json: ValidationErrorBlueprint.render(errors: form.errors.messages), status: :unprocessable_entity
     end
   end
 

--- a/app/models/form/create_question.rb
+++ b/app/models/form/create_question.rb
@@ -9,6 +9,9 @@ class Form::CreateQuestion
   USER_QUESTION_PRESENCE_ERROR_MESSAGE = "Ask a question. For example, 'how do I register for VAT?'".freeze
   USER_QUESTION_LENGTH_MAXIMUM = 300
   USER_QUESTION_LENGTH_ERROR_MESSAGE = "Question must be %{count} characters or less".freeze
+  USER_QUESTION_PII_ERROR_MESSAGE = "Personal data has been detected in your question. Please remove it and try asking again.".freeze
+  QUESTION_LIMIT_REACHED_MESSAGE = "You’ve reached the message limit for the GOV.UK Chat trial. You have no messages left.".freeze
+  UNANSWERED_QUESTION_ERROR_MESSAGE = "Previous question pending. Please wait for a response".freeze
 
   before_validation :sanitise_user_question
 
@@ -51,15 +54,13 @@ private
 
   def all_questions_answered?
     if conversation.questions.unanswered.exists?
-      errors.add(:base, "Previous question pending. Please wait for a response")
+      errors.add(:base, UNANSWERED_QUESTION_ERROR_MESSAGE)
     end
   end
 
   def no_pii_present?
     if PiiValidator.invalid?(user_question)
-      error_message = "Personal data has been detected in your question. Please remove it and try asking again."
-
-      errors.add(:user_question, error_message)
+      errors.add(:user_question, USER_QUESTION_PII_ERROR_MESSAGE)
     end
   end
 
@@ -67,6 +68,6 @@ private
     return if conversation.user.nil?
     return unless conversation.user.question_limit_reached?
 
-    errors.add(:base, "You’ve reached the message limit for the GOV.UK Chat trial. You have no messages left.")
+    errors.add(:base, QUESTION_LIMIT_REACHED_MESSAGE)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       post "/conversation", to: "conversations#create", as: :create_conversation
       get "/conversation/:conversation_id", to: "conversations#show", as: :show_conversation
+      put "/conversation/:conversation_id", to: "conversations#update", as: :update_conversation
       get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
       post "/conversation/:conversation_id/answers/:answer_id/feedback", to: "conversations#answer_feedback", as: :answer_feedback
     end


### PR DESCRIPTION
## Description

This adds the PUT conversation endpoint. This endpoint expects a user_question and returns:

- 201 if the params are valid. It creates a new question on the conversation
- 422 if the params are invalid
- 400 for requests that don't adhere to the schema
- 404 if the conversation cannot be found 

I've done a minor clean up in the CreateQuestion form so we're consistent in applying the use of constants for our error messages.

## Trello card

https://trello.com/c/wSIOGv6W/2424-chat-api-add-put-conversation-endpoint