### PR TITLE
Update conversation history to be 90 days

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,7 @@ module GovukChat
     config.opensearch = config_for(:opensearch)
     config.conversations = Hashie::Mash.new(
       answer_timeout_in_seconds: 120,
-      max_question_age_days: 30,
+      max_question_age_days: 90,
       max_question_count: 500,
       max_questions_per_user: 70,
       question_warning_threshold: 20,

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -102,7 +102,7 @@ paths:
           description: |
             Returns a list of AnsweredQuestions with potentially one PendingQuestion.
             Is limited to returning 500 questions for a conversation and only
-            questions asked within last 30 days.
+            questions asked within last 90 days.
           content:
             application/json:
               schema:

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -572,6 +572,6 @@ RSpec.describe "ConversationsController" do
   def expect_conversation_id_set_on_cookie(conversation)
     cookie = cookies.get_cookie("conversation_id")
     expect(cookie.value).to eq(conversation.id)
-    expect(cookie.expires).to eq(30.days.from_now)
+    expect(cookie.expires).to eq(90.days.from_now)
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/vIxopPJY/2541-change-availability-of-answers-from-30-days-to-90-days

A product decision has been made today by Sam Dub that for the app beta we will extend the 30 days conversation history to be 90 days.

The simplest way to apply this is to apply it to both web and API, since we don't have an active web version where users will be affected by this.

A knock-on effect of this is that we will likely need to adjust our deletion task (that is currently not used) that deletes conversations after 3 months [1].

[1]: https://github.com/alphagov/govuk-chat/blob/0bc8a4a466f812124bb8c2c182e4d20bdb6e43eb/lib/tasks/date_retention.rake