### PR TITLE
Titan embedding and retrieval

### DIFF
--- a/lib/message_queue/content_synchroniser/index_content_item.rb
+++ b/lib/message_queue/content_synchroniser/index_content_item.rb
@@ -38,13 +38,21 @@ class MessageQueue::ContentSynchroniser
     end
 
     def index_chunks(indexable_chunks)
-      embeddings = Search::TextToEmbedding.call(indexable_chunks.map(&:plain_content), llm_provider: :openai)
+      openai_embeddings = Search::TextToEmbedding.call(
+        indexable_chunks.map(&:plain_content), llm_provider: :openai
+      )
+      titan_embeddings = Search::TextToEmbedding.call(
+        indexable_chunks.map(&:plain_content), llm_provider: :titan
+      )
 
       created = 0
       updated = 0
 
       indexable_chunks.each.with_index do |chunk, index|
-        document = chunk.to_opensearch_hash.merge(openai_embedding: embeddings[index])
+        document = chunk.to_opensearch_hash.merge(
+          openai_embedding: openai_embeddings[index],
+          titan_embedding: titan_embeddings[index],
+        )
         result = chunked_content_repository.index_document(chunk.id, document)
 
         case result

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -60,7 +60,13 @@ namespace :search do
       end
     end
 
-    embeddings = Search::TextToEmbedding.call(chunks.map(&:plain_content), llm_provider: :openai)
+    openai_embeddings = Search::TextToEmbedding.call(
+      chunks.map(&:plain_content), llm_provider: :openai
+    )
+    titan_embeddings = Search::TextToEmbedding.call(
+      chunks.map(&:plain_content), llm_provider: :titan
+    )
+
     repository = Search::ChunkedContentRepository.new
     indexed = 0
 
@@ -72,7 +78,10 @@ namespace :search do
     puts "#{deleted} conflicting chunks deleted"
 
     chunks.each.with_index do |chunk, index|
-      document = chunk.to_opensearch_hash.merge(openai_embedding: embeddings[index])
+      document = chunk.to_opensearch_hash.merge(
+        openai_embedding: openai_embeddings[index],
+        titan_embedding: titan_embeddings[index],
+      )
       repository.index_document(chunk.id, document)
       indexed += 1
     end

--- a/spec/factories/chunked_content_record_factory.rb
+++ b/spec/factories/chunked_content_record_factory.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     description { "Description" }
     plain_content { "Some content" }
     openai_embedding { [rand(-0.9...0.9)] * Search::ChunkedContentRepository::OPENAI_EMBEDDING_DIMENSIONS }
+    titan_embedding { [rand(-0.9...0.9)] * Search::ChunkedContentRepository::TITAN_EMBEDDING_DIMENSIONS }
 
     initialize_with { attributes }
   end

--- a/spec/lib/message_queue/content_synchroniser/index_content_item_spec.rb
+++ b/spec/lib/message_queue/content_synchroniser/index_content_item_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe MessageQueue::ContentSynchroniser::IndexContentItem, :chunked_con
 
     before do
       stub_any_openai_embedding
+      stub_bedrock_embedding(:titan)
       allow(Chunking::ContentItemToChunks).to receive(:call).with(content_item).and_return(chunks)
     end
 

--- a/spec/lib/message_queue/message_processor_spec.rb
+++ b/spec/lib/message_queue/message_processor_spec.rb
@@ -3,7 +3,10 @@ RSpec.describe MessageQueue::MessageProcessor do
 
   describe "#process" do
     context "when given a payload we can index", :chunked_content_index do
-      before { stub_any_openai_embedding }
+      before do
+        stub_any_openai_embedding
+        stub_bedrock_embedding(:titan)
+      end
 
       let(:base_path) { "/news" }
       let(:payload_version) { 20 }

--- a/spec/lib/search/chunked_content_repository_spec.rb
+++ b/spec/lib/search/chunked_content_repository_spec.rb
@@ -207,9 +207,10 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
 
   describe "#search_by_embedding" do
     let(:openai_embedding) { mock_openai_embedding("How do i pay my tax?") }
+    let(:titan_embedding) { mock_titan_embedding("How do i get universal credit?") }
     let(:chunked_content_records) do
       [
-        build(:chunked_content_record, openai_embedding:),
+        build(:chunked_content_record, openai_embedding:, titan_embedding:),
         build(:chunked_content_record),
         build(:chunked_content_record),
       ]
@@ -219,14 +220,28 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
       populate_chunked_content_index(chunked_content_records)
     end
 
-    it "returns an array of Result objects" do
+    it "returns an array of Result objects for OpenAI embedding" do
       result = repository.search_by_embedding(
         openai_embedding,
         max_chunks: 10,
         llm_provider: :openai,
       )
       expected_attributes = chunked_content_records.first
-                                                   .except(:openai_embedding)
+                                                   .except(:openai_embedding, :titan_embedding)
+                                                   .merge(score: a_value_between(0.9, 1))
+
+      expect(result).to all be_a(Search::ChunkedContentRepository::Result)
+      expect(result.first).to have_attributes(**expected_attributes)
+    end
+
+    it "returns an array of Result objects for Titan embedding" do
+      result = repository.search_by_embedding(
+        titan_embedding,
+        max_chunks: 10,
+        llm_provider: :titan,
+      )
+      expected_attributes = chunked_content_records.first
+                                                   .except(:titan_embedding, :openai_embedding)
                                                    .merge(score: a_value_between(0.9, 1))
 
       expect(result).to all be_a(Search::ChunkedContentRepository::Result)
@@ -269,7 +284,7 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
     it "returns the correct chunk as a ChunkedContentRepository::Result" do
       chunk_result = repository.chunk(chunk_id)
       expect(chunk_result).to be_a(Search::ChunkedContentRepository::Result)
-        .and have_attributes(content_chunk.except(:openai_embedding))
+        .and have_attributes(content_chunk.except(:openai_embedding, :titan_embedding))
         .and have_attributes(_id: chunk_id)
     end
 

--- a/spec/lib/search/results_for_question/reranker_spec.rb
+++ b/spec/lib/search/results_for_question/reranker_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Search::ResultsForQuestion::Reranker do
   end
 
   def build_chunked_content_result(attributes)
-    defaults = build(:chunked_content_record).except(:openai_embedding)
+    defaults = build(:chunked_content_record).except(:openai_embedding, :titan_embedding)
     Search::ChunkedContentRepository::Result.new(**defaults.merge(attributes))
   end
 end

--- a/spec/lib/tasks/search_spec.rb
+++ b/spec/lib/tasks/search_spec.rb
@@ -71,8 +71,12 @@ RSpec.describe "rake search tasks" do
     before do
       Rake::Task[task_name].reenable
 
-      allow(Search::TextToEmbedding).to receive(:call) do |arg|
+      allow(Search::TextToEmbedding::OpenAI).to receive(:call) do |arg|
         arg.map { |a| mock_openai_embedding(a) }
+      end
+
+      allow(Search::TextToEmbedding::Titan).to receive(:call) do |arg|
+        arg.map { |a| mock_titan_embedding(a) }
       end
     end
 

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -104,6 +104,13 @@ module StubBedrock
     }
   end
 
+  def mock_titan_embedding(text, dimensions: Search::ChunkedContentRepository::TITAN_EMBEDDING_DIMENSIONS)
+    # This returns a mock vector embedding which is deterministic based on the
+    # text given
+    random_generator = Random.new(text.bytes.sum)
+    dimensions.times.map { random_generator.rand }
+  end
+
   def bedrock_claude_text_response(response_text,
                                    user_message: nil,
                                    input_tokens: 10,

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -95,6 +95,14 @@ module StubBedrock
     end
   end
 
+  def stub_bedrock_embedding(llm_provider, text: "text")
+    raise "Unsupported LLM provider" unless llm_provider.to_sym == :titan
+
+    stub_bedrock_invoke_model(
+      bedrock_titan_embedding_response(mock_titan_embedding(text)),
+    )
+  end
+
   def bedrock_titan_embedding_response(embedding_array)
     {
       content_type: "application/json",


### PR DESCRIPTION
* Adds a mapping in OpenSearch for `titan_embedding` to allow us to store the embedding data against a document. We can then use this field when querying the index
* Updates the seed task to generate embeddings for Titan as well as OpenAI
* When pulling content items from the GOV.UK message queue, we generate and store the Titan embeddings

Note that we'll continue to keep the OpenAI embeddings around and generate embeddings for both providers for all documents in the store. This allows us to switch between providers for testing and evaluation.

At some point we'll be removing the OpenAI embeddings once we decide on a replacement provider. For that reason there's quite a bit of code duplication which would be nicer to tidy up (e.g. in a loop to generate both provider embeddings), but given we'll be removing OpenAI, the duplication won't be around for long.


