### PR TITLE
Associate web conversation with Signon user

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -37,7 +37,7 @@ class ConversationsController < BaseController
   end
 
   def update
-    @conversation ||= Conversation.new
+    @conversation ||= Conversation.new(signon_user: current_user, source: :web)
     @create_question = Form::CreateQuestion.new(user_question_params.merge(conversation: @conversation))
 
     if @create_question.valid?
@@ -111,7 +111,8 @@ private
     return if cookies[:conversation_id].blank?
 
     @conversation = Conversation.active
-                                .find_by!(id: cookies[:conversation_id], source: :web)
+                                .where(signon_user: current_user, source: :web)
+                                .find_by!(id: cookies[:conversation_id])
     set_conversation_cookie(@conversation)
   rescue ActiveRecord::RecordNotFound
     cookies.delete(:conversation_id)

--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -62,9 +62,9 @@ module Admin
       ].compact
 
       signon_user = conversation.signon_user
-      if signon_user.present? && conversation.source_api?
+      if signon_user.present?
         rows << {
-          field: "API user",
+          field: "Signon user",
           value: safe_join([
             signon_user.name,
             " (",

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -143,10 +143,10 @@ RSpec.describe Admin::QuestionsHelper do
 
     it "returns a row with a link to filter the questions table by the signon user" do
       signon_user = create(:signon_user)
-      conversation.update!(signon_user:, source: :api)
+      conversation.update!(signon_user:)
       result = helper.question_show_summary_list_rows(question, nil, 1, 1)
 
-      row = result.find { |r| r[:field] == "API user" }
+      row = result.find { |r| r[:field] == "Signon user" }
       expect(row[:value])
         .to include(conversation.signon_user.name)
         .and have_link(

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -1,4 +1,9 @@
 module SystemSpecHelpers
+  def given_i_am_signed_in
+    @signon_user = create(:signon_user)
+    login_as(@signon_user)
+  end
+
   def given_i_am_using_the_claude_structured_answer_strategy
     allow(Rails.configuration)
       .to receive(:answer_strategy)

--- a/spec/system/conversation_js_features_spec.rb
+++ b/spec/system/conversation_js_features_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dismiss_cookie_banner, :js do
   scenario "questions with answers" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_a_first_question
     then_i_see_the_first_question_was_accepted
 
@@ -15,7 +16,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "client side validation" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_an_empty_question
     then_i_see_a_presence_validation_message
 
@@ -24,7 +26,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "server side validation" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_a_question_with_pii
     then_i_see_a_pii_validation_message
 
@@ -33,7 +36,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "reloading the page while an answer is pending" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_a_first_question
     then_i_see_the_first_question_was_accepted
 
@@ -43,7 +47,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "User gives feedback on an answer" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_a_first_question
     then_i_see_the_first_question_was_accepted
 
@@ -53,7 +58,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "character limits" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_type_in_a_question_approaching_the_character_count_limit
     then_i_see_a_character_count_warning
 
@@ -62,7 +68,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "loading messages" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     when_i_enter_a_first_question_with_a_slow_response
     then_i_see_a_question_loading_message
 
@@ -75,7 +82,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "showing clear chat link in navigation" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     then_i_cant_see_the_clear_chat_link
 
     when_i_enter_a_first_question
@@ -84,7 +92,8 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
   end
 
   scenario "print link is added to navigation" do
-    given_i_have_confirmed_i_understand_chat_risks
+    given_i_am_signed_in
+    and_i_have_confirmed_i_understand_chat_risks
     then_i_see_a_print_link_in_the_menu
   end
 
@@ -97,7 +106,7 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
 
   def when_i_enter_a_first_question_with_a_slow_response
     @first_question = "How do I setup a workplace pension?"
-    conversation = build(:conversation)
+    conversation = build(:conversation, signon_user: @signon_user)
     prepared_question = create(:question, message: @first_question, conversation:)
 
     allow(Question).to receive(:new).and_return(prepared_question)
@@ -285,10 +294,6 @@ RSpec.describe "Conversation JavaScript features", :chunked_content_index, :dism
     end
 
     expect(page).to have_button("Print or save this chat")
-  end
-
-  def and_i_have_an_active_conversation
-    create(:conversation)
   end
 
   def when_i_visit_the_conversation_page

--- a/spec/system/user_clears_chat_spec.rb
+++ b/spec/system/user_clears_chat_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "User clears chat" do
   scenario do
-    given_i_have_an_active_conversation_with_an_answered_question
+    given_i_am_signed_in
+    and_i_have_an_active_conversation_with_an_answered_question
     and_i_visit_the_conversation_page
     when_i_click_the_clear_chat_link
     and_i_cancel
@@ -10,8 +11,8 @@ RSpec.describe "User clears chat" do
     then_i_cannot_see_my_previous_questions_and_answer
   end
 
-  def given_i_have_an_active_conversation_with_an_answered_question
-    @conversation = create(:conversation)
+  def and_i_have_an_active_conversation_with_an_answered_question
+    @conversation = create(:conversation, signon_user: @signon_user)
     set_rack_cookie(:conversation_id, @conversation.id)
     answer = build(:answer, message: "Example answer")
     create(:question, answer:, conversation: @conversation, message: "Example question")

--- a/spec/system/user_gives_feedback_on_answer_spec.rb
+++ b/spec/system/user_gives_feedback_on_answer_spec.rb
@@ -1,13 +1,14 @@
 RSpec.describe "User gives feedback on an answer" do
   scenario do
-    given_i_have_an_active_conversation_with_an_answered_question
+    given_i_am_signed_in
+    and_i_have_an_active_conversation_with_an_answered_question
     when_i_visit_the_conversation_page
     and_i_click_that_the_answer_was_useful
     then_i_see_that_my_feedback_was_submitted
   end
 
-  def given_i_have_an_active_conversation_with_an_answered_question
-    @conversation = create(:conversation)
+  def and_i_have_an_active_conversation_with_an_answered_question
+    @conversation = create(:conversation, signon_user: @signon_user)
     set_rack_cookie(:conversation_id, @conversation.id)
     create(:question, :with_answer, conversation: @conversation)
   end


### PR DESCRIPTION
## Description

We associate API conversations with a signon user to ensure we track who initiated the conversation. This updates the web version to do the same for consistency.

It also updates the show question page to show the Signon user for conversations created via the web or API and updates the text from "API user" to "Signon user"

## Screenshot

<img width="585" alt="image" src="https://github.com/user-attachments/assets/50b224fd-79a5-4ff8-8599-5a843d76c296" />

## Trello card

https://trello.com/c/5hAzumge/2530-store-when-signon-users-interact-with-web-interface