### PR TITLE
Raise a warning for generate_answer for error status

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -44,6 +44,12 @@ namespace :evaluation do
 
     question = Question.new(message: ENV["QUESTION"], conversation: Conversation.new, answer_strategy:)
     answer = AnswerComposition::Composer.call(question)
+
+    if answer.status =~ /^error/
+      warn "Warning: answer has an error status: #{answer.status}"
+      warn answer.error_message
+    end
+
     puts({ message: answer.message }.to_json)
   end
 

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -139,6 +139,23 @@ RSpec.describe "rake evaluation tasks" do
                                           conversation: an_instance_of(Conversation),
                                           answer_strategy: default_answer_strategy))
     end
+
+    it "warns when an answer has an erorr status" do
+      error_message = "Something is broken"
+      answer = build(:answer, status: :error_answer_service_error, error_message:)
+
+      allow(AnswerComposition::Composer)
+        .to receive(:call)
+        .with(an_instance_of(Question))
+        .and_return(answer)
+
+      ClimateControl.modify(QUESTION: "What is the current VAT rate?") do
+        expected_message = "Warning: answer has an error status: error_answer_service_error\n#{error_message}\n"
+        expect { Rake::Task[task_name].invoke("claude_structured_answer") }
+          .to output.to_stdout
+          .and output(expected_message).to_stderr
+      end
+    end
   end
 
   describe "generate_jailbreak_guardrail_response" do


### PR DESCRIPTION
This change is to make it a bit easier to debug error situations with the generate_answer command. This will raise a warning with some details of the error so the user has a thread to pull to work out why. Example usage:

```
➜  govuk-chat git:(warn-on-error) ✗ bundle exec rake evaluation:generate_answer[claude_structured_answer] QUESTION="what are the vat rates?"
Warning: answer has an error status: error_answer_service_error
The security token included in the request is expired
{"message":"Sorry, something went wrong while trying to answer your question. Try again later.\n\nWe saved your conversation. Check [GOV.UK guidance for businesses](https://www.gov.uk/browse/business) if you need information now.\n"}
```