### PR TITLE
Add filter for SignonUsers to AdminUI

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -5,7 +5,8 @@ class Admin::QuestionsController < Admin::BaseController
   end
 
   def show
-    @question = Question.includes(conversation: %i[user], answer: %i[feedback sources]).find(params[:id])
+    @question = Question.includes(conversation: %i[user signon_user], answer: %i[feedback sources])
+                         .find(params[:id])
     @answer = @question.answer
     @question_number = Question.where(conversation: @question.conversation)
                                .where("created_at <= ? ", @question.created_at)

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -25,6 +25,7 @@ private
       :page,
       :sort,
       :user_id,
+      :signon_user_id,
       :conversation_id,
     )
   end

--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -84,6 +84,19 @@ module Admin
         }
       end
 
+      signon_user = conversation.signon_user
+      if signon_user.present?
+        rows << {
+          field: "API user",
+          value: safe_join([
+            signon_user.name,
+            " (",
+            link_to("View all questions", admin_questions_path(signon_user_id: signon_user.id), class: "govuk-link"),
+            ")",
+          ]),
+        }
+      end
+
       rows << if answer.present?
                 [
                   {

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -7,6 +7,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
   attribute :answer_feedback_useful, :boolean
   attribute :question_routing_label
   attribute :user_id
+  attribute :signon_user_id
 
   validate :validate_dates
 
@@ -36,6 +37,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
       scope = question_routing_label_scope(scope)
       scope = ordering_scope(scope)
       scope = user_scope(scope)
+      scope = signon_user_scope(scope)
       scope.page(page)
            .per(25)
     end
@@ -113,6 +115,12 @@ private
     return scope if user_id.blank?
 
     scope.joins(:conversation).where("conversations.early_access_user_id = ?", user_id)
+  end
+
+  def signon_user_scope(scope)
+    return scope if signon_user_id.blank? || user_id.present?
+
+    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id })
   end
 
   def question_routing_label_scope(scope)

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -46,7 +46,13 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
   def user
     return @user if defined?(@user)
 
-    @user = EarlyAccessUser.includes(:conversations).find_by(id: user_id)
+    @user = EarlyAccessUser.includes(:conversations).find_by_id(user_id)
+  end
+
+  def signon_user
+    return @signon_user if defined?(@signon_user)
+
+    @signon_user = SignonUser.includes(:conversations).find_by_id(signon_user_id)
   end
 
   def conversation

--- a/app/views/admin/questions/_question_filters.html.erb
+++ b/app/views/admin/questions/_question_filters.html.erb
@@ -1,6 +1,7 @@
 <%
   user = filter.user
   conversation = filter.conversation
+  signon_user = filter.signon_user
 %>
 
 <%= form_with(url: admin_questions_path, method: :get) do %>
@@ -14,6 +15,11 @@
       <% end %>
     </p>
     <%= hidden_field_tag(:user_id, params[:user_id]) %>
+  <% elsif signon_user.present? %>
+    <p class="govuk-body">
+      Filtering by API user: <%= signon_user.name %>
+    </p>
+    <%= hidden_field_tag(:signon_user_id, params[:signon_user_id]) %>
   <% end %>
 
   <% if user.present? %>

--- a/spec/factories/signon_user_factory.rb
+++ b/spec/factories/signon_user_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :signon_user do
-    sequence(:email) { |n| "admin.user#{n}@dev.gov.uk" }
+    sequence(:email) { |n| "signon.user#{n}@dev.gov.uk" }
+    sequence(:name) { |n| "Signon User #{n}" }
 
     trait :admin do
       permissions { %w[admin-area] }

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -173,6 +173,20 @@ RSpec.describe Admin::QuestionsHelper do
       result = helper.question_show_summary_list_rows(question, nil, 1, 1)
       expect(returned_keys(result)).not_to include("Early access user")
     end
+
+    it "returns a row with a link to filter the questions table by the signon user" do
+      signon_user = create(:signon_user)
+      conversation.update!(signon_user:)
+      result = helper.question_show_summary_list_rows(question, nil, 1, 1)
+
+      row = result.find { |r| r[:field] == "API user" }
+      expect(row[:value])
+        .to include(conversation.signon_user.name)
+        .and have_link(
+          "View all questions",
+          href: admin_questions_path(signon_user_id: conversation.signon_user.id),
+        )
+    end
   end
 
   describe "#decode_and_mark_unicode_tag_segments" do

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -273,6 +273,63 @@ RSpec.describe Admin::Filters::QuestionsFilter do
     end
   end
 
+  describe "#user" do
+    it "returns the user if user_id is passed in" do
+      user = create(:early_access_user)
+      filter = described_class.new(user_id: user.id)
+
+      expect(filter.user).to eq(user)
+    end
+
+    it "returns nil if user_id is not passed in" do
+      filter = described_class.new
+      expect(filter.user).to be_nil
+    end
+
+    it "returns nil if user_id is passed in but the user does not exist" do
+      filter = described_class.new(user_id: "invalid_id")
+      expect(filter.user).to be_nil
+    end
+  end
+
+  describe "#signon_user" do
+    it "returns the signon_user if signon_user_id is passed in" do
+      signon_user = create(:signon_user)
+      filter = described_class.new(signon_user_id: signon_user.id)
+
+      expect(filter.signon_user).to eq(signon_user)
+    end
+
+    it "returns nil if signon_user_id is not passed in" do
+      filter = described_class.new
+      expect(filter.signon_user).to be_nil
+    end
+
+    it "returns nil if signon_user_id is passed in but the signon_user does not exist" do
+      filter = described_class.new(signon_user_id: "invalid_id")
+      expect(filter.signon_user).to be_nil
+    end
+  end
+
+  describe "#conversation" do
+    it "returns the conversation if conversation_id is passed in" do
+      conversation = create(:conversation)
+      filter = described_class.new(conversation_id: conversation.id)
+
+      expect(filter.conversation).to eq(conversation)
+    end
+
+    it "returns nil if conversation_id is not passed in" do
+      filter = described_class.new
+      expect(filter.conversation).to be_nil
+    end
+
+    it "returns nil if conversation_id is passed in but the conversation does not exist" do
+      filter = described_class.new(conversation_id: "invalid_id")
+      expect(filter.conversation).to be_nil
+    end
+  end
+
   it_behaves_like "a paginatable filter", :question
 
   describe "#previous_page_params" do

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -220,6 +220,29 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       expect(filter.results).to eq([bob_question])
     end
 
+    it "filters the results by signon user" do
+      alice = create(:signon_user, email: "alice@example.com")
+      bob = create(:signon_user, email: "bob@example.com")
+      alice_question = create(:question, conversation: create(:conversation, signon_user: alice))
+      bob_question = create(:question, conversation: create(:conversation, signon_user: bob))
+
+      filter = described_class.new(signon_user_id: alice.id)
+      expect(filter.results).to eq([alice_question])
+
+      filter = described_class.new(signon_user_id: bob.id)
+      expect(filter.results).to eq([bob_question])
+    end
+
+    it "doesn't filter the results by signon user if signon_user_id and user_id are passed in" do
+      alice = create(:signon_user, email: "alice@example.com")
+      bob = create(:early_access_user, email: "bob@example.com")
+      create(:question, conversation: create(:conversation, signon_user: alice))
+      bob_question = create(:question, conversation: create(:conversation, user: bob))
+
+      filter = described_class.new(signon_user_id: alice.id, user_id: bob.id)
+      expect(filter.results).to eq([bob_question])
+    end
+
     it "filters the results by question routing label" do
       create(:question, answer: build(:answer, question_routing_label: "genuine_rag"))
       non_english_question = create(:question, answer: build(:answer, question_routing_label: "non_english"))

--- a/spec/requests/admin/questions_spec.rb
+++ b/spec/requests/admin/questions_spec.rb
@@ -110,6 +110,30 @@ RSpec.describe "Admin::QuestionsController" do
 
         expect(response.body.squish).to have_content("Filtering by conversation ID:   #{conversation.id}")
       end
+
+      it "renders the signon user's details when filtering by signon_user_id" do
+        signon_user = create(:signon_user)
+        create(:conversation, signon_user:)
+        get admin_questions_path(signon_user_id: signon_user.id)
+
+        expect(response.body.squish)
+          .to have_content("Filtering by API user: #{signon_user.name}")
+      end
+
+      context "and filter params are present for user and signon user" do
+        it "doesn't render the signon user's details" do
+          signon_user = create(:signon_user)
+          create(:conversation, signon_user:)
+
+          get admin_questions_path(
+            signon_user_id: signon_user.id,
+            user_id: SecureRandom.uuid,
+          )
+
+          expect(response.body.squish)
+            .not_to have_content("Filtering by API user: #{signon_user.name}")
+        end
+      end
     end
 
     context "when the sort param is not the default value" do

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -58,9 +58,27 @@ RSpec.describe "Admin user filters questions" do
     then_i_see_the_question_from_the_first_conversation
   end
 
+  scenario "filtered by a signon user" do
+    given_i_am_an_admin
+    and_there_are_signon_users
+    and_there_are_questions_associated_with_signon_users
+
+    when_i_visit_the_questions_section_filtered_by_a_signon_user
+    then_i_see_that_signon_users_details_in_the_sidebar
+    and_i_see_all_the_questions_for_that_signon_user
+
+    when_i_search_for_a_question_from_the_signon_user
+    then_i_see_the_filtered_questions_for_that_signon_user
+  end
+
   def and_there_are_early_access_users
     @user = create(:early_access_user)
     @user2 = create(:early_access_user)
+  end
+
+  def and_there_are_signon_users
+    @signon_user = create(:signon_user)
+    @signon_user2 = create(:signon_user)
   end
 
   def and_there_are_questions
@@ -78,6 +96,16 @@ RSpec.describe "Admin user filters questions" do
     create(:question, conversation: conversation2, message: "Greetings world")
 
     conversation3 = build(:conversation, user: @user2)
+    create(:question, conversation: conversation3, message: "Goodbye")
+  end
+
+  def and_there_are_questions_associated_with_signon_users
+    @conversation1 = build(:conversation, signon_user: @signon_user)
+    conversation2 = build(:conversation, signon_user: @signon_user)
+    create(:question, conversation: @conversation1, message: "Hello world")
+    create(:question, conversation: conversation2, message: "Greetings world")
+
+    conversation3 = build(:conversation, signon_user: @signon_user2)
     create(:question, conversation: conversation3, message: "Goodbye")
   end
 
@@ -123,6 +151,10 @@ RSpec.describe "Admin user filters questions" do
     expect(page).to have_content("Filtering by user: #{@user.email}")
   end
 
+  def then_i_see_that_signon_users_details_in_the_sidebar
+    expect(page).to have_content("Filtering by API user: #{@signon_user.name}")
+  end
+
   def and_i_see_all_the_questions_for_that_user
     within(".govuk-table") do
       expect(page).to have_content("Hello world")
@@ -130,6 +162,7 @@ RSpec.describe "Admin user filters questions" do
       expect(page).not_to have_content("Goodbye")
     end
   end
+  alias_method :and_i_see_all_the_questions_for_that_signon_user, :and_i_see_all_the_questions_for_that_user
 
   def then_i_see_the_filtered_questions_for_that_user
     within(".govuk-table") do
@@ -138,6 +171,7 @@ RSpec.describe "Admin user filters questions" do
       expect(page).not_to have_content("Goodbye")
     end
   end
+  alias_method :then_i_see_the_filtered_questions_for_that_signon_user, :then_i_see_the_filtered_questions_for_that_user
 
   def when_clear_the_search_filter
     fill_in "search", with: ""
@@ -174,6 +208,7 @@ RSpec.describe "Admin user filters questions" do
     fill_in "Search", with: "Greetings"
     click_button "Filter"
   end
+  alias_method :when_i_search_for_a_question_from_the_signon_user, :when_i_search_for_a_question_from_the_user
 
   def then_i_see_questions_related_to_my_search
     expect(page).to have_content(@question1.message)
@@ -235,5 +270,9 @@ RSpec.describe "Admin user filters questions" do
 
   def when_i_visit_the_questions_section_filtered_by_a_user
     visit admin_questions_path(user_id: @user.id)
+  end
+
+  def when_i_visit_the_questions_section_filtered_by_a_signon_user
+    visit admin_questions_path(signon_user_id: @signon_user.id)
   end
 end


### PR DESCRIPTION
## Description

This PR adds a filter for signon users to the questions show page and exposes the signon user details on the question show page. 

It follows roughly the same pattern implemented for EarlyAccessUser in that you can only access the filter by clicking the link to `View all questions` for the user on the question show page. If the `signon_user_id` params isn't present then no filter/user info will be rendered.

I've made a few choices that might be worth discussing:

- I've used the SignonUsers name rather than email as i think it will be more useful/easy to distinguish the user based on that. Signon API users will likely be created by a dev from the various teams that will consume the API, but will be named in a way that will make it clear which team is using the API key
- I've not worried too much about duplication and instead prioritised that code can be easily removed so it's as easy as possible to strip out EarlyAccess and WaitingList users 
- I've only allowed you to filter by SignonUser if the user_id params isn't present since the filters are mutually exclusive. It might be that we want to do the inverse since we will be stripping out EarlyAccessUser soon. Or just not worry about is since EarlyAccess user will be stripped out soon. But for now since EarlyAccessUsers are knocking about and the mechanism required for web app users to use the app, i thought it was better to give that priority

## Screenshots
### Show question page
<img width="665" alt="image" src="https://github.com/user-attachments/assets/a85b188b-e188-4aa9-b978-7666901ad0d9" />

### Question index page

<img width="943" alt="image" src="https://github.com/user-attachments/assets/bb319256-e93b-4ddc-83fd-d7b7e77748b8" />

### Filtered by conversation

<img width="854" alt="image" src="https://github.com/user-attachments/assets/0c60cc9f-477c-4d15-b733-79154c975dbd" />

## Out of scope 

The Trello card mentions adding a source filter so we can filter on  `:api` or `web` based on if the convo was created by the API or not. That will be added in a follow up PR.

## Trello card

https://trello.com/b/BoPNvU55/stand-up-board-ai-govuk-llm-team-user-experience-govuk