### PR TITLE
Output answer strategy and embedding provider during evaluation rake task

### DIFF
--- a/lib/evaluation/report_generator.rb
+++ b/lib/evaluation/report_generator.rb
@@ -6,6 +6,7 @@ module Evaluation
       raise "File #{input_path} does not exist" unless File.exist?(input_path)
 
       questions = YAML.load_file(input_path)
+      answer_strategy = Rails.configuration.answer_strategy
 
       questions.map.with_index do |evaluation_question, index|
         yield questions.size, index + 1, evaluation_question if block_given?
@@ -19,6 +20,7 @@ module Evaluation
         {
           question: evaluation_question,
           answer: answer_json,
+          answer_strategy:,
           retrieved_context: answer.sources.flat_map(&method(:build_retrieved_context)),
         }
       end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -19,8 +19,12 @@ namespace :evaluation do
       raise msg
     end
 
-    ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.gov.uk"
+    answer_strategy = Rails.configuration.answer_strategy
+    embedding_provider = Rails.configuration.embedding_provider
 
+    puts "Generating report with answer strategy: #{answer_strategy} and embedding provider: #{embedding_provider}"
+
+    ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.gov.uk"
     results = Evaluation::ReportGenerator.call(input_path) do |total, current, evaluation_question|
       puts "(#{current} / #{total}): #{evaluation_question}"
     end

--- a/spec/lib/evaluation/report_generator_spec.rb
+++ b/spec/lib/evaluation/report_generator_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
         {
           question: "How do I pay VAT?",
           answer: hash_including("message" => "First answer from OpenAI"),
+          answer_strategy: "openai_structured_answer",
           retrieved_context: [
             hash_including(title: "Late payments", used: true),
             hash_including(title: "Pay your VAT bill online", used: true),
@@ -103,6 +104,7 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
         {
           question: "Do I need a visa?",
           answer: hash_including("message" => "Second answer from OpenAI"),
+          answer_strategy: "openai_structured_answer",
           retrieved_context: [hash_including(title: "Check if you need a visa", used: true)],
         },
       ])

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe "rake evaluation tasks" do
         .to raise_error(/Usage: evaluation:generate_report/)
     end
 
+    it "outputs the answer_strategy and embedding_provider to stdout" do
+      expect { Rake::Task[task_name].invoke("input.yml") }
+        .to output(/Generating report with answer strategy: openai_structured_answer and embedding provider: openai/).to_stdout
+    end
+
     it "generates the results as JSONL and prints them" do
       expect { Rake::Task[task_name].invoke("input.yml") }
         .to output(/#{Regexp.escape(jsonl)}/).to_stdout


### PR DESCRIPTION
## Description

As the answer strategy and embedding strategy are controlled by env variables it is easy to run the task expecting one thing and getting another. It is also quite a slow task so an early indication is good. Finally having the data of what it was when looking at the data is helpful for clarifying what was used to generate the data.

While it’s a bit of a shame the same data has to be repeated to every row, we don’t really have another option with the JSONL format.

## Trello card

https://trello.com/c/fFWFHfUC/2540-output-information-about-strategy-and-embedding-provider-for-the-evaluationgeneratereport-task