### PR TITLE
Remove unused Heroku early access env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,9 +28,6 @@
     "AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION": {
       "value": "true"
     },
-    "AVAILABLE_WITHOUT_EARLY_ACCESS_AUTHENTICATION": {
-      "value": "true"
-    },
     "OPENAI_ACCESS_TOKEN": {
       "required": true
     },


### PR DESCRIPTION
## Description

While working on something else i noticed that this isn't being used for anything anymore so we can remove it.