### PR TITLE
Use fulladmin AWS role for bedrock credentials

### DIFF
--- a/bin/export-aws-credentials
+++ b/bin/export-aws-credentials
@@ -6,7 +6,9 @@ rails_root = File.expand_path("..", __dir__)
 config_file_path = File.join(rails_root, ".env.aws.local")
 
 # Export AWS credentials using the gds-cli tool, stripping off the leading "export" and the trailing ";"
-aws_credentials = %x(gds aws govuk-test-poweruser -e --art 8h)
+# TODO: currently developer permission lacks bedrock invoke model so we need to
+# use full admin - we totally shouldn't rely on this long term
+aws_credentials = %x(gds aws govuk-test-fulladmin -e --art 8h)
 raise "Command failed with status #{$?.exitstatus}" unless $?.success?
 
 relevant_credentials = aws_credentials.split("\n").filter_map do |line|


### PR DESCRIPTION
The govuk-test-poweruser role has been retired and unfortunately the replacement, govuk-test-developer, doesn't have sufficient access that we can invoke models with Bedrock.

Therefore to be able to remain using AWS we need to make use of the fulladmin permission to invoke the model - despite this being advised against.

We're starting a story to update the permissions for the developer role so we can fallback to a reduced access role.