### PR TITLE
Remove early access from introduction component

### DIFF
--- a/app/assets/stylesheets/components/_chat-introduction.scss
+++ b/app/assets/stylesheets/components/_chat-introduction.scss
@@ -7,10 +7,6 @@
   }
 }
 
-.app-c-chat-introduction--error {
-  padding-top: 0; // top padding needs to be removed when error summary component is rendered
-}
-
 .app-c-chat-introduction__info_text {
   margin-top: govuk-spacing(8);
 

--- a/app/views/components/_chat_introduction.html.erb
+++ b/app/views/components/_chat_introduction.html.erb
@@ -1,74 +1,27 @@
 <%
-  early_access ||= false
-  signed_in_user_email ||= nil
-  input_error_items ||= []
-  input_value ||= nil
-  form_url = Rails.application.routes.url_helpers.homepage_path
   start_button_href ||= Rails.application.routes.url_helpers.onboarding_limitations_path
-
-  wrapper_classes = "app-c-chat-introduction"
-  wrapper_classes += " app-c-chat-introduction--error" if input_error_items.any?
   info_text_classes = "app-c-chat-introduction__info_text govuk-body"
-
-  title = signed_in_user_email ? "GOV.UK Chat" : "Try GOV.UK Chat"
 %>
 
-<%= content_tag :div, class: wrapper_classes do %>
+<%= content_tag :div, class: "app-c-chat-introduction" do %>
   <%= render "components/chat_introduction_title", {
-    title:,
+    title: "Try GOV.UK Chat",
     standfirst_paragraphs: ["An experimental new way to find answers to your business questions, powered by AI"],
   } %>
 
-  <% if signed_in_user_email %>
-    <%= render "components/blue_button", {
-      text: "Return to chat",
-      href: start_button_href,
-      start: true,
-      aria_describedby: "info-text",
-    } %>
+  <%= render "components/blue_button", {
+    text: "Try GOV.UK Chat",
+    href: start_button_href,
+    start: true,
+    aria_describedby: "info-text",
+    data_attributes: {
+      "module": "ga4-link-tracker",
+      "ga4-link": '{ "event_name": "navigation", "type": "start button", "index_link": 1, "index_total": 1, "section": "Landing page" }',
+    },
+  } %>
 
-    <% info_text = "You are currently signed in with #{signed_in_user_email}." %>
-    <%= content_tag(:p, info_text, {id: "info-text", class: info_text_classes}) %>
-  <% elsif early_access %>
-    <div class="govuk-!-width-three-quarters">
-      <%= form_with url: form_url, class: "app-c-chat-introduction__form", authenticity_token: false do |f| %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Enter your email to sign up or get a new link for GOV.UK Chat",
-          },
-          name: "sign_in_or_up_form[email]",
-          id: "sign_in_or_up_form_email",
-          value: input_value,
-          heading_level: 2,
-          heading_size: "m",
-          error_items: input_error_items,
-          describedby: "info-text",
-        } %>
-
-        <%= render "components/blue_button", {
-          text: "Get started",
-          start: true,
-        } %>
-      <% end %>
-
-      <% info_text = "By continuing, you consent to your email being used to provide access to the tool." %>
-      <%= content_tag(:p, info_text, { id: "info-text", class: info_text_classes }) %>
-    </div>
-  <% else %>
-    <%= render "components/blue_button", {
-      text: "Try GOV.UK Chat",
-      href: start_button_href,
-      start: true,
-      aria_describedby: "info-text",
-      data_attributes: {
-        "module": "ga4-link-tracker",
-        "ga4-link": '{ "event_name": "navigation", "type": "start button", "index_link": 1, "index_total": 1, "section": "Landing page" }',
-      },
-    } %>
-
-    <% info_text = "Your chat history will be available for #{Rails.configuration.conversations.max_question_age_days} days" %>
-    <div class="govuk-!-width-three-quarters">
-      <%= content_tag(:p, info_text, { id: "info-text", class: info_text_classes}) %>
-    </div>
-  <% end %>
+  <% info_text = "Your chat history will be available for #{Rails.configuration.conversations.max_question_age_days} days" %>
+  <div class="govuk-!-width-three-quarters">
+    <%= content_tag(:p, info_text, { id: "info-text", class: info_text_classes}) %>
+  </div>
 <% end %>

--- a/app/views/components/docs/chat_introduction.yml
+++ b/app/views/components/docs/chat_introduction.yml
@@ -26,20 +26,3 @@ shared_accessibility_criteria:
   - link
 examples:
   default:
-  with_early_access:
-    data:
-      early_access: true
-  early_access_with_input_error_items:
-    data:
-      early_access: true
-      input_error_items:
-        - text: "Error item 1"
-        - text: "Error item 2"
-  early_access_with_input_value:
-    data:
-      early_access: true
-      input_value: "Example input value"
-  with_signed_in_user:
-    data:
-      signed_in_user_email: "user@example.com"
-      start_button_href: "/chat/conversation"

--- a/spec/views/components/_chat_introduction.html.erb_spec.rb
+++ b/spec/views/components/_chat_introduction.html.erb_spec.rb
@@ -11,37 +11,4 @@ RSpec.describe "components/_chat_introduction.html.erb" do
       .and have_link("Try GOV.UK Chat")
       .and have_selector("#info-text", text: "Your chat history will be available for #{max_days} days")
   end
-
-  context "when early_access is true" do
-    it "renders the chat introduction component with an email address form" do
-      render("components/chat_introduction", early_access: true)
-
-      expect(rendered)
-        .to have_selector(".app-c-chat-introduction")
-        .and have_text("Try GOV.UK Chat")
-        .and have_selector(".app-c-chat-introduction__form")
-        .and have_selector(".app-c-chat-introduction__form label", text: "Enter your email to sign up or get a new link for GOV.UK Chat")
-        .and have_selector(".app-c-chat-introduction__form input[name='sign_in_or_up_form[email]']")
-        .and have_selector(".app-c-chat-introduction__form input[aria-describedby~=info-text]")
-        .and have_selector(".app-c-blue-button[type='submit']", text: "Get started")
-        .and have_text("By continuing, you consent to your email being used to provide access to the tool.")
-    end
-
-    it "renders the email input with error items when 'input_error_items' are passed in" do
-      render("components/chat_introduction", {
-        early_access: true,
-        input_error_items: [{ text: "Enter an email address" }],
-      })
-
-      expect(rendered)
-        .to have_selector(".app-c-chat-introduction__form .govuk-error-message", text: /Enter an email address/)
-    end
-
-    it "sets the value of the email address input when an input_value is passed in" do
-      render("components/chat_introduction", early_access: true, input_value: "test@email.com")
-
-      expect(rendered)
-        .to have_selector(".app-c-chat-introduction__form input[value='test@email.com']")
-    end
-  end
 end


### PR DESCRIPTION
## Description

This still has logic for optionally rendering a form with an email input. We're no longer using this so we can strip it out the component and remove any associated styles.