### PR TITLE
Evaluation report: remove absolute URLs

### DIFF
--- a/lib/evaluation/report_generator.rb
+++ b/lib/evaluation/report_generator.rb
@@ -34,16 +34,12 @@ module Evaluation
       )
     end
 
-    def absolute_govuk_url(path)
-      Plek.website_root + path
-    end
-
     def build_retrieved_context(source)
       data = {
         title: source.title,
         used: source.used,
-        exact_path: absolute_govuk_url(source.exact_path),
-        base_path: absolute_govuk_url(source.base_path),
+        exact_path: source.exact_path,
+        base_path: source.base_path,
         content_chunk_id: source.content_chunk_id,
         content_chunk_available: false,
       }

--- a/spec/lib/evaluation/report_generator_spec.rb
+++ b/spec/lib/evaluation/report_generator_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
       expect(context).to eq({
         title: "Late payments",
         used: true,
-        exact_path: "https://www.test.gov.uk/vat-payments/late-payments",
-        base_path: "https://www.test.gov.uk/vat-payments",
+        exact_path: "/vat-payments/late-payments",
+        base_path: "/vat-payments",
         content_chunk_id: "id2",
         content_chunk_available: true,
         heading_hierarchy: ["VAT", "Late payments"],


### PR DESCRIPTION
DS have asked for the `exact_path` and `base_path` to be relative paths,
not absolute URLs:

> The ground-truth data I have just uses the OpenSearch exact_path/base_path
> without the root so to save me tidying it away again on my end if I
> want to use the paths, if we could just take it out in the rake task,
> that'd be great.
