### PR TITLE
Rename public_access to web_access

### DIFF
--- a/app/controllers/admin/settings/public_access_controller.rb
+++ b/app/controllers/admin/settings/public_access_controller.rb
@@ -1,13 +1,13 @@
 class Admin::Settings::PublicAccessController < Admin::BaseController
   def edit
     settings = Settings.instance
-    @form = Admin::Form::Settings::PublicAccessForm.new(
+    @form = Admin::Form::Settings::WebAccessForm.new(
       enabled: settings.public_access_enabled,
     )
   end
 
   def update
-    @form = Admin::Form::Settings::PublicAccessForm.new(update_params)
+    @form = Admin::Form::Settings::WebAccessForm.new(update_params)
 
     if @form.valid?
       @form.submit
@@ -21,7 +21,7 @@ private
 
   def update_params
     params
-      .require(:public_access_form)
+      .require(:web_access_form)
       .permit(:enabled, :author_comment)
       .merge(user: current_user)
   end

--- a/app/controllers/admin/settings/web_access_controller.rb
+++ b/app/controllers/admin/settings/web_access_controller.rb
@@ -1,8 +1,8 @@
-class Admin::Settings::PublicAccessController < Admin::BaseController
+class Admin::Settings::WebAccessController < Admin::BaseController
   def edit
     settings = Settings.instance
     @form = Admin::Form::Settings::WebAccessForm.new(
-      enabled: settings.public_access_enabled,
+      enabled: settings.web_access_enabled,
     )
   end
 
@@ -11,7 +11,7 @@ class Admin::Settings::PublicAccessController < Admin::BaseController
 
     if @form.valid?
       @form.submit
-      redirect_to admin_settings_path, notice: "Public access updated"
+      redirect_to admin_settings_path, notice: "Web access updated"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,12 +1,12 @@
 class BaseController < ApplicationController
   before_action :ensure_signon_user_if_required
-  before_action :check_chat_public_access
+  before_action :check_chat_web_access
   helper_method :settings
 
 private
 
-  def check_chat_public_access
-    return if settings.public_access_enabled
+  def check_chat_web_access
+    return if settings.web_access_enabled
 
     expires_in(1.minute, public: true) unless Rails.env.development?
     request.session_options[:skip] = true

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,7 +1,7 @@
 class ErrorsController < BaseController
   skip_before_action :verify_authenticity_token
   skip_before_action :ensure_signon_user_if_required
-  skip_before_action :check_chat_public_access
+  skip_before_action :check_chat_web_access
   after_action { response.headers["No-Fallback"] = "true" }
 
   def bad_request

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,5 @@
 class StaticController < BaseController
-  skip_before_action :check_chat_public_access, except: %i[support]
+  skip_before_action :check_chat_web_access, except: %i[support]
   before_action :cache_cookieless_requests
 
   def support; end

--- a/app/models/admin/form/settings/web_access_form.rb
+++ b/app/models/admin/form/settings/web_access_form.rb
@@ -1,4 +1,4 @@
-class Admin::Form::Settings::PublicAccessForm < Admin::Form::Settings::BaseForm
+class Admin::Form::Settings::WebAccessForm < Admin::Form::Settings::BaseForm
   attribute :enabled, :boolean
 
   def submit

--- a/app/models/admin/form/settings/web_access_form.rb
+++ b/app/models/admin/form/settings/web_access_form.rb
@@ -4,16 +4,16 @@ class Admin::Form::Settings::WebAccessForm < Admin::Form::Settings::BaseForm
   def submit
     validate!
 
-    return if settings.public_access_enabled == enabled
+    return if settings.web_access_enabled == enabled
 
     settings.locked_audited_update(user, action, author_comment) do
-      settings.public_access_enabled = enabled
+      settings.web_access_enabled = enabled
     end
   end
 
 private
 
   def action
-    "Public access enabled set to #{enabled}"
+    "Web access enabled set to #{enabled}"
   end
 end

--- a/app/views/admin/homepage/index.html.erb
+++ b/app/views/admin/homepage/index.html.erb
@@ -18,9 +18,9 @@ end
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% if !settings.public_access_enabled %>
+    <% if !settings.web_access_enabled %>
       <%= render "govuk_publishing_components/components/notice", {
-        title: "Public access to chat is disabled",
+        title: "Web access to chat is disabled",
       } do %>
         <%= render "govuk_publishing_components/components/warning_text", {
           text: "All users attempting to use chat will receive an error response",

--- a/app/views/admin/settings/public_access/edit.html.erb
+++ b/app/views/admin/settings/public_access/edit.html.erb
@@ -19,7 +19,7 @@ content_for(:back_link, render("govuk_publishing_components/components/back_link
         heading_size: "l",
         heading_level: 2,
         margin_bottom: 8,
-        name: "public_access_form[enabled]",
+        name: "web_access_form[enabled]",
         hint: 'Be very cautious, setting this option to "No" will prevent users from accessing GOV.UK Chat.',
         items: [
           {
@@ -36,7 +36,7 @@ content_for(:back_link, render("govuk_publishing_components/components/back_link
         ],
       } %>
 
-      <%= render "admin/settings/shared/author_comment", form: @form, setting: "public_access" %>
+      <%= render "admin/settings/shared/author_comment", form: @form, setting: "web_access" %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Submit",

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -21,22 +21,22 @@ content_for(:active_navigation_item, admin_settings_path)
 <div class="govuk-!-margin-bottom-8">
   <div>
     <%= render "govuk_publishing_components/components/summary_list", {
-      title: "Public access",
-      id: "public-access",
+      title: "Web access",
+      id: "web-access",
       heading_level: 2,
       heading_size: "l",
       items: [
         {
           field: "Enabled",
-          value: @settings.public_access_enabled ? "Yes" : "No",
+          value: @settings.web_access_enabled ? "Yes" : "No",
           edit: {
-            href: admin_settings_edit_public_access_path,
+            href: admin_settings_edit_web_access_path,
             link_text: "Edit",
           },
         },
         {
           field: "Description",
-          value: "Whether the public can use GOV.UK Chat.",
+          value: "Whether the GOV.UK Chat web app is enabled.",
         },
       ],
     } %>

--- a/app/views/admin/settings/web_access/edit.html.erb
+++ b/app/views/admin/settings/web_access/edit.html.erb
@@ -1,5 +1,5 @@
 <%
-content_for(:title, "Edit public access")
+content_for(:title, "Edit web access")
 content_for(:title_context, "Settings")
 content_for(:active_navigation_item, admin_settings_path)
 content_for(:back_link, render("govuk_publishing_components/components/back_link", href: admin_settings_path))
@@ -8,14 +8,14 @@ content_for(:back_link, render("govuk_publishing_components/components/back_link
 <%= render "shared/error_summary",
   model: @form,
   anchor_mappings: {
-    author_comment: "#public_access_form_author_comment",
+    author_comment: "#web_access_form_author_comment",
   } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: admin_settings_edit_public_access_path, method: :patch do |f| %>
+    <%= form_with url: admin_settings_edit_web_access_path, method: :patch do |f| %>
       <%= render "govuk_publishing_components/components/radio", {
-        heading: "Public access enabled",
+        heading: "Web access enabled",
         heading_size: "l",
         heading_level: 2,
         margin_bottom: 8,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   browser_title = (content_for?(:browser_title) ? yield(:browser_title) : yield(:title)).presence
   page_title = (content_for?(:page_title) ? yield(:page_title) : yield(:title)).presence
 
-  public_access_enabled = settings.public_access_enabled? rescue true
+  web_access_enabled = settings.web_access_enabled? rescue true
 
   header_navigation_items = [
     {
@@ -22,7 +22,7 @@
     ({
       href: support_url,
       text: "Help and support",
-    } if public_access_enabled),
+    } if web_access_enabled),
   ].compact
 
   footer_link_items = [
@@ -33,7 +33,7 @@
     ({
       href: support_url,
       text: "Help and support",
-    } if public_access_enabled),
+    } if web_access_enabled),
     {
       href: privacy_url,
       text: "Privacy",

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,7 +1,7 @@
 <%
   content_for(:title, "About GOV.UK Chat")
   content_for(:back_link, render("govuk_publishing_components/components/back_link", text: "Back to start page", href: homepage_path))
-  support_href = settings.public_access_enabled? ? support_path : "https://surveys.publishing.service.gov.uk/s/govuk-chat-support/"
+  support_href = settings.web_access_enabled? ? support_path : "https://surveys.publishing.service.gov.uk/s/govuk-chat-support/"
 %>
 
 <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,8 @@ Rails.application.routes.draw do
     scope :settings do
       get "", to: "settings#show", as: :settings
 
-      get "/public-access", to: "settings/public_access#edit", as: :settings_edit_public_access
-      patch "/public-access", to: "settings/public_access#update"
+      get "/web-access", to: "settings/web_access#edit", as: :settings_edit_web_access
+      patch "/web-access", to: "settings/web_access#update"
 
       get "/api-access", to: "settings/api_access#edit", as: :settings_edit_api_access
       patch "/api-access", to: "settings/api_access#update"

--- a/db/migrate/20250612081130_add_web_access_enabled_to_settings.rb
+++ b/db/migrate/20250612081130_add_web_access_enabled_to_settings.rb
@@ -1,0 +1,5 @@
+class AddWebAccessEnabledToSettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :settings, :web_access_enabled, :boolean, default: true
+  end
+end

--- a/db/migrate/20250612095735_remove_public_access_from_settings.rb
+++ b/db/migrate/20250612095735_remove_public_access_from_settings.rb
@@ -1,0 +1,5 @@
+class RemovePublicAccessFromSettings < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :settings, :public_access_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_11_101238) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_12_081130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_101238) do
     t.datetime "updated_at", null: false
     t.boolean "public_access_enabled", default: true
     t.boolean "api_access_enabled", default: true
+    t.boolean "web_access_enabled", default: true
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_12_081130) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_12_095735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -109,7 +109,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_081130) do
     t.integer "singleton_guard", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "public_access_enabled", default: true
     t.boolean "api_access_enabled", default: true
     t.boolean "web_access_enabled", default: true
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true

--- a/spec/models/admin/form/settings/web_access_form_spec.rb
+++ b/spec/models/admin/form/settings/web_access_form_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::Form::Settings::PublicAccessForm do
+RSpec.describe Admin::Form::Settings::WebAccessForm do
   describe "valid?" do
     it "returns false when invalid" do
       form = described_class.new(author_comment: "a" * 256)

--- a/spec/models/admin/form/settings/web_access_form_spec.rb
+++ b/spec/models/admin/form/settings/web_access_form_spec.rb
@@ -12,23 +12,23 @@ RSpec.describe Admin::Form::Settings::WebAccessForm do
       expect { form.submit }.to raise_error(ActiveModel::ValidationError)
     end
 
-    it "updates the settings public_access_enabled" do
-      settings = create(:settings, public_access_enabled: true)
+    it "updates the settings web_access_enabled" do
+      settings = create(:settings, web_access_enabled: true)
       form = described_class.new(enabled: false)
       expect { form.submit }
-        .to change { settings.reload.public_access_enabled }.to(false)
+        .to change { settings.reload.web_access_enabled }.to(false)
     end
 
-    it "doesn't persist an audit if public_access_enabled isn't changed" do
-      create(:settings, public_access_enabled: false)
+    it "doesn't persist an audit if web_access_enabled isn't changed" do
+      create(:settings, web_access_enabled: false)
       form = described_class.new(enabled: false)
       expect { form.submit }.not_to change(SettingsAudit, :count)
     end
 
-    it "mentions public access in the action when disabling public access" do
-      create(:settings, public_access_enabled: true)
+    it "mentions web access in the action when disabling web access" do
+      create(:settings, web_access_enabled: true)
       described_class.new(enabled: false).submit
-      expect(SettingsAudit.last.action).to eq("Public access enabled set to false")
+      expect(SettingsAudit.last.action).to eq("Web access enabled set to false")
     end
   end
 end

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Settings do
 
   describe "#locked_audited_update" do
     let(:audit_user) { build(:signon_user) }
-    let(:audit_action) { "Public access enabled set to true." }
+    let(:audit_action) { "Web access enabled set to true." }
     let(:audit_comment) { "We're going live." }
     let(:call_locked_audit_update) do
       settings.locked_audited_update(
@@ -30,21 +30,21 @@ RSpec.describe Settings do
         audit_action,
         audit_comment,
       ) do
-        settings.public_access_enabled = true
+        settings.web_access_enabled = true
       end
     end
-    let(:settings) { create(:settings, public_access_enabled: false) }
+    let(:settings) { create(:settings, web_access_enabled: false) }
 
     it "locks the settings instance to cope with concurrent edits" do
       expect(settings).to receive(:with_lock).and_call_original
       call_locked_audit_update
-      expect(settings.reload.public_access_enabled).to be(true)
+      expect(settings.reload.web_access_enabled).to be(true)
     end
 
     it "persists a settings audit based on the arguments passed in" do
       expect { call_locked_audit_update }
         .to change(SettingsAudit, :count).by(1)
-        .and change { settings.reload.public_access_enabled }.to(true)
+        .and change { settings.reload.web_access_enabled }.to(true)
       expect(SettingsAudit.includes(:user).last).to have_attributes(
         user: audit_user,
         action: audit_action,

--- a/spec/requests/admin/homepage_spec.rb
+++ b/spec/requests/admin/homepage_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe "Admin::HomepageController" do
       expect(response.body).to have_content("Browse questions")
     end
 
-    context "when public access is disabled" do
-      before { Settings.instance.update(public_access_enabled: false) }
+    context "when web access is disabled" do
+      before { Settings.instance.update(web_access_enabled: false) }
 
       it "renders a notice" do
         get admin_homepage_path
         expect(response.body)
-          .to have_selector(".gem-c-notice", text: /Public access to chat is disabled/)
+          .to have_selector(".gem-c-notice", text: /Web access to chat is disabled/)
       end
     end
 

--- a/spec/requests/admin/settings/public_access_spec.rb
+++ b/spec/requests/admin/settings/public_access_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin::Settings::PublicAccessController" do
 
       expect {
         patch admin_settings_edit_public_access_path,
-              params: { public_access_form: { enabled: "true" } }
+              params: { web_access_form: { enabled: "true" } }
       }
         .to change(SettingsAudit, :count).by(1)
 
@@ -26,7 +26,7 @@ RSpec.describe "Admin::Settings::PublicAccessController" do
 
     it "re-renders the edit page when given invalid params" do
       patch admin_settings_edit_public_access_path,
-            params: { public_access_form: { enabled: "true", author_comment: "a" * 256 } }
+            params: { web_access_form: { enabled: "true", author_comment: "a" * 256 } }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to have_selector(".govuk-error-summary")

--- a/spec/requests/admin/settings/web_access_spec.rb
+++ b/spec/requests/admin/settings/web_access_spec.rb
@@ -1,31 +1,31 @@
-RSpec.describe "Admin::Settings::PublicAccessController" do
+RSpec.describe "Admin::Settings::WebAccessController" do
   describe "GET :edit" do
     it "renders the edit page successfully" do
-      get admin_settings_edit_public_access_path
+      get admin_settings_edit_web_access_path
 
       expect(response).to have_http_status(:ok)
       expect(response.body)
-        .to have_selector(".govuk-heading-xl", text: "Edit public access")
+        .to have_selector(".govuk-heading-xl", text: "Edit web access")
     end
   end
 
   describe "PATCH :update" do
-    it "updates the public_access_enabled then redirects to the settings page" do
-      settings = create(:settings, public_access_enabled: false)
+    it "updates the web_access_enabled then redirects to the settings page" do
+      settings = create(:settings, web_access_enabled: false)
 
       expect {
-        patch admin_settings_edit_public_access_path,
+        patch admin_settings_edit_web_access_path,
               params: { web_access_form: { enabled: "true" } }
       }
         .to change(SettingsAudit, :count).by(1)
 
       expect(response).to redirect_to(admin_settings_path)
-      expect(flash[:notice]).to eq("Public access updated")
-      expect(settings.reload).to have_attributes(public_access_enabled: true)
+      expect(flash[:notice]).to eq("Web access updated")
+      expect(settings.reload).to have_attributes(web_access_enabled: true)
     end
 
     it "re-renders the edit page when given invalid params" do
-      patch admin_settings_edit_public_access_path,
+      patch admin_settings_edit_web_access_path,
             params: { web_access_form: { enabled: "true", author_comment: "a" * 256 } }
 
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/downtime_spec.rb
+++ b/spec/requests/downtime_spec.rb
@@ -1,6 +1,6 @@
-RSpec.describe "toggling downtime with Settings.instance.public_access_enabled" do
-  context "when public_access_enabled is false" do
-    before { create(:settings, public_access_enabled: false) }
+RSpec.describe "toggling downtime with Settings.instance.web_access_enabled" do
+  context "when web_access_enabled is false" do
+    before { create(:settings, web_access_enabled: false) }
 
     it "renders service unavailable content, with a service_unavailable status" do
       get homepage_path
@@ -14,11 +14,11 @@ RSpec.describe "toggling downtime with Settings.instance.public_access_enabled" 
     end
 
     it "skips regenerating a session so the resource can be cached" do
-      # re-enable public_access_enabled so we can make a request to create a session cookie
-      Settings.instance.update!(public_access_enabled: true)
+      # re-enable web_access_enabled so we can make a request to create a session cookie
+      Settings.instance.update!(web_access_enabled: true)
       get show_conversation_path
       expect(response.cookies.keys).to include("_govuk_chat_session")
-      Settings.instance.update!(public_access_enabled: false)
+      Settings.instance.update!(web_access_enabled: false)
 
       get homepage_path
       expect(response.cookies).to be_empty
@@ -40,8 +40,8 @@ RSpec.describe "toggling downtime with Settings.instance.public_access_enabled" 
     end
   end
 
-  context "when public_access_enabled is true" do
-    before { create(:settings, public_access_enabled: true) }
+  context "when web_access_enabled is true" do
+    before { create(:settings, web_access_enabled: true) }
 
     it "doesn't impact routes" do
       get homepage_path

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "StaticController" do
     end
   end
 
-  shared_examples "operates when public access is disabled" do |path_method|
-    context "when public access is disabled" do
+  shared_examples "operates when web access is disabled" do |path_method|
+    context "when web access is disabled" do
       before { Settings.instance.update!(web_access_enabled: false) }
 
       it "returns a success despite the status" do
@@ -28,7 +28,7 @@ RSpec.describe "StaticController" do
         .and have_link("Back to start page", href: homepage_path)
     end
 
-    context "when public access is enabled" do
+    context "when web access is enabled" do
       before { Settings.instance.update!(web_access_enabled: true) }
 
       it "renders the support link correctly" do
@@ -38,7 +38,7 @@ RSpec.describe "StaticController" do
       end
     end
 
-    context "when public access is disabled" do
+    context "when web access is disabled" do
       before { Settings.instance.update!(web_access_enabled: false) }
 
       it "renders the support link correctly" do
@@ -52,11 +52,11 @@ RSpec.describe "StaticController" do
     end
 
     include_examples "caches the page", :about_path
-    include_examples "operates when public access is disabled", :about_path
+    include_examples "operates when web access is disabled", :about_path
   end
 
   describe "GET :support" do
-    context "when public access is enabled" do
+    context "when web access is enabled" do
       before { Settings.instance.update!(web_access_enabled: true) }
 
       it "renders the view correctly" do
@@ -70,7 +70,7 @@ RSpec.describe "StaticController" do
       include_examples "caches the page", :support_path
     end
 
-    context "when public access is disabled" do
+    context "when web access is disabled" do
       before { Settings.instance.update!(web_access_enabled: false) }
 
       it "returns a :service_unavailable status code" do
@@ -95,6 +95,6 @@ RSpec.describe "StaticController" do
     end
 
     include_examples "caches the page", :accessibility_path
-    include_examples "operates when public access is disabled", :accessibility_path
+    include_examples "operates when web access is disabled", :accessibility_path
   end
 end

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "StaticController" do
 
   shared_examples "operates when public access is disabled" do |path_method|
     context "when public access is disabled" do
-      before { Settings.instance.update!(public_access_enabled: false) }
+      before { Settings.instance.update!(web_access_enabled: false) }
 
       it "returns a success despite the status" do
         get public_send(path_method)
@@ -29,7 +29,7 @@ RSpec.describe "StaticController" do
     end
 
     context "when public access is enabled" do
-      before { Settings.instance.update!(public_access_enabled: true) }
+      before { Settings.instance.update!(web_access_enabled: true) }
 
       it "renders the support link correctly" do
         get about_path
@@ -39,7 +39,7 @@ RSpec.describe "StaticController" do
     end
 
     context "when public access is disabled" do
-      before { Settings.instance.update!(public_access_enabled: false) }
+      before { Settings.instance.update!(web_access_enabled: false) }
 
       it "renders the support link correctly" do
         get about_path
@@ -57,7 +57,7 @@ RSpec.describe "StaticController" do
 
   describe "GET :support" do
     context "when public access is enabled" do
-      before { Settings.instance.update!(public_access_enabled: true) }
+      before { Settings.instance.update!(web_access_enabled: true) }
 
       it "renders the view correctly" do
         get support_path
@@ -71,7 +71,7 @@ RSpec.describe "StaticController" do
     end
 
     context "when public access is disabled" do
-      before { Settings.instance.update!(public_access_enabled: false) }
+      before { Settings.instance.update!(web_access_enabled: false) }
 
       it "returns a :service_unavailable status code" do
         get support_path

--- a/spec/system/admin/user_updates_settings_spec.rb
+++ b/spec/system/admin/user_updates_settings_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe "Admin user updates settings" do
     and_a_settings_instance_exists
 
     when_i_visit_the_settings_page
-    and_i_should_see_the_public_access_enabled_setting_is_enabled
+    and_i_should_see_the_web_access_enabled_setting_is_enabled
     and_i_should_see_the_api_access_enabled_setting_is_enabled
 
-    when_i_click_the_edit_link_for_public_access
-    and_i_disable_public_access
-    then_i_see_that_public_access_is_disabled
+    when_i_click_the_edit_link_for_web_access
+    and_i_disable_web_access
+    then_i_see_that_web_access_is_disabled
 
     when_i_click_the_edit_link_for_api_access
     and_i_disable_api_access
@@ -20,15 +20,15 @@ RSpec.describe "Admin user updates settings" do
   end
 
   def and_a_settings_instance_exists
-    create(:settings, public_access_enabled: true)
+    create(:settings, web_access_enabled: true)
   end
 
   def when_i_visit_the_settings_page
     visit admin_settings_path
   end
 
-  def and_i_should_see_the_public_access_enabled_setting_is_enabled
-    within("#public-access") do
+  def and_i_should_see_the_web_access_enabled_setting_is_enabled
+    within("#web-access") do
       expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled Yes")
     end
   end
@@ -39,17 +39,17 @@ RSpec.describe "Admin user updates settings" do
     end
   end
 
-  def when_i_click_the_edit_link_for_public_access
-    within("#public-access") { click_on "Edit Enabled" }
+  def when_i_click_the_edit_link_for_web_access
+    within("#web-access") { click_on "Edit Enabled" }
   end
 
   def when_i_click_the_edit_link_for_api_access
     within("#api-access") { click_on "Edit Enabled" }
   end
 
-  def and_i_disable_public_access
+  def and_i_disable_web_access
     choose "No"
-    fill_in "Comment (optional)", with: "Reason for disabling public access"
+    fill_in "Comment (optional)", with: "Reason for disabling web access"
     click_on "Submit"
   end
 
@@ -59,8 +59,8 @@ RSpec.describe "Admin user updates settings" do
     click_on "Submit"
   end
 
-  def then_i_see_that_public_access_is_disabled
-    within("#public-access") do
+  def then_i_see_that_web_access_is_disabled
+    within("#web-access") do
       expect(page).to have_selector(".govuk-summary-list__row", text: "Enabled No")
     end
   end
@@ -77,8 +77,8 @@ RSpec.describe "Admin user updates settings" do
 
   def then_i_can_see_the_audits_for_my_changes
     expect(page)
-      .to have_content("Public access enabled set to false")
-      .and have_content("Reason for disabling public access")
+      .to have_content("Web access enabled set to false")
+      .and have_content("Reason for disabling web access")
       .and have_content("API access enabled set to false")
   end
 end


### PR DESCRIPTION

Now that we have `api_access_enabled`, it makes sense to rename `public_access` to `web_access`.

This removes the column from the settings table, and adds the new one. It then removes all references to `public_access` and replaces them with `web_access`.



- **Add web_access_enabled to Settings**
- **Rename public_access_enabled to web_access_enabled**
- **Rename PublicAccessForm to WebAccessForm**
- **Use web_access_enabled in Settings spec**
- **Admin panel: public_access to web_access**
- **Remove public_access_enabled from Settings**
