### PR TITLE
Rate limit API endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -41,6 +41,18 @@ class Rack::Attack
     end
   end
 
+  throttle("read requests to Conversations API with device id", limit: 120, period: 1.minute) do |request|
+    if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
+      request.get_header("HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID").presence
+    end
+  end
+
+  throttle("write requests to Conversations API with device id", limit: 20, period: 1.minute) do |request|
+    if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
+      request.get_header("HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID").presence
+    end
+  end
+
   def self.rails_controller_action(url)
     route = Rails.application.routes.recognize_path(url)
 

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -18,6 +18,8 @@ paths:
     post:
       summary: Start conversation
       description: Create a conversation by posting an initial question
+      parameters:
+        - $ref: "#/components/parameters/DeviceIdHeader"
       requestBody:
         required: true
         content:
@@ -52,6 +54,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: "#/components/parameters/DeviceIdHeader"
       responses:
         "200":
           description: |
@@ -82,6 +85,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: "#/components/parameters/DeviceIdHeader"
       requestBody:
         required: true
         content:
@@ -123,6 +127,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: "#/components/parameters/DeviceIdHeader"
       responses:
         "200":
           description: The answer is available and is returned
@@ -158,6 +163,7 @@ paths:
           schema:
             type: string
             format: uuid
+        - $ref: "#/components/parameters/DeviceIdHeader"
       requestBody:
         required: true
         content:
@@ -195,6 +201,17 @@ components:
         GOV.UK Signon issued bearer token which is used to authenticate the
         client application (e.g. GOV.UK App) and not an individual end user
       scheme: bearer
+  parameters:
+    DeviceIdHeader:
+      name: Govuk-Chat-Client-Device-Id
+      in: header
+      required: false
+      description: |
+        An identifier for an individual end-user client to be used to provide
+        individual end-user rate limiting to ensure that no one client can
+        consume all of an API users' limits.
+      schema:
+        type: string
   schemas:
     UserQuestion:
       type: object

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe "Api::V0::ConversationsController" do
                     end
                   end
 
+  it_behaves_like "throttles traffic for a single device",
+                  routes: {
+                    api_v0_show_conversation_path: %i[get],
+                    api_v0_answer_question_path: %i[get],
+                    api_v0_create_conversation_path: %i[post],
+                    api_v0_update_conversation_path: %i[put],
+                    api_v0_answer_feedback_path: %i[post],
+                  },
+                  period: 1.minute do
+    let(:route_params) do
+      {
+        conversation_id: SecureRandom.uuid,
+        question_id: SecureRandom.uuid,
+        answer_id: SecureRandom.uuid,
+      }
+    end
+  end
+
   describe "middleware ensures adherance to the OpenAPI specification" do
     context "when the response returned does not conform to the OpenAPI specification" do
       it "raises an error and returns the invalid params in the error message" do

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe "Api::V0::ConversationsController" do
                     },
                   ]
 
+  it_behaves_like "throttles traffic for an access token",
+                  routes: {
+                    api_v0_show_conversation_path: %i[get],
+                    api_v0_answer_question_path: %i[get],
+                    api_v0_create_conversation_path: %i[post],
+                    api_v0_update_conversation_path: %i[put],
+                    api_v0_answer_feedback_path: %i[post],
+                  },
+                  period: 1.minute do
+                    let(:route_params) do
+                      {
+                        conversation_id: SecureRandom.uuid,
+                        question_id: SecureRandom.uuid,
+                        answer_id: SecureRandom.uuid,
+                      }
+                    end
+                  end
+
   describe "middleware ensures adherance to the OpenAPI specification" do
     context "when the response returned does not conform to the OpenAPI specification" do
       it "raises an error and returns the invalid params in the error message" do

--- a/spec/support/rack_attack_examples.rb
+++ b/spec/support/rack_attack_examples.rb
@@ -109,4 +109,55 @@ module RackAttackExamples
       end
     end
   end
+
+  RSpec.shared_examples "throttles traffic for a single device" do |routes:, period:|
+    let(:route_params) { {} }
+    let(:device_id) { "test-device-123" }
+
+    before do
+      read_throttle = Rack::Attack.throttles["read requests to Conversations API with device id"]
+      allow(read_throttle).to receive(:limit).and_return(1)
+
+      write_throttle = Rack::Attack.throttles["write requests to Conversations API with device id"]
+      allow(write_throttle).to receive(:limit).and_return(1)
+    end
+
+    routes.each do |path, methods|
+      methods.each do |method|
+        before do
+          process(method.to_sym,
+                  public_send(path, **route_params),
+                  headers: { "HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID" => device_id })
+        end
+
+        context "when a users device uses its allowance", :rack_attack do
+          it "rejects the next request to #{method} #{path}" do
+            process(method.to_sym,
+                    public_send(path, **route_params),
+                    headers: { "HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID" => device_id })
+
+            expect(response).to have_http_status(:too_many_requests)
+          end
+
+          it "doesn't reject a request with a different device id" do
+            process(method.to_sym,
+                    public_send(path, **route_params),
+                    headers: { "HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID" => "test-device-456" })
+
+            expect(response).not_to have_http_status(:too_many_requests)
+          end
+
+          it "doesn't reject a request after the time period" do
+            travel_to(Time.current + period + 1.second) do
+              process(method.to_sym,
+                      public_send(path, **route_params),
+                      headers: { "HTTP_GOVUK_CHAT_CLIENT_DEVICE_ID" => device_id })
+
+              expect(response).not_to have_http_status(:too_many_requests)
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

This adds two throttles:

1. Throttle by token: This will limit the number of requests a single token can make to a specific endpoint within a given time and will protect us being spammed by a single products API consumption
2. Throttle by device id: This will limit the number of requests a single device id can make to a specific endpoint within a given time and will protect us from a single device id spamming the API

I've been generous with the limits for now, but we will probably want to discuss limits with the App team.
I'm going to look into adding rate limit details to the headers in a separate PR/bit of work.

## Tests

I've added to the RackAttack shared examples. Part of me feels like this could just live in one test at the top of the file though rather than testing every endpoint. Or we could move shared functionality (Committee, auth & rate limiting) to an API req spec rather than the conversation controller req spec. Interested to see what people think.

## IP based rate limiting

I've looked into the rate limiting provision Nginx and AWS provide to us as part of being integrated in the GOV.UK Stack. AWS WAF rules allow 2000 requests per ip address every 5 mins. So thats 400 per minute which should be okay for us in the short to mid term. If we got a massive uptick in consumers post rollout we may need to reevaluate due to NATs (Network Address Translation).

Mobile devices often connect through cellular networks that use NATs which can result in many users sharing the same public IP address.

## Additional functionality provided by RackAttack 

Looking into the offering there's stuff they provide which i think we're unlikely to want to use at this point, but may want to down the line

- safelist - app will be public facing so won't need it
- blocklist - may want to use down the line to block malicious actors, but probs overkill for now
  - if we do end up wanting to use this RackAttack has integrated [Fail2Ban](https://github.com/rack/rack-attack?tab=readme-ov-file#fail2ban) and [Allow2Ban](https://github.com/rack/rack-attack?tab=readme-ov-file#fail2ban) which are different strategies for banning malicious users.
- [Tracking users](https://github.com/rack/rack-attack?tab=readme-ov-file#tracks) - we could use this to warn us if API keys are within say 80% of the limit and provide us with info if wanted to, but again seems overkill for now

## Trello card

https://trello.com/c/NGj7izB0/2446-chat-api-rate-limit-api-endpoints