### PR TITLE
Include additional data in evaluation:generate_report

### DIFF
--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "rake evaluation tasks" do
     let(:task_name) { "evaluation:generate_report" }
     let(:evaluation_data) do
       [
-        { question: "First question", llm_answer: "First answer" },
-        { question: "Second question", llm_answer: "Second answer" },
+        { question: "First question", answer: { "message" => "First answer" }, retrieved_context: [] },
+        { question: "Second question", answer: { "message" => "Second answer" }, retrieved_context: [] },
       ]
     end
     let(:jsonl) do
@@ -47,7 +47,7 @@ RSpec.describe "rake evaluation tasks" do
 
     it "generates the results as JSONL and prints them" do
       expect { Rake::Task[task_name].invoke("input.yml") }
-        .to output(/#{jsonl}/).to_stdout
+        .to output(/#{Regexp.escape(jsonl)}/).to_stdout
     end
 
     it "generates the results as JSONL and writes them to a file" do


### PR DESCRIPTION
This changes the data that is returned from Evaluation::ReportGenerator to hold much richer information about the answer. It essentially includes every field we store in the database aside from the ones created at write time (ids and timestamps). This has been done to provide the data scientists with a much greater insight into what was produced.

I've enhanced the retrieved_context to include all sources, not just used ones, with a flag as to which ones are used - as per the request. I've also modified the handling of the extreme edge case of search data changing while the task is running to be flagged with a boolean as to whether the search data is available.

A somewhat janky thing is that the answer data is returned in a hash that hash string keys rather than symbols. I didn't see it being very valuable to correct this as the expectation is that the data is dumped to JSON and all becomes string. We may want to fix this is if we ever have other usages for this class.

Originally in my chat with Nick we were going to make use of the existing serialize code for export (serialize_for_export) however when I started implementing I realised that would lease the extra search data this task already has and leave a bunch of null values for ids and timestamps.