### PR TITLE
Use configured answer strategy in eval report generator

### DIFF
--- a/lib/evaluation/report_generator.rb
+++ b/lib/evaluation/report_generator.rb
@@ -24,7 +24,11 @@ module Evaluation
   private
 
     def build_question(question_message)
-      Question.new(message: question_message, conversation: Conversation.new)
+      Question.new(
+        message: question_message,
+        conversation: Conversation.new,
+        answer_strategy: Rails.configuration.answer_strategy,
+      )
     end
 
     def absolute_govuk_url(path)

--- a/spec/lib/evaluation/report_generator_spec.rb
+++ b/spec/lib/evaluation/report_generator_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
         .to raise_error("File nonexistent.yml does not exist")
     end
 
+    it "uses the configured answer strategy" do
+      allow(Rails.configuration).to receive(:answer_strategy).and_return("claude_structured_answer")
+
+      described_class.call(input_file.path)
+
+      expect(AnswerComposition::Composer).to have_received(:call).with(
+        an_object_having_attributes(answer_strategy: "claude_structured_answer"),
+      ).twice
+    end
+
     it "returns the items" do
       items = described_class.call(input_file.path)
 


### PR DESCRIPTION
It'd be useful to be able to set the `ANSWER_STRATEGY` env var when
running the `evaluation:generate_report` Rake task to override the
provider, as we allow in multiple other places in the app.

Currently we build the question object manually which will use the
database default `answer_strategy`. This commit explicitly sets it to be
the Rails configuration value which uses the `ANSWER_STRATEGY` env var.
