### PR TITLE
Remove early access users and Smart Survey from BigQuery exports

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,12 +74,6 @@ module GovukChat
     config.openai_access_token = ENV["OPENAI_ACCESS_TOKEN"]
     config.openai_request_timeout = 45
 
-    config.smart_survey = Hashie::Mash.new(
-      survey_id: "1561650",
-      api_key: ENV["SMART_SURVEY_API_KEY"],
-      api_key_secret: ENV["SMART_SURVEY_API_KEY_SECRET"],
-    )
-
     config.answer_statuses = Hashie::Mash.new(YAML.load_file("#{__dir__}/answer_statuses.yml"))
     config.question_routing_labels = Hashie::Mash.new(YAML.load_file("#{__dir__}/question_routing_labels.yml"))
     config.search = Hashie::Mash.new(YAML.load_file("#{__dir__}/search.yml"))

--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -4,9 +4,5 @@ module Bigquery
   TABLES_TO_EXPORT = [
     ExportTable.new(name: "questions", time_partitioning_field: "created_at"),
     ExportTable.new(name: "answer_feedback", time_partitioning_field: "created_at"),
-    ExportTable.new(name: "early_access_users", time_partitioning_field: "created_at"),
-    ExportTable.new(name: "early_access_users_aggregates", time_partitioning_field: "exported_until"),
-    ExportTable.new(name: "waiting_list_users_aggregates", time_partitioning_field: "exported_until"),
-    ExportTable.new(name: "smart_survey_responses", time_partitioning_field: "exported_until"),
   ].freeze
 end

--- a/spec/lib/bigquery/individual_export_spec.rb
+++ b/spec/lib/bigquery/individual_export_spec.rb
@@ -50,63 +50,12 @@ RSpec.describe Bigquery::IndividualExport do
   end
 
   describe ".call" do
-    before do
-      allow(Rails.configuration).to receive(:smart_survey).and_return(
-        Hashie::Mash.new(
-          survey_id: "12345",
-          api_key: "test_smart_survey_username",
-          api_key_secret: "test_smart_survey_password",
-        ),
-      )
-    end
-
     it "can successfully return a Result for each table_name in Bigquery::TABLES_TO_EXPORT" do
-      stub_smart_survey_request
-
       results = Bigquery::TABLES_TO_EXPORT.map do |table|
         described_class.call(table.name)
       end
 
       expect(results).to all(be_a(described_class::Result))
-    end
-
-    context "when given a table name of 'smart_survey_responses'" do
-      it "returns a result with data up to the time of the smart survey request" do
-        freeze_time do
-          smart_survey_request = stub_smart_survey_request(responses: 10)
-
-          result = described_class.call("smart_survey_responses")
-
-          expect(smart_survey_request).to have_been_made
-          expect(result.count).to eq(1)
-
-          tempfile_json = JSON.parse(result.tempfile.read)
-          expect(tempfile_json).to match({ "completed_surveys" => 10,
-                                           "exported_until" => Time.current })
-        end
-      end
-
-      it "raises an error if a smart survey request fails" do
-        stub_smart_survey_request(status: 500)
-
-        expect { described_class.call("smart_survey_responses") }
-          .to raise_error(Faraday::Error)
-      end
-    end
-
-    context "when given a table name for aggregate statistics" do
-      let(:table_name) { "early_access_users_aggregates" }
-
-      it "returns a result with a single record containing the model's `aggregate_export_data` as JSON" do
-        export_until = Time.current
-
-        result = described_class.call(table_name, export_until:)
-
-        expect(result.count).to eq(1)
-
-        tempfile_json = JSON.parse(result.tempfile.read)
-        expect(tempfile_json).to match(EarlyAccessUser.aggregate_export_data(export_until))
-      end
     end
 
     context "when given a model table name" do
@@ -136,16 +85,5 @@ RSpec.describe Bigquery::IndividualExport do
         expect(first_json_record).to match(expected_json)
       end
     end
-  end
-
-  def stub_smart_survey_request(status: 200, responses: 1)
-    stub_request(:get, "https://api.smartsurvey.io/v1/surveys/12345")
-      .with(
-        headers: {
-          "Accept" => "application/json",
-          "Authorization" => "Basic #{Base64.strict_encode64('test_smart_survey_username:test_smart_survey_password').chomp}",
-        },
-      )
-      .to_return_json(status:, body: { responses: })
   end
 end

--- a/spec/lib/tasks/bigquery_spec.rb
+++ b/spec/lib/tasks/bigquery_spec.rb
@@ -23,15 +23,20 @@ RSpec.describe "rake bigquery tasks" do
 
     before do
       Rake::Task[task_name].reenable
-      stub_request(:get, /api.smartsurvey.io/)
-        .to_return_json(status: 200, body: { responses: 1 })
     end
 
     it "prints what it has exported" do
-      previous_export = create(:bigquery_export)
+      previous_export = create(:bigquery_export, exported_until: 2.hours.ago)
+      create(:answer, created_at: 1.hour.ago)
+      create(:answer_feedback, created_at: 1.hour.ago)
+
+      expected_counts = {
+        "questions" => 1,
+        "answer_feedback" => 1,
+      }
 
       tables_output = Bigquery::TABLES_TO_EXPORT.map do |table|
-        count = table.name =~ /(smart_survey_responses|aggregates)$/ ? 1 : 0
+        count = expected_counts[table.name]
         "Table #{table.name} (#{count})\n"
       end
 


### PR DESCRIPTION
This PR removes all BigQuery export functionality related to private beta features:
- Remove 4 ExportTable entries: early_access_users, early_access_users_aggregates, waiting_list_users_aggregates, and smart_survey_responses
- Remove Smart Survey API integration code and configuration
- Remove aggregate data export handling

This is part of the cleanup effort to remove private beta functionality that is no longer needed. The BigQuery exports now only include questions and answer_feedback tables.

Note: the aggregate_export_data methods in EarlyAccessUser and WaitingListUser models have not been removed as these models will be deleted entirely in another PR.