### PR TITLE
Accept answer_strategy argument for evaluation:generate_answer

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -36,10 +36,13 @@ namespace :evaluation do
   end
 
   desc "Generate a single answer to a question returned as JSON, for 3rd party evaluation tools"
-  task generate_answer: :environment do
+  task :generate_answer, %i[answer_strategy] => :environment do |_, args|
     raise "requires a QUESTION env var" if ENV["QUESTION"].blank?
 
-    question = Question.new(message: ENV["QUESTION"], conversation: Conversation.new)
+    answer_strategy = args.fetch(:answer_strategy, Rails.configuration.answer_strategy)
+    warn "No answer strategy argument provided, using #{answer_strategy}" unless args[:answer_strategy]
+
+    question = Question.new(message: ENV["QUESTION"], conversation: Conversation.new, answer_strategy:)
     answer = AnswerComposition::Composer.call(question)
     puts({ message: answer.message }.to_json)
   end


### PR DESCRIPTION
This builds on https://github.com/alphagov/govuk-chat/pull/198 to fix a separate rake task that was also only possible to use the database default of the answer_strategy.

I've configured this task to now accept an answer_strategy argument so a user can specify the answer strategy at runtime.

I thought it was a bit delicate relying on env var for this as it seemed quite easy that a user could be surprised by the answer_strategy used. Therefore I've made this an individual rake argument and set a warning if it's not used to specify what was used.

Following this change we should update the data science documentation to suggest using:

```
bundle exec rake evaluation:generate_answer[claude_structured_answer] QUESTION="what are the vat rates?"
```

over:

```
bundle exec rake evaluation:generate_answer QUESTION="what are the vat rates?" ANSWER_STRATEGY=claude_structured_answer
```