### PR TITLE
Switch all Claude models to 3.7 Sonnet

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/claude/question_rephraser.rb
@@ -1,9 +1,6 @@
 module AnswerComposition::Pipeline
   module Claude
     class QuestionRephraser
-      # TODO: change this to a more basic model
-      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
-
       def self.call(...) = new(...).call
 
       def initialize(question_message, message_records)
@@ -14,7 +11,7 @@ module AnswerComposition::Pipeline
       def call
         response = bedrock_client.converse(
           system: [{ text: config[:system_prompt] }],
-          model_id: BEDROCK_MODEL,
+          model_id: BedrockModels::CLAUDE_3_7_SONNET, # TODO: change this to a more basic model
           messages:,
           inference_config:,
         )

--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -1,8 +1,6 @@
 module AnswerComposition::Pipeline
   module Claude
     class QuestionRouter
-      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
-
       def self.call(...) = new(...).call
 
       def initialize(context)
@@ -85,7 +83,7 @@ module AnswerComposition::Pipeline
       def bedrock_response
         @bedrock_response ||= bedrock_client.converse(
           system: [{ text: prompt_config[:system_prompt] }],
-          model_id: BEDROCK_MODEL,
+          model_id: BedrockModels::CLAUDE_3_7_SONNET,
           messages:,
           inference_config:,
           tool_config:,

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -1,8 +1,6 @@
 module AnswerComposition::Pipeline
   module Claude
     class StructuredAnswerComposer
-      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
-
       def self.call(...) = new(...).call
 
       def initialize(context)
@@ -15,7 +13,7 @@ module AnswerComposition::Pipeline
 
         response = bedrock_client.converse(
           system: [{ text: system_prompt }],
-          model_id: BEDROCK_MODEL,
+          model_id: BedrockModels::CLAUDE_3_7_SONNET,
           messages:,
           inference_config:,
           tool_config:,

--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -1,0 +1,3 @@
+module BedrockModels
+  CLAUDE_3_7_SONNET = "anthropic.claude-3-7-sonnet-20250219-v1:0".freeze
+end

--- a/lib/guardrails/claude/jailbreak_checker.rb
+++ b/lib/guardrails/claude/jailbreak_checker.rb
@@ -1,7 +1,5 @@
 module Guardrails::Claude
   class JailbreakChecker
-    BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
-
     def self.call(...) = new(...).call
 
     def initialize(input)
@@ -11,7 +9,7 @@ module Guardrails::Claude
     def call
       response = bedrock_client.converse(
         system: [{ text: system_prompt }],
-        model_id: BEDROCK_MODEL,
+        model_id: BedrockModels::CLAUDE_3_7_SONNET,
         messages:,
         inference_config:,
       )

--- a/lib/guardrails/claude/multiple_checker.rb
+++ b/lib/guardrails/claude/multiple_checker.rb
@@ -1,7 +1,6 @@
 module Guardrails
   module Claude
     class MultipleChecker
-      BEDROCK_MODEL = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0".freeze
       MAX_TOKENS = 100
 
       def self.call(...) = new(...).call
@@ -15,7 +14,7 @@ module Guardrails
       def call
         claude_response = bedrock_client.converse(
           system: [{ text: prompt.system_prompt }],
-          model_id: BEDROCK_MODEL,
+          model_id: BedrockModels::CLAUDE_3_7_SONNET,
           messages: [{ role: "user", content: [{ text: prompt.user_prompt(input) }] }],
           inference_config: {
             max_tokens: MAX_TOKENS,


### PR DESCRIPTION
https://trello.com/c/7gnhh5TG/2459-switch-claude-models-from-35-to-37

This is available on Bedrock now so we want to experiment with using it.

Rather than hardcoding the model ID all over the place, it's been
extracted to a constant in a `BedrockModels` module.
