### PR TITLE
Add ability to filter questions in Admin UI by source 

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -20,6 +20,7 @@ private
     params.permit(
       :search,
       :status,
+      :source,
       { start_date_params: %i[day month year], end_date_params: %i[day month year] },
       :answer_feedback_useful,
       :question_routing_label,

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -4,7 +4,7 @@ class Api::V0::ConversationsController < ApplicationController
   before_action :find_conversation, only: %i[show update answer answer_feedback]
 
   def create
-    conversation = Conversation.new(signon_user: current_user)
+    conversation = Conversation.new(signon_user: current_user, source: :api)
     form = Form::CreateQuestion.new(question_params.merge(conversation:))
 
     if form.valid?

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -70,7 +70,7 @@ private
   def find_conversation
     @conversation = Conversation
                     .includes(questions: { answer: %i[sources feedback] })
-                    .where(signon_user_id: current_user.id)
+                    .where(signon_user_id: current_user.id, source: :api)
                     .find(params[:conversation_id])
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -111,7 +111,9 @@ private
   def find_conversation
     return if cookies[:conversation_id].blank?
 
-    @conversation = Conversation.includes(:user).active.find_by!(id: cookies[:conversation_id], user: current_early_access_user)
+    @conversation = Conversation.includes(:user)
+                                .active
+                                .find_by!(id: cookies[:conversation_id], user: current_early_access_user, source: :web)
     set_conversation_cookie(@conversation)
   rescue ActiveRecord::RecordNotFound
     cookies.delete(:conversation_id)

--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -97,6 +97,11 @@ module Admin
         }
       end
 
+      rows << {
+        field: "Source",
+        value: conversation.source_api? ? "API" : conversation.source.humanize,
+      }
+
       rows << if answer.present?
                 [
                   {

--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -85,7 +85,7 @@ module Admin
       end
 
       signon_user = conversation.signon_user
-      if signon_user.present?
+      if signon_user.present? && conversation.source_api?
         rows << {
           field: "API user",
           value: safe_join([

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -1,6 +1,7 @@
 class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
   attribute :status
   attribute :search
+  attribute :source
   attribute :start_date_params, default: {}
   attribute :end_date_params, default: {}
   attribute :conversation_id
@@ -30,6 +31,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
                       .left_outer_joins(:answer)
       scope = search_scope(scope)
       scope = status_scope(scope)
+      scope = source_scope(scope)
       scope = start_date_scope(scope)
       scope = end_date_scope(scope)
       scope = answer_feedback_useful_scope(scope)
@@ -91,6 +93,12 @@ private
     else
       scope.where(answers: { status: })
     end
+  end
+
+  def source_scope(scope)
+    return scope if source.blank?
+
+    scope.joins(:conversation).where(conversations: { source: })
   end
 
   def start_date_scope(scope)

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -134,7 +134,7 @@ private
   def signon_user_scope(scope)
     return scope if signon_user_id.blank? || user_id.present?
 
-    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id })
+    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id, source: :api })
   end
 
   def question_routing_label_scope(scope)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,6 +6,13 @@ class Conversation < ApplicationRecord
 
   scope :active, -> { where(Question.active.where("questions.conversation_id = conversations.id").arel.exists) }
 
+  enum :source,
+       {
+         api: "api",
+         web: "web",
+       },
+       prefix: true
+
   def questions_for_showing_conversation
     Question.where(conversation: self)
             .includes(answer: %i[feedback sources])

--- a/app/views/admin/questions/_question_filters.html.erb
+++ b/app/views/admin/questions/_question_filters.html.erb
@@ -74,6 +74,30 @@
     end,
   } %>
 
+  <%= render "govuk_publishing_components/components/select", {
+    id: "source",
+    name: "source",
+    label: "Source",
+    heading_size: "s",
+    full_width: true,
+    options: [
+      {
+        text: "",
+        value: "",
+      },
+      {
+        text: "Web",
+        value: "web",
+        selected: params[:source] == "web",
+      },
+      {
+        text: "API",
+        value: "api",
+        selected: params[:source] == "api",
+      },
+    ],
+  } %>
+
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Start date",
     heading_size: "s",

--- a/db/migrate/20250506133220_add_source_to_conversations.rb
+++ b/db/migrate/20250506133220_add_source_to_conversations.rb
@@ -1,0 +1,6 @@
+class AddSourceToConversations < ActiveRecord::Migration[8.0]
+  def change
+    create_enum "conversation_source", %w[web api]
+    add_column :conversations, :source, :conversation_source, null: false, default: "web"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_01_150559) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_06_133220) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_01_150559) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "answer_status", ["answered", "banned", "clarification", "error_answer_guardrails", "error_answer_service_error", "error_context_length_exceeded", "error_jailbreak_guardrails", "error_non_specific", "error_question_routing_guardrails", "error_timeout", "guardrails_answer", "guardrails_forbidden_terms", "guardrails_jailbreak", "guardrails_question_routing", "unanswerable_llm_cannot_answer", "unanswerable_no_govuk_content", "unanswerable_question_routing"]
+  create_enum "conversation_source", ["web", "api"]
   create_enum "deleted_early_access_user_deletion_type", ["unsubscribe", "admin"]
   create_enum "deleted_waiting_list_user_deletion_type", ["unsubscribe", "admin", "promotion"]
   create_enum "early_access_user_source", ["admin_added", "instant_signup", "admin_promoted", "delayed_signup"]
@@ -97,6 +98,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_01_150559) do
     t.datetime "updated_at", null: false
     t.uuid "early_access_user_id"
     t.uuid "signon_user_id"
+    t.enum "source", default: "web", null: false, enum_type: "conversation_source"
     t.index ["created_at"], name: "index_conversations_on_created_at"
     t.index ["early_access_user_id"], name: "index_conversations_on_early_access_user_id"
     t.index ["signon_user_id"], name: "index_conversations_on_signon_user_id"

--- a/spec/factories/conversation_factory.rb
+++ b/spec/factories/conversation_factory.rb
@@ -34,5 +34,9 @@ FactoryBot.define do
         create(:question, :with_answer, conversation:)
       end
     end
+
+    trait :api do
+      source { :api }
+    end
   end
 end

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Admin::QuestionsHelper do
 
     it "returns a row with a link to filter the questions table by the signon user" do
       signon_user = create(:signon_user)
-      conversation.update!(signon_user:)
+      conversation.update!(signon_user:, source: :api)
       result = helper.question_show_summary_list_rows(question, nil, 1, 1)
 
       row = result.find { |r| r[:field] == "API user" }
@@ -201,6 +201,14 @@ RSpec.describe Admin::QuestionsHelper do
 
       row = result.find { |r| r[:field] == "Source" }
       expect(row[:value]).to eq("API")
+    end
+
+    it "doesn't return a signon user row if the conversation wasn't created via the API" do
+      signon_user = create(:signon_user)
+      conversation.update!(signon_user:)
+
+      result = helper.question_show_summary_list_rows(question, nil, 1, 1)
+      expect(returned_keys(result)).not_to include("API user")
     end
   end
 

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Admin::QuestionsHelper do
         "Question created at",
         "Question",
         "Show search results",
+        "Source",
         "Status",
       ]
 
@@ -72,6 +73,7 @@ RSpec.describe Admin::QuestionsHelper do
         "Question",
         "Show search results",
         "Early access user",
+        "Source",
         "Rephrased question",
         "Status",
         "Answer created at",
@@ -186,6 +188,19 @@ RSpec.describe Admin::QuestionsHelper do
           "View all questions",
           href: admin_questions_path(signon_user_id: conversation.signon_user.id),
         )
+    end
+
+    it "returns a row with the source of the conversation" do
+      result = helper.question_show_summary_list_rows(question, nil, 1, 1)
+
+      row = result.find { |r| r[:field] == "Source" }
+      expect(row[:value]).to eq("Web")
+
+      conversation.update!(source: :api)
+      result = helper.question_show_summary_list_rows(question, nil, 1, 1)
+
+      row = result.find { |r| r[:field] == "Source" }
+      expect(row[:value]).to eq("API")
     end
   end
 

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -234,14 +234,23 @@ RSpec.describe Admin::Filters::QuestionsFilter do
     it "filters the results by signon user" do
       alice = create(:signon_user, email: "alice@example.com")
       bob = create(:signon_user, email: "bob@example.com")
-      alice_question = create(:question, conversation: create(:conversation, signon_user: alice))
-      bob_question = create(:question, conversation: create(:conversation, signon_user: bob))
+      alice_question = create(:question, conversation: create(:conversation, :api, signon_user: alice))
+      bob_question = create(:question, conversation: create(:conversation, :api, signon_user: bob))
 
       filter = described_class.new(signon_user_id: alice.id)
       expect(filter.results).to eq([alice_question])
 
       filter = described_class.new(signon_user_id: bob.id)
       expect(filter.results).to eq([bob_question])
+    end
+
+    it "filters out results assoicated with a signon user that weren't created via the API" do
+      signon_user = create(:signon_user)
+      create(:question, conversation: create(:conversation, signon_user:))
+
+      filter = described_class.new(signon_user_id: signon_user.id)
+
+      expect(filter.results).to eq([])
     end
 
     it "doesn't filter the results by signon user if signon_user_id and user_id are passed in" do

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       expect(filter.results).to eq([question2])
     end
 
+    it "filters the results by conversation source" do
+      question1 = create(:question)
+      question2 = create(:question, conversation: build(:conversation, :api))
+
+      filter = described_class.new(source: "web")
+      expect(filter.results).to eq([question1])
+
+      filter = described_class.new(source: "api")
+      expect(filter.results).to eq([question2])
+    end
+
     it "filters the results by start date" do
       question = create(:question)
       create(:question, created_at: 2.days.ago)

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -1,32 +1,54 @@
 RSpec.describe "Api::V0::ConversationsController" do
   let(:api_user) { create(:signon_user, :conversation_api) }
-  let(:conversation) { create(:conversation, signon_user: api_user) }
+  let(:conversation) { create(:conversation, :api, signon_user: api_user) }
   let(:question) { create(:question, conversation:) }
 
   before do
     login_as(api_user)
   end
 
-  shared_examples "responds with forbidden if user doesn't have conversation-api permission" do |routes:|
-    before { login_as(create(:signon_user)) }
-
+  shared_examples "limits access based on permissions and conversation source" do |routes:|
     routes.each do |route|
+      method = route[:method]
+      path = route[:path]
+      route_params = route[:route_params] || []
+      params = route[:params] || {}
+
       describe "responds with forbidden if user doesn't have conversation-api permission" do
-        it "returns with 403 for #{route[:method]} #{route[:path]}" do
+        before { login_as(create(:signon_user)) }
+
+        it "returns 403 for #{method} #{path}" do
           process(
-            route[:method.to_sym],
-            public_send(route[:path].to_sym, *(route[:route_params] || [])),
-            params: route[:params] || {},
+            method.to_sym,
+            public_send(path.to_sym, *route_params),
+            params: params,
             as: :json,
           )
 
           expect(response).to have_http_status(:forbidden)
         end
       end
+
+      next if path == :api_v0_create_conversation_path
+
+      describe "ensures the conversation was created by the API" do
+        it "returns 404 when conversation source is not :api for #{method} #{path}" do
+          conversation.update!(source: :web)
+
+          process(
+            method.to_sym,
+            public_send(path.to_sym, *route_params),
+            params: params,
+            as: :json,
+          )
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
   end
 
-  it_behaves_like "responds with forbidden if user doesn't have conversation-api permission",
+  it_behaves_like "limits access based on permissions and conversation source",
                   routes: [
                     {
                       path: :api_v0_create_conversation_path,

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -143,6 +143,13 @@ RSpec.describe "Api::V0::ConversationsController" do
         conversation = Conversation.includes(:signon_user).last
         expect(conversation.signon_user).to eq(api_user)
       end
+
+      it "sets the conversations source to :api" do
+        post api_v0_create_conversation_path, params: payload, as: :json
+
+        conversation = Conversation.last
+        expect(conversation.source).to eq("api")
+      end
     end
 
     context "when the question is invalid" do

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "ConversationsController" do
     let(:route_params) { [SecureRandom.uuid] }
   end
 
-  it_behaves_like "requires a conversation", routes: { answer_question_path: %i[get], answer_feedback_path: %i[post] } do
+  it_behaves_like "requires a conversation created via the chat interface", routes: { answer_question_path: %i[get], answer_feedback_path: %i[post] } do
     let(:route_params) { [SecureRandom.uuid] }
   end
 

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -21,8 +21,12 @@ RSpec.describe "Admin user filters questions" do
     then_i_see_questions_related_to_my_search
 
     when_i_clear_the_filters
+    and_i_filter_on_questions_created_via_the_api
+    then_i_see_question_created_via_the_api
+
+    when_i_clear_the_filters
     and_i_search_for_recent_questions
-    then_i_see_the_recent_question
+    then_i_see_the_recent_questions
 
     when_i_clear_the_filters
     and_i_search_for_old_questions
@@ -83,10 +87,13 @@ RSpec.describe "Admin user filters questions" do
 
   def and_there_are_questions
     conversation = build(:conversation)
+    api_conversation = build(:conversation, source: :api)
     @question1 = create(:question, conversation:, message: "Hello world", created_at: 2.years.ago)
     @question2 = create(:question, message: "World", conversation:)
-    answer2 = create(:answer, question: @question2, question_routing_label: "non_english")
-    create(:answer_feedback, answer: answer2, useful: true)
+    @question3 = create(:question, conversation: api_conversation, message: "Greetings world", created_at: 1.minute.ago)
+    answer = create(:answer, question: @question2, question_routing_label: "non_english")
+    create(:answer_feedback, answer: answer, useful: true)
+    create(:answer, status: :clarification, question: @question3)
   end
 
   def and_there_are_questions_associated_with_users
@@ -143,7 +150,7 @@ RSpec.describe "Admin user filters questions" do
 
   def then_i_see_all_the_questions
     within(".govuk-table") do
-      expect(page).to have_content(/World.*Hello world./)
+      expect(page).to have_content(/World.*Greetings world.*Hello world./)
     end
   end
 
@@ -195,7 +202,7 @@ RSpec.describe "Admin user filters questions" do
 
   def then_i_see_the_ordering_has_changed
     within(".govuk-table") do
-      expect(page).to have_content(/Hello world.*World./)
+      expect(page).to have_content(/Hello world.*Greetings world.*World./)
     end
   end
 
@@ -213,6 +220,18 @@ RSpec.describe "Admin user filters questions" do
   def then_i_see_questions_related_to_my_search
     expect(page).to have_content(@question1.message)
     expect(page).not_to have_content(@question2.message)
+    expect(page).not_to have_content(@question3.message)
+  end
+
+  def and_i_filter_on_questions_created_via_the_api
+    select "API", from: "source"
+    click_button "Filter"
+  end
+
+  def then_i_see_question_created_via_the_api
+    expect(page).to have_content(@question3.message)
+    expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question2.message)
   end
 
   def and_i_search_for_recent_questions
@@ -224,8 +243,9 @@ RSpec.describe "Admin user filters questions" do
     click_button "Filter"
   end
 
-  def then_i_see_the_recent_question
+  def then_i_see_the_recent_questions
     expect(page).to have_content(@question2.message)
+    expect(page).to have_content(@question3.message)
     expect(page).not_to have_content(@question1.message)
   end
 
@@ -241,6 +261,7 @@ RSpec.describe "Admin user filters questions" do
   def then_i_see_the_old_question
     expect(page).to have_content(@question1.message)
     expect(page).not_to have_content(@question2.message)
+    expect(page).not_to have_content(@question3.message)
   end
 
   def and_i_filter_by_questions_with_useful_answers
@@ -251,6 +272,7 @@ RSpec.describe "Admin user filters questions" do
   def then_i_see_the_useful_question
     expect(page).to have_content(@question2.message)
     expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question3.message)
   end
 
   def and_i_filter_by_questions_with_a_specific_question_routing_label
@@ -261,6 +283,7 @@ RSpec.describe "Admin user filters questions" do
   def then_i_see_the_question_with_that_routing_label
     expect(page).to have_content(@question2.message)
     expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question3.message)
   end
 
   def when_i_view_the_questions_conversation

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe "Admin user filters questions" do
   end
 
   def and_there_are_questions_associated_with_signon_users
-    @conversation1 = build(:conversation, signon_user: @signon_user)
-    conversation2 = build(:conversation, signon_user: @signon_user)
+    @conversation1 = build(:conversation, :api, signon_user: @signon_user)
+    conversation2 = build(:conversation, :api, signon_user: @signon_user)
     create(:question, conversation: @conversation1, message: "Hello world")
     create(:question, conversation: conversation2, message: "Greetings world")
 


### PR DESCRIPTION
## Description

This PR does a few things:

- adds a new enum for conversation_source to the db
- adds a source column to the conversations table for so which defaults to :web
- updates the API controller to set the source value to :API when a conversation is created
- adds a filter to the questions index page which allows you to filter on source

<img width="903" alt="image" src="https://github.com/user-attachments/assets/7005ff3a-d402-4451-9103-b616b7f84748" />

## Trello card

https://trello.com/c/euKSVD56/2449-chat-api-add-admin-ui-functionality-for-api-users