### PR TITLE
Add eval rake task for retrieving documents from index

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -121,4 +121,21 @@ namespace :evaluation do
 
     puts(result.to_json)
   end
+
+  desc "Query the index for results matching a user input"
+  task search_results_for_question: :environment do
+    raise "Requires an INPUT env var" if ENV["INPUT"].blank?
+    raise "Requires an EMBEDDING_PROVIDER env var" if ENV["EMBEDDING_PROVIDER"].blank?
+
+    search_results = Search::ResultsForQuestion.call(ENV["INPUT"]).results
+
+    items = search_results.map do |result|
+      {
+        exact_path: result.exact_path,
+        plain_content: result.plain_content,
+      }
+    end
+
+    puts(items.to_json)
+  end
 end


### PR DESCRIPTION
Adds a new Rake task under the `evaluation` namespace to pull documents
from the OpenSearch index based on a query string.

We'll use this in the Python evaluation codebase to evaluate different
embedding providers.

I asked Nick what fields we want to return here to consume by the Python
eval app:

> If you could return the `exact_path` and the `plain_content` that'd be great. In principle the `exact_path` is sufficient to identify the chunk on OpenSearch but it'd be good to have the content of the chunk to have some way of tracking/capturing differences between a ground-truth retrieval data set and the current version of the content on GOV.UK (where changes happen within a chunk without touching the chunk structure)