### PR TITLE
Admin homepage warning when API access is disabled

### DIFF
--- a/app/views/admin/homepage/index.html.erb
+++ b/app/views/admin/homepage/index.html.erb
@@ -18,12 +18,12 @@ end
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% if !settings.web_access_enabled %>
+    <% if !settings.api_access_enabled %>
       <%= render "govuk_publishing_components/components/notice", {
-        title: "Web access to chat is disabled",
+        title: "API access to chat is disabled",
       } do %>
         <%= render "govuk_publishing_components/components/warning_text", {
-          text: "All users attempting to use chat will receive an error response",
+          text: "All users attempting to use chat via the API will receive an error response",
         } %>
         <p class="govuk-body">
           This can be changed in <%= link_to("settings", admin_settings_path, class: "govuk-link") %>.

--- a/spec/requests/admin/homepage_spec.rb
+++ b/spec/requests/admin/homepage_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe "Admin::HomepageController" do
       expect(response.body).to have_content("Browse questions")
     end
 
-    context "when web access is disabled" do
-      before { Settings.instance.update(web_access_enabled: false) }
+    context "when api access is disabled" do
+      before { Settings.instance.update(api_access_enabled: false) }
 
       it "renders a notice" do
         get admin_homepage_path
         expect(response.body)
-          .to have_selector(".gem-c-notice", text: /Web access to chat is disabled/)
+          .to have_selector(".gem-c-notice", text: /API access to chat is disabled/)
       end
     end
 


### PR DESCRIPTION

https://trello.com/c/pnENCZ5f/2529

This changes the existing warning which shows when web access is
disabled to instead show when API access is disabled, as it's a more
useful bit of info.
