### PR TITLE
Remove Early Access & Waiting List users from admin homepage

### DIFF
--- a/app/controllers/admin/homepage_controller.rb
+++ b/app/controllers/admin/homepage_controller.rb
@@ -1,36 +1,5 @@
 class Admin::HomepageController < Admin::BaseController
   def index
     @questions_total = Question.count
-    early_access_users_current = EarlyAccessUser.count
-    waiting_list_users_current = WaitingListUser.count
-
-    unsubscribed_early_access_users = DeletedEarlyAccessUser.deletion_type_unsubscribe.count
-    admin_deleted_early_access_users = DeletedEarlyAccessUser.deletion_type_admin.count
-
-    @early_access_user_stats = {
-      current: early_access_users_current,
-      unsubscribed: unsubscribed_early_access_users,
-      admin_deleted: admin_deleted_early_access_users,
-      total: [early_access_users_current,
-              unsubscribed_early_access_users,
-              admin_deleted_early_access_users].sum,
-    }
-
-    promoted_waiting_list_users = DeletedWaitingListUser.deletion_type_promotion.count
-    unsubscribed_waiting_list_users = DeletedWaitingListUser.deletion_type_unsubscribe.count
-    admin_deleted_waiting_list_users = DeletedWaitingListUser.deletion_type_admin.count
-    percentage_of_waiting_list_used = (waiting_list_users_current.to_f / Settings.instance.max_waiting_list_places) * 100
-
-    @waiting_list_user_stats = {
-      current: waiting_list_users_current,
-      promoted: promoted_waiting_list_users,
-      unsubscribed: unsubscribed_waiting_list_users,
-      admin_deleted: admin_deleted_waiting_list_users,
-      total: [waiting_list_users_current,
-              promoted_waiting_list_users,
-              unsubscribed_waiting_list_users,
-              admin_deleted_waiting_list_users].sum,
-      percentage_of_waiting_list_used:,
-    }
   end
 end

--- a/app/views/admin/homepage/index.html.erb
+++ b/app/views/admin/homepage/index.html.erb
@@ -29,25 +29,6 @@ end
           This can be changed in <%= link_to("settings", admin_settings_path, class: "govuk-link") %>.
         </p>
       <% end %>
-    <% elsif !settings.sign_up_enabled %>
-      <%= render "govuk_publishing_components/components/notice", {
-        title: "Sign ups are disabled",
-      } do %>
-        <p class="govuk-body">
-          All users who attempt to sign up will be denied. Only existing users
-          can login.
-          <%= link_to("Update settings", admin_settings_path, class: "govuk-link") %>.
-        </p>
-      <% end %>
-    <% elsif @waiting_list_user_stats[:percentage_of_waiting_list_used] >= 80 %>
-      <%= render "govuk_publishing_components/components/notice", {
-        title: "The waiting list is #{number_to_percentage(@waiting_list_user_stats[:percentage_of_waiting_list_used], precision: 0)} full",
-      } do %>
-        <p class="govuk-body">
-          There are <%= @waiting_list_user_stats[:current] %> users on the waiting list. The maximum allowed is <%= settings.max_waiting_list_places %>.
-          If you would like to increase the maximum places you can <%= link_to("update the setting", admin_settings_edit_max_waiting_list_places_path, class: "govuk-link") %>.
-        </p>
-      <% end %>
     <% end %>
   </div>
 </div>
@@ -70,30 +51,6 @@ end
       ],
     } %>
   </div>
-  <div class="govuk-grid-column-one-third">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Pilot users",
-      font_size: "m",
-      heading_level: 2,
-      margin_bottom: 4,
-    } %>
-
-    <%= render "govuk_publishing_components/components/list", {
-      visible_counters: true,
-      items: [
-        safe_join(["Instant access places: #{settings.instant_access_places} (",
-                   link_to("Update", admin_settings_path, class: "govuk-link"),
-                   ")"]),
-        safe_join(["Delayed access places: #{settings.delayed_access_places} (",
-                   link_to("Update", admin_settings_path, class: "govuk-link"),
-                   ")"]),
-        link_to("Add an early access user", new_admin_early_access_user_path, class: "govuk-link"),
-        link_to("Browse early access users (#{number_with_delimiter(@early_access_user_stats[:current])})", admin_early_access_users_path, class: "govuk-link"),
-        link_to("Add someone to the waiting list", new_admin_waiting_list_user_path, class: "govuk-link"),
-        link_to("Browse waiting list users (#{number_with_delimiter(@waiting_list_user_stats[:current])})", admin_waiting_list_users_path, class: "govuk-link"),
-      ],
-    } %>
-  </div>
   <% if dashboard_link_items.any? %>
     <div class="govuk-grid-column-one-third">
       <%= render "govuk_publishing_components/components/heading", {
@@ -109,62 +66,4 @@ end
       } %>
     </div>
   <% end %>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <%= render "govuk_publishing_components/components/summary_list", {
-      title: "Early access user stats",
-      heading_level: 2,
-      items: [
-        {
-          field: "Current",
-          value: link_to(number_with_delimiter(@early_access_user_stats[:current]), admin_early_access_users_path, class: "govuk-link"),
-        },
-        {
-          field: "Unsubscribed",
-          value: number_with_delimiter(@early_access_user_stats[:unsubscribed]),
-        },
-        {
-          field: "Admin deleted",
-          value: number_with_delimiter(@early_access_user_stats[:admin_deleted]),
-        },
-        {
-          field: "Total",
-          value: number_with_delimiter(@early_access_user_stats[:total]),
-        },
-      ],
-      borderless: true,
-    } %>
-  </div>
-
-  <div class="govuk-grid-column-one-half">
-    <%= render "govuk_publishing_components/components/summary_list", {
-      title: "Waiting list user stats",
-      heading_level: 2,
-      items: [
-        {
-          field: "Current",
-          value: link_to(number_with_delimiter(@waiting_list_user_stats[:current]), admin_waiting_list_users_path, class: "govuk-link"),
-        },
-        {
-          field: "Promoted to early access user",
-          value: number_with_delimiter(@waiting_list_user_stats[:promoted]),
-        },
-        {
-          field: "Unsubscribed",
-          value: number_with_delimiter(@waiting_list_user_stats[:unsubscribed]),
-        },
-        {
-          field: "Admin deleted",
-          value: number_with_delimiter(@waiting_list_user_stats[:admin_deleted]),
-        },
-        {
-          field: "Total",
-          value: number_with_delimiter(@waiting_list_user_stats[:total]),
-        },
-      ],
-      borderless: true,
-    } %>
-  </div>
 </div>

--- a/spec/requests/admin/homepage_spec.rb
+++ b/spec/requests/admin/homepage_spec.rb
@@ -16,33 +16,6 @@ RSpec.describe "Admin::HomepageController" do
       end
     end
 
-    context "when sign up is disabled" do
-      before { Settings.instance.update(public_access_enabled: true, sign_up_enabled: false) }
-
-      it "renders a notice" do
-        get admin_homepage_path
-        expect(response.body)
-          .to have_selector(".gem-c-notice", text: /Sign ups are disabled/)
-      end
-    end
-
-    context "when signups are enabled and the waiting list is 80% or more full" do
-      before do
-        create_list(:waiting_list_user, 4)
-        Settings.instance.update!(max_waiting_list_places: 5, sign_up_enabled: true)
-      end
-
-      it "renders a notice" do
-        get admin_homepage_path
-        expect(response.body).to have_selector(".gem-c-notice", text: /The waiting list is 80% full/)
-      end
-
-      it "renders a link to update the setting" do
-        get admin_homepage_path
-        expect(response.body).to have_link("update the setting", href: admin_settings_edit_max_waiting_list_places_path)
-      end
-    end
-
     context "when a user has the developer tools permission" do
       before do
         user = create(


### PR DESCRIPTION
Trello: https://trello.com/c/zhI0UIU3/2464-remove-earlyaccessuser-and-waitinglistuser-functionality-from-the-admin-area

This PR removes the @early_access_user_stats and @waiting_list_user_stats from the controller, strips out the panels from the view, and updates the homepage request spec, as part of the ongoing effort to remove EarlyAccess & WaitingList uses from the codebase
