### PR TITLE
Drop back to developer permission for Bedrock access

### DIFF
--- a/bin/export-aws-credentials
+++ b/bin/export-aws-credentials
@@ -6,9 +6,7 @@ rails_root = File.expand_path("..", __dir__)
 config_file_path = File.join(rails_root, ".env.aws.local")
 
 # Export AWS credentials using the gds-cli tool, stripping off the leading "export" and the trailing ";"
-# TODO: currently developer permission lacks bedrock invoke model so we need to
-# use full admin - we totally shouldn't rely on this long term
-aws_credentials = %x(gds aws govuk-test-fulladmin -e --art 8h)
+aws_credentials = %x(gds aws govuk-test-developer -e --art 8h)
 raise "Command failed with status #{$?.exitstatus}" unless $?.success?
 
 relevant_credentials = aws_credentials.split("\n").filter_map do |line|


### PR DESCRIPTION
Now there is a policy that allows the developer role to invoke Bedrock models [1] we can reduce the level of access needed to export credentials.

[1]: https://github.com/alphagov/govuk-user-reviewer/pull/1543