### PR TITLE
Admin panel: API access management

### DIFF
--- a/app/controllers/admin/settings/api_access_controller.rb
+++ b/app/controllers/admin/settings/api_access_controller.rb
@@ -1,0 +1,28 @@
+class Admin::Settings::ApiAccessController < Admin::BaseController
+  def edit
+    settings = Settings.instance
+    @form = Admin::Form::Settings::ApiAccessForm.new(
+      enabled: settings.api_access_enabled,
+    )
+  end
+
+  def update
+    @form = Admin::Form::Settings::ApiAccessForm.new(update_params)
+
+    if @form.valid?
+      @form.submit
+      redirect_to admin_settings_path, notice: "API access updated"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def update_params
+    params
+      .require(:api_access_form)
+      .permit(:enabled)
+      .merge(user: current_user)
+  end
+end

--- a/app/models/admin/form/settings/api_access_form.rb
+++ b/app/models/admin/form/settings/api_access_form.rb
@@ -1,0 +1,17 @@
+class Admin::Form::Settings::ApiAccessForm < Admin::Form::Settings::BaseForm
+  attribute :enabled, :boolean
+
+  def submit
+    return if settings.api_access_enabled == enabled
+
+    settings.locked_audited_update(user, action, author_comment) do
+      settings.api_access_enabled = enabled
+    end
+  end
+
+private
+
+  def action
+    "API access enabled set to #{enabled}"
+  end
+end

--- a/app/views/admin/settings/api_access/edit.html.erb
+++ b/app/views/admin/settings/api_access/edit.html.erb
@@ -1,0 +1,46 @@
+<%
+content_for(:title, "Edit API access")
+content_for(:title_context, "Settings")
+content_for(:active_navigation_item, admin_settings_path)
+content_for(:back_link, render("govuk_publishing_components/components/back_link", href: admin_settings_path))
+%>
+
+<%= render "shared/error_summary",
+  model: @form,
+  anchor_mappings: {
+    author_comment: "#api_access_form_author_comment",
+  } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_settings_edit_api_access_path, method: :patch do |f| %>
+      <%= render "govuk_publishing_components/components/radio", {
+        heading: "API access enabled",
+        heading_size: "l",
+        heading_level: 2,
+        margin_bottom: 8,
+        name: "api_access_form[enabled]",
+        hint: 'Be very cautious, setting this option to "No" will completely disable the GOV.UK Chat API for all users.',
+        items: [
+          {
+            value: "true",
+            text: "Yes",
+            checked: @form.enabled,
+
+          },
+          {
+            value: "false",
+            text: "No",
+            checked: !@form.enabled,
+          },
+        ],
+      } %>
+
+      <%= render "admin/settings/shared/author_comment", form: @form, setting: "api_access" %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Submit",
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -26,23 +26,42 @@ content_for(:active_navigation_item, admin_settings_path)
                          "permanently offline"
                        end
   %>
+  <div>
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "Public access",
+      id: "public-access",
+      heading_level: 2,
+      heading_size: "l",
+      items: [
+        {
+          field: "Enabled",
+          value: @settings.public_access_enabled ? "Yes" : "No - #{downtime_message}",
+          edit: {
+            href: admin_settings_edit_public_access_path,
+            link_text: "Edit",
+          },
+        },
+        {
+          field: "Description",
+          value: "Whether the public can use GOV.UK Chat.",
+        },
+      ],
+    } %>
+  </div>
+
   <%= render "govuk_publishing_components/components/summary_list", {
-    title: "Public access",
-    id: "public-access",
+    title: "API access",
+    id: "api-access",
     heading_level: 2,
     heading_size: "l",
     items: [
       {
         field: "Enabled",
-        value: @settings.public_access_enabled ? "Yes" : "No - #{downtime_message}",
-        edit: {
-          href: admin_settings_edit_public_access_path,
-          link_text: "Edit",
-        },
+        value: @settings.api_access_enabled ? "Yes" : "No",
       },
       {
         field: "Description",
-        value: "Whether the public can use GOV.UK Chat.",
+        value: "Whether the GOV.UK Chat API is enabled.",
       },
     ],
   } %>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -58,6 +58,10 @@ content_for(:active_navigation_item, admin_settings_path)
       {
         field: "Enabled",
         value: @settings.api_access_enabled ? "Yes" : "No",
+        edit: {
+          href: admin_settings_edit_api_access_path,
+          link_text: "Edit",
+        },
       },
       {
         field: "Description",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,9 @@ Rails.application.routes.draw do
       get "/public-access", to: "settings/public_access#edit", as: :settings_edit_public_access
       patch "/public-access", to: "settings/public_access#update"
 
+      get "/api-access", to: "settings/api_access#edit", as: :settings_edit_api_access
+      patch "/api-access", to: "settings/api_access#update"
+
       get "/audits", to: "settings#audits", as: :settings_audits
     end
   end

--- a/db/migrate/20250610103300_add_api_access_enabled_to_settings.rb
+++ b/db/migrate/20250610103300_add_api_access_enabled_to_settings.rb
@@ -1,0 +1,5 @@
+class AddApiAccessEnabledToSettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :settings, :api_access_enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_160109) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_10_103300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -165,6 +165,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_160109) do
     t.datetime "updated_at", null: false
     t.boolean "public_access_enabled", default: true
     t.enum "downtime_type", default: "temporary", enum_type: "settings_downtime_type"
+    t.boolean "api_access_enabled", default: true
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/spec/models/admin/form/settings/api_access_form_spec.rb
+++ b/spec/models/admin/form/settings/api_access_form_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Admin::Form::Settings::ApiAccessForm do
+  describe "#submit" do
+    it "updates the settings api_access_enabled attribute" do
+      settings = create(:settings, api_access_enabled: true)
+      form = described_class.new(enabled: false)
+      expect { form.submit }
+        .to change { settings.reload.api_access_enabled }.to(false)
+    end
+
+    it "doesn't persist an audit if api_access_enabled isn't changed" do
+      create(:settings, api_access_enabled: false)
+      form = described_class.new(enabled: false)
+      expect { form.submit }.not_to change(SettingsAudit, :count)
+    end
+
+    it "mentions API access in the action when disabling api access" do
+      create(:settings, api_access_enabled: true)
+      described_class.new(enabled: false).submit
+      expect(SettingsAudit.last.action).to eq("API access enabled set to false")
+    end
+  end
+end

--- a/spec/requests/admin/settings/api_access_spec.rb
+++ b/spec/requests/admin/settings/api_access_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "Admin::Settings::ApiAccessController" do
+  describe "GET :edit" do
+    it "renders the edit page successfully" do
+      get admin_settings_edit_api_access_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body)
+        .to have_selector(".govuk-heading-xl", text: "Edit API access")
+    end
+  end
+
+  describe "PATCH :update" do
+    it "updates the api_access_enabled, then redirects to the settings page" do
+      settings = create(:settings, api_access_enabled: false)
+
+      expect {
+        patch admin_settings_edit_api_access_path,
+              params: { api_access_form: { enabled: "true" } }
+      }
+        .to change(SettingsAudit, :count).by(1)
+
+      expect(response).to redirect_to(admin_settings_path)
+      expect(flash[:notice]).to eq("API access updated")
+      expect(settings.reload).to have_attributes(api_access_enabled: true)
+    end
+  end
+end

--- a/spec/system/admin/user_updates_settings_spec.rb
+++ b/spec/system/admin/user_updates_settings_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Admin user updates settings" do
     and_i_disable_public_access
     then_i_see_that_public_access_is_disabled
 
+    when_i_click_the_edit_link_for_api_access
+    and_i_disable_api_access
+    then_i_see_that_api_access_is_disabled
+
     when_i_click_on_the_audits_link
     then_i_can_see_the_audits_for_my_changes
   end
@@ -43,6 +47,10 @@ RSpec.describe "Admin user updates settings" do
     within("#public-access") { click_on "Edit Enabled" }
   end
 
+  def when_i_click_the_edit_link_for_api_access
+    within("#api-access") { click_on "Edit Enabled" }
+  end
+
   def and_i_disable_public_access
     choose "No"
     choose "Permanent"
@@ -50,9 +58,21 @@ RSpec.describe "Admin user updates settings" do
     click_on "Submit"
   end
 
+  def and_i_disable_api_access
+    choose "No"
+    fill_in "Comment (optional)", with: "Reason for disabling API access"
+    click_on "Submit"
+  end
+
   def then_i_see_that_public_access_is_disabled
     within("#public-access") do
       expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled No - permanently offline")
+    end
+  end
+
+  def then_i_see_that_api_access_is_disabled
+    within("#api-access") do
+      expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled No")
     end
   end
 
@@ -64,5 +84,6 @@ RSpec.describe "Admin user updates settings" do
     expect(page)
       .to have_content("Public access enabled set to false, downtime type permanent")
       .and have_content("Reason for disabling public access")
+      .and have_content("API access enabled set to false")
   end
 end

--- a/spec/system/admin/user_updates_settings_spec.rb
+++ b/spec/system/admin/user_updates_settings_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Admin user updates settings" do
 
     when_i_visit_the_settings_page
     and_i_should_see_the_public_access_enabled_setting_is_enabled
+    and_i_should_see_the_api_access_enabled_setting_is_enabled
 
     when_i_click_the_edit_link_for_public_access
     and_i_disable_public_access
@@ -28,6 +29,12 @@ RSpec.describe "Admin user updates settings" do
 
   def and_i_should_see_the_public_access_enabled_setting_is_enabled
     within("#public-access") do
+      expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled Yes")
+    end
+  end
+
+  def and_i_should_see_the_api_access_enabled_setting_is_enabled
+    within("#api-access") do
       expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled Yes")
     end
   end


### PR DESCRIPTION

https://trello.com/c/pnENCZ5f/2529

Adds the necessary setting and admin panel controls to manage access to the API.

This is just the first step in the process; changing the setting doesn't actually do anything yet, that'll come later.

To test this, you can just go to the admin panel and toggle the setting on and off, making sure it saves correctly and creates the necessary audit log.

Note that we're not setting a downtime type like we do for public access; that's by design.