### PR TITLE
Associate conversations created by api with the current signon user

### DIFF
--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,4 +1,5 @@
 class Api::V0::ConversationsController < ApplicationController
+  skip_before_action :verify_authenticity_token
   before_action { authorise_user!(SignonUser::Permissions::CONVERSATION_API) }
   before_action :find_conversation, only: %i[show update answer answer_feedback]
 

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -69,6 +69,7 @@ private
   def find_conversation
     @conversation = Conversation
                     .includes(questions: { answer: %i[sources feedback] })
+                    .where(signon_user_id: current_user.id)
                     .find(params[:conversation_id])
   end
 

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -3,7 +3,7 @@ class Api::V0::ConversationsController < ApplicationController
   before_action :find_conversation, only: %i[show update answer answer_feedback]
 
   def create
-    conversation = Conversation.new
+    conversation = Conversation.new(signon_user: current_user)
     form = Form::CreateQuestion.new(question_params.merge(conversation:))
 
     if form.valid?

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,6 +2,7 @@ class Conversation < ApplicationRecord
   has_many :questions
   has_many :answers, through: :questions
   belongs_to :user, optional: true, class_name: "EarlyAccessUser", foreign_key: :early_access_user_id
+  belongs_to :signon_user, optional: true
 
   scope :active, -> { where(Question.active.where("questions.conversation_id = conversations.id").arel.exists) }
 

--- a/app/models/signon_user.rb
+++ b/app/models/signon_user.rb
@@ -6,4 +6,6 @@ class SignonUser < ApplicationRecord
     CONVERSATION_API = "conversation-api".freeze
     DEVELOPER_TOOLS = "developer-tools".freeze
   end
+
+  has_many :conversations
 end

--- a/db/migrate/20250501150559_add_signon_user_foreign_key_to_conversation.rb
+++ b/db/migrate/20250501150559_add_signon_user_foreign_key_to_conversation.rb
@@ -1,0 +1,5 @@
+class AddSignonUserForeignKeyToConversation < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :conversations, :signon_user, foreign_key: { null: true, on_delete: :restrict }, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_01_150559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -96,8 +96,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "early_access_user_id"
+    t.uuid "signon_user_id"
     t.index ["created_at"], name: "index_conversations_on_created_at"
     t.index ["early_access_user_id"], name: "index_conversations_on_early_access_user_id"
+    t.index ["signon_user_id"], name: "index_conversations_on_signon_user_id"
   end
 
   create_table "deleted_early_access_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -223,6 +225,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_120236) do
   add_foreign_key "answer_feedback", "answers", on_delete: :cascade
   add_foreign_key "answer_sources", "answers", on_delete: :cascade
   add_foreign_key "answers", "questions", on_delete: :cascade
+  add_foreign_key "conversations", "signon_users", on_delete: :restrict
   add_foreign_key "questions", "conversations"
   add_foreign_key "settings_audits", "signon_users", column: "user_id", on_delete: :nullify
 end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe "Api::V0::ConversationsController" do
   let(:conversation) { create(:conversation) }
   let(:question) { create(:question, conversation:) }
+  let(:api_user) { create(:signon_user, :conversation_api) }
 
   before do
-    login_as(create(:signon_user, :conversation_api))
+    login_as(api_user)
   end
 
   shared_examples "responds with forbidden if user doesn't have conversation-api permission" do |routes:|
@@ -125,6 +126,13 @@ RSpec.describe "Api::V0::ConversationsController" do
         expected_payload = QuestionBlueprint.render_as_json(question, view: :pending)
 
         expect(JSON.parse(response.body)).to eq(expected_payload)
+      end
+
+      it "associates the conversation with the SignonUser" do
+        post api_v0_create_conversation_path, params: payload, as: :json
+
+        conversation = Conversation.includes(:signon_user).last
+        expect(conversation.signon_user).to eq(api_user)
       end
     end
 

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -126,27 +126,27 @@ RSpec.describe "Api::V0::ConversationsController" do
 
         expect(JSON.parse(response.body)).to eq(expected_payload)
       end
+    end
 
-      context "when the question is invalid" do
-        let(:payload) { { user_question: "" } }
+    context "when the question is invalid" do
+      let(:payload) { { user_question: "" } }
 
-        it "returns a 422 Unprocessable Entity status" do
-          post api_v0_create_conversation_path, params: payload, as: :json
+      it "returns a 422 Unprocessable Entity status" do
+        post api_v0_create_conversation_path, params: payload, as: :json
 
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
 
-        it "returns the correct JSON in the body" do
-          post api_v0_create_conversation_path, params: payload, as: :json
+      it "returns the correct JSON in the body" do
+        post api_v0_create_conversation_path, params: payload, as: :json
 
-          expect(JSON.parse(response.body))
-            .to eq(
-              {
-                "message" => "Unprocessable entity",
-                "errors" => { "user_question" => [Form::CreateQuestion::USER_QUESTION_PRESENCE_ERROR_MESSAGE] },
-              },
-            )
-        end
+        expect(JSON.parse(response.body))
+          .to eq(
+            {
+              "message" => "Unprocessable entity",
+              "errors" => { "user_question" => [Form::CreateQuestion::USER_QUESTION_PRESENCE_ERROR_MESSAGE] },
+            },
+          )
       end
     end
   end

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Api::V0::ConversationsController" do
-  let(:conversation) { create(:conversation) }
-  let(:question) { create(:question, conversation:) }
   let(:api_user) { create(:signon_user, :conversation_api) }
+  let(:conversation) { create(:conversation, signon_user: api_user) }
+  let(:question) { create(:question, conversation:) }
 
   before do
     login_as(api_user)
@@ -102,6 +102,15 @@ RSpec.describe "Api::V0::ConversationsController" do
 
     it "returns a 404 if the conversation cannot be found" do
       get api_v0_show_conversation_path(SecureRandom.uuid)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns a 404 if the conversation is not associated with the user" do
+      different_user = create(:signon_user, :conversation_api)
+      conversation = create(:conversation, signon_user: different_user)
+
+      get api_v0_show_conversation_path(conversation)
 
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
## Description

We need to be able to associate conversations created by the API with the SignonUser (API user) that made the request. Down the line we suspect we will have multiple API users and want to be able to distinguish between conversations belonging to each. As well as between API users and web users.

This: 
- adds a signon_user foreign key to the conversations table
- creates the association in the models
- updates the create endpoint to associate the conversation with the current user (SignonUser)

## Out of scope 

- changes to the Admin UI

## Trello card

https://trello.com/c/3979ssqM/2447-chat-api-associate-conversations-created-by-api-with-user