### PR TITLE
Trigger guardrails when JailbreakChecker returns unexpected result 

### DIFF
--- a/spec/lib/guardrails/jailbreak_checker_spec.rb
+++ b/spec/lib/guardrails/jailbreak_checker_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe Guardrails::JailbreakChecker do
     }
 
     allow(Guardrails::OpenAI::JailbreakChecker).to receive(:call).and_return(result)
-    stub_openai_jailbreak_guardrails(input)
-
     described_class.call(input)
     expect(Guardrails::OpenAI::JailbreakChecker).to have_received(:call).with(input)
   end
@@ -44,8 +42,6 @@ RSpec.describe Guardrails::JailbreakChecker do
     }
 
     allow(Guardrails::Claude::JailbreakChecker).to receive(:call).and_return(result)
-    stub_openai_jailbreak_guardrails(input)
-
     described_class.call(input, :claude)
     expect(Guardrails::Claude::JailbreakChecker).to have_received(:call).with(input)
   end

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -52,10 +52,7 @@ module StubBedrock
 
   def bedrock_claude_jailbreak_guardrails_response(triggered: false)
     common_prompts = Rails.configuration.govuk_chat_private.llm_prompts.common
-    allow(common_prompts).to receive(:jailbreak_guardrails).and_return(
-      pass_value: "PassValue",
-      fail_value: "FailValue",
-    )
+    allow(common_prompts).to receive(:jailbreak_guardrails).and_return(pass_value: "PassValue")
 
     lambda do |context|
       response_text = if triggered

--- a/spec/support/stub_openai_chat.rb
+++ b/spec/support/stub_openai_chat.rb
@@ -141,10 +141,7 @@ module StubOpenAIChat
     )
 
     common_prompts = Rails.configuration.govuk_chat_private.llm_prompts.common
-    allow(common_prompts).to receive(:jailbreak_guardrails).and_return(
-      pass_value: "PassValue",
-      fail_value: "FailValue",
-    )
+    allow(common_prompts).to receive(:jailbreak_guardrails).and_return(pass_value: "PassValue")
 
     response = triggered ? "FailValue" : "PassValue"
 


### PR DESCRIPTION
## Description 

With Claude we don’t have the ability we had with OpenAI to specify that a model can only return a single token from a limited list of options (thus our ability to force a 0 or 1 response).

We therefore want to avoid a situation where the system raises an exception when the model reaches the max tokens limit, and passes back an unexpected value in the response for `llm_guardrail_result`.

We want to be able to see the response in full to see what the issue is so we've bumped the max_tokens to 50 in the prompt config in this [PR](https://github.com/alphagov/govuk_chat_private/pull/20).

This updates the jailbreak checker to only raise an exception for non-claude models.

## Trello card

https://trello.com/c/oMWS5Kgp/2511-change-jailbreak-guardrails-to-be-more-forgiving-for-claude
