### PR TITLE
Fix JSON parsing error for long question routing responses

### DIFF
--- a/lib/answer_composition/pipeline/openai/question_router.rb
+++ b/lib/answer_composition/pipeline/openai/question_router.rb
@@ -18,14 +18,14 @@ module AnswerComposition::Pipeline::OpenAI
       if genuine_rag?
         answer.assign_attributes(
           question_routing_label:,
-          question_routing_confidence_score: llm_classification_data["confidence"],
+          question_routing_confidence_score: confidence_score,
         )
       else
         answer.assign_attributes(
           message: use_llm_answer? ? llm_answer : Answer::CannedResponses.response_for_question_routing_label(question_routing_label),
           status: answer_status,
           question_routing_label:,
-          question_routing_confidence_score: llm_classification_data["confidence"],
+          question_routing_confidence_score: confidence_score,
         )
 
         context.abort_pipeline unless use_llm_answer?
@@ -56,6 +56,12 @@ module AnswerComposition::Pipeline::OpenAI
 
     def openai_token_limit_reached?
       openai_response_choice["finish_reason"] == "length"
+    end
+
+    def confidence_score
+      return if openai_token_limit_reached?
+
+      llm_classification_data["confidence"]
     end
 
     def llm_answer

--- a/spec/lib/answer_composition/pipeline/openai/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai/question_router_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
   end
 
   let(:classification_response) do
-    { answer: "Hello!", confidence: 0.85 }
+    { answer: "Hello!", confidence: 0.85 }.to_json
   end
 
   let(:expected_message_history) do
@@ -113,7 +113,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
           expected_message_history,
           tools:,
           function_name: "genuine_rag",
-          function_arguments: { answer: "Generic answer", confidence: 0.9 },
+          function_arguments: { answer: "Generic answer", confidence: 0.9 }.to_json,
         )
       end
 
@@ -144,10 +144,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
           expected_message_history,
           tools:,
           function_name: "vague_acronym_grammar",
-          function_arguments: {
-            answer: "A long answer that is terminated mid senten",
-            confidence: 0.99,
-          },
+          function_arguments: '{"answer": "A long answer that is terminated mid senten',
           finish_reason: "length",
         )
       end
@@ -184,7 +181,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
           expected_message_history,
           tools:,
           function_name: "multi_questions",
-          function_arguments: { answer: answer_message, confidence: 0.9 },
+          function_arguments: { answer: answer_message, confidence: 0.9 }.to_json,
         )
       end
 
@@ -211,7 +208,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
           expected_message_history,
           tools:,
           function_name: "harmful_vulgar_controversy",
-          function_arguments: { answer: "Ignored", confidence: 0.9 },
+          function_arguments: { answer: "Ignored", confidence: 0.9 }.to_json,
         )
       end
 


### PR DESCRIPTION
We learnt that a JSON Parser Error can be triggered when the question router uses more tokens than is allowed.

This was previously not covered in our tests as we weren't setting the JSON string that we receive from OpenAI and our truncation example was still valid JSON. When we received this as a real issue, we instead got back a truncated string of JSON which raised an error when parsed.

I've updated this code to no longer try access a confidence value when JSON can't be parsed.

I expected I'd have to fix this same issue on both OpenAI and on Claude, however with Claude we seem to always be guaranteed a valid response back - I'm not sure if this Claude or the Bedrock Converse API. When a max_tokens value is returned the field that is truncated seems to just be missing. Here's an example response to illustrate it:

```
[20] pry(main)> client.converse(**args)
=> #<struct Aws::BedrockRuntime::Types::ConverseResponse
 output=
  #<struct Aws::BedrockRuntime::Types::ConverseOutput::Message
   message=
    #<struct Aws::BedrockRuntime::Types::Message
     role="assistant",
     content=
      [#<struct Aws::BedrockRuntime::Types::ContentBlock::ToolUse
        text=nil,
        image=nil,
        document=nil,
        video=nil,
        tool_use=#<struct Aws::BedrockRuntime::Types::ToolUseBlock tool_use_id="tooluse_3CILFZyKS9iZx09rItKabA", name="harmful_vulgar_controversy", input={"confidence" => 0.95}>,
        tool_result=nil,
        guard_content=nil,
        cache_point=nil,
        reasoning_content=nil,
        unknown=nil>]>,
   unknown=nil>,
 stop_reason="max_tokens",
 usage=#<struct Aws::BedrockRuntime::Types::TokenUsage input_tokens=5896, output_tokens=50, total_tokens=5946, cache_read_input_tokens=0, cache_write_input_tokens=0>,
 metrics=#<struct Aws::BedrockRuntime::Types::ConverseMetrics latency_ms=1678>,
 additional_model_response_fields=nil,
 trace=nil,
 performance_config=nil>
```

Where we expect there was also an answer value for 'input' which was truncated, but has instead been removed.