### PR TITLE
Allow OpenSearch to be queried by Titan embedding

### DIFF
--- a/spec/factories/chunked_content_record_factory.rb
+++ b/spec/factories/chunked_content_record_factory.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     description { "Description" }
     plain_content { "Some content" }
     openai_embedding { [rand(-0.9...0.9)] * Search::ChunkedContentRepository::OPENAI_EMBEDDING_DIMENSIONS }
+    titan_embedding { [rand(-0.9...0.9)] * Search::ChunkedContentRepository::TITAN_EMBEDDING_DIMENSIONS }
 
     initialize_with { attributes }
   end

--- a/spec/lib/search/chunked_content_repository_spec.rb
+++ b/spec/lib/search/chunked_content_repository_spec.rb
@@ -207,9 +207,10 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
 
   describe "#search_by_embedding" do
     let(:openai_embedding) { mock_openai_embedding("How do i pay my tax?") }
+    let(:titan_embedding) { mock_titan_embedding("How do i get universal credit?") }
     let(:chunked_content_records) do
       [
-        build(:chunked_content_record, openai_embedding:),
+        build(:chunked_content_record, openai_embedding:, titan_embedding:),
         build(:chunked_content_record),
         build(:chunked_content_record),
       ]
@@ -219,14 +220,28 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
       populate_chunked_content_index(chunked_content_records)
     end
 
-    it "returns an array of Result objects" do
+    it "returns an array of Result objects for OpenAI embedding" do
       result = repository.search_by_embedding(
         openai_embedding,
         max_chunks: 10,
         llm_provider: :openai,
       )
       expected_attributes = chunked_content_records.first
-                                                   .except(:openai_embedding)
+                                                   .except(:openai_embedding, :titan_embedding)
+                                                   .merge(score: a_value_between(0.9, 1))
+
+      expect(result).to all be_a(Search::ChunkedContentRepository::Result)
+      expect(result.first).to have_attributes(**expected_attributes)
+    end
+
+    it "returns an array of Result objects for Titan embedding" do
+      result = repository.search_by_embedding(
+        titan_embedding,
+        max_chunks: 10,
+        llm_provider: :titan,
+      )
+      expected_attributes = chunked_content_records.first
+                                                   .except(:titan_embedding, :openai_embedding)
                                                    .merge(score: a_value_between(0.9, 1))
 
       expect(result).to all be_a(Search::ChunkedContentRepository::Result)
@@ -269,7 +284,7 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
     it "returns the correct chunk as a ChunkedContentRepository::Result" do
       chunk_result = repository.chunk(chunk_id)
       expect(chunk_result).to be_a(Search::ChunkedContentRepository::Result)
-        .and have_attributes(content_chunk.except(:openai_embedding))
+        .and have_attributes(content_chunk.except(:openai_embedding, :titan_embedding))
         .and have_attributes(_id: chunk_id)
     end
 

--- a/spec/lib/search/results_for_question/reranker_spec.rb
+++ b/spec/lib/search/results_for_question/reranker_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Search::ResultsForQuestion::Reranker do
   end
 
   def build_chunked_content_result(attributes)
-    defaults = build(:chunked_content_record).except(:openai_embedding)
+    defaults = build(:chunked_content_record).except(:openai_embedding, :titan_embedding)
     Search::ChunkedContentRepository::Result.new(**defaults.merge(attributes))
   end
 end

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -104,6 +104,13 @@ module StubBedrock
     }
   end
 
+  def mock_titan_embedding(text, dimensions: Search::ChunkedContentRepository::TITAN_EMBEDDING_DIMENSIONS)
+    # This returns a mock vector embedding which is deterministic based on the
+    # text given
+    random_generator = Random.new(text.bytes.sum)
+    dimensions.times.map { random_generator.rand }
+  end
+
   def bedrock_claude_text_response(response_text,
                                    user_message: nil,
                                    input_tokens: 10,


### PR DESCRIPTION
This extends the `ChunkedContentRepository` class to reflect OpenSearch
instances where we have a `titan_embedding` field containing the content
of a document embedded by Titan.

It follows the logic we currently have for OpenAI in that we have an
`titan_embedding` field in each OpenSearch document and the
`ChunkedContentRepository#search_by_embedding` method takes the provider
as an argument and queries against the relevant field.

This will allow us to add a Rake task that will retrieve documents from the
index via both the openai_embedding and titan_embedding fields, and then
be able to evaluate both.