### PR TITLE
Fix Claude 3.7 Sonnet model ID

### DIFF
--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -1,3 +1,3 @@
 module BedrockModels
-  CLAUDE_3_7_SONNET = "anthropic.claude-3-7-sonnet-20250219-v1:0".freeze
+  CLAUDE_3_7_SONNET = "eu.anthropic.claude-3-7-sonnet-20250219-v1:0".freeze
 end


### PR DESCRIPTION
We're using this model via Bedrock's cross region inference, meaning we
need to use the Inference profile ID rather than the generic model ID.
