### PR TITLE
Return jailbreak guardrail errors in evaluation task

### DIFF
--- a/lib/guardrails/jailbreak_checker.rb
+++ b/lib/guardrails/jailbreak_checker.rb
@@ -13,6 +13,17 @@ module Guardrails
         @llm_completion_tokens = llm_completion_tokens
         @llm_cached_tokens = llm_cached_tokens
       end
+
+      def as_json
+        {
+          message:,
+          llm_guardrail_result:,
+          llm_response:,
+          llm_prompt_tokens:,
+          llm_completion_tokens:,
+          llm_cached_tokens:,
+        }
+      end
     end
 
     def self.pass_value

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -49,9 +49,13 @@ namespace :evaluation do
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
     raise "Requires a provider" if args[:provider].blank?
 
-    response = Guardrails::JailbreakChecker.call(ENV["INPUT"], args[:provider].to_sym)
+    begin
+      response = Guardrails::JailbreakChecker.call(ENV["INPUT"], args[:provider].to_sym)
 
-    puts(response.to_json)
+      puts({ success: response }.to_json)
+    rescue Guardrails::JailbreakChecker::ResponseError => e
+      puts({ response_error: e }.to_json)
+    end
   end
 
   desc "Produce the output guardrails response for a user input"


### PR DESCRIPTION
This is an approach to return the data for a jailbreak guardrail that has been returned misformatted.

The motivation for making this change is to assist with the task of optimising the prompt, where it is currently breaking when Claude returns an unexpected response.

The expectation is that a client of this rake task will check whether the JSON response has a success or response_error key to decide what to do further with the evaluation.

We may well want to use this same approach on other LLM components.