### PR TITLE
Add `admin-area-settings` permission

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -2,4 +2,8 @@ class Admin::BaseController < ApplicationController
   layout "admin"
   before_action { authorise_user!(SignonUser::Permissions::ADMIN_AREA) }
   before_action { Current.signon_user = current_user }
+
+  def authorise_admin_settings
+    authorise_user!(SignonUser::Permissions::ADMIN_AREA_SETTINGS)
+  end
 end

--- a/app/controllers/admin/settings/api_access_controller.rb
+++ b/app/controllers/admin/settings/api_access_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Settings::ApiAccessController < Admin::BaseController
+  before_action :authorise_admin_settings
+
   def edit
     settings = Settings.instance
     @form = Admin::Form::Settings::ApiAccessForm.new(

--- a/app/controllers/admin/settings/web_access_controller.rb
+++ b/app/controllers/admin/settings/web_access_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Settings::WebAccessController < Admin::BaseController
+  before_action :authorise_admin_settings
+
   def edit
     settings = Settings.instance
     @form = Admin::Form::Settings::WebAccessForm.new(

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,4 +1,6 @@
 class Admin::SettingsController < Admin::BaseController
+  before_action :authorise_admin_settings
+
   def show
     @settings = Settings.instance
   end

--- a/app/models/signon_user.rb
+++ b/app/models/signon_user.rb
@@ -3,6 +3,7 @@ class SignonUser < ApplicationRecord
 
   module Permissions
     ADMIN_AREA = "admin-area".freeze
+    ADMIN_AREA_SETTINGS = "admin-area-settings".freeze
     CONVERSATION_API = "conversation-api".freeze
     DEVELOPER_TOOLS = "developer-tools".freeze
     WEB_CHAT = "web-chat".freeze

--- a/app/models/signon_user.rb
+++ b/app/models/signon_user.rb
@@ -9,5 +9,9 @@ class SignonUser < ApplicationRecord
     WEB_CHAT = "web-chat".freeze
   end
 
+  def has_permission?(permission)
+    permissions.include?(permission)
+  end
+
   has_many :conversations
 end

--- a/app/views/admin/homepage/index.html.erb
+++ b/app/views/admin/homepage/index.html.erb
@@ -25,9 +25,16 @@ end
         <%= render "govuk_publishing_components/components/warning_text", {
           text: "All users attempting to use chat via the API will receive an error response",
         } %>
-        <p class="govuk-body">
-          This can be changed in <%= link_to("settings", admin_settings_path, class: "govuk-link") %>.
-        </p>
+
+        <% if current_user.has_permission?("admin-area-settings") %>
+          <p class="govuk-body">
+            This can be changed in <%= link_to("settings", admin_settings_path, class: "govuk-link") %>.
+          </p>
+        <% else %>
+          <p class="govuk-body">
+            Please contact a developer to enable API access.
+          </p>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -11,7 +11,13 @@
       ["Metrics", admin_metrics_path],
       ["Questions", admin_questions_path],
       ["Search", admin_search_path],
-      ["Settings", admin_settings_path],
+    ]
+
+    if current_user.has_permission?("admin-area-settings")
+      navigation_items << ["Settings", admin_settings_path]
+    end
+
+    navigation_items += [
       [Current.signon_user.name, href: Plek.external_url_for("signon")],
       ["Log out", gds_sign_out_path],
     ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,5 +3,5 @@ SignonUser.find_or_create_by!(
   email: "chat.user@dev.gov.uk",
 ).update!(
   uid: SecureRandom.uuid,
-  permissions: %w[developer-tools admin-area conversation-api web-chat],
+  permissions: %w[developer-tools admin-area admin-area-settings conversation-api web-chat],
 )

--- a/spec/factories/signon_user_factory.rb
+++ b/spec/factories/signon_user_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       permissions { %w[admin-area] }
     end
 
+    trait :admin_area_settings do
+      permissions { %w[admin-area admin-area-settings] }
+    end
+
     trait :conversation_api do
       permissions { %w[conversation-api] }
     end

--- a/spec/models/signon_user_spec.rb
+++ b/spec/models/signon_user_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe SignonUser do
+  describe "has_permission?" do
+    let(:user) { create(:signon_user, permissions: %w[permission]) }
+
+    it "returns true if the user permissions include the specified permission" do
+      expect(user.has_permission?("permission")).to be true
+    end
+
+    it "returns false if the user permissions don't include the specified permission" do
+      expect(user.has_permission?("another-permission")).to be false
+    end
+  end
+end

--- a/spec/requests/admin/homepage_spec.rb
+++ b/spec/requests/admin/homepage_spec.rb
@@ -7,12 +7,30 @@ RSpec.describe "Admin::HomepageController" do
     end
 
     context "when api access is disabled" do
-      before { Settings.instance.update(api_access_enabled: false) }
+      before do
+        Settings.instance.update!(api_access_enabled: false)
+        login_as(create(:signon_user, :admin))
+      end
 
       it "renders a notice" do
         get admin_homepage_path
         expect(response.body)
           .to have_selector(".gem-c-notice", text: /API access to chat is disabled/)
+      end
+
+      it "informs users to contact a developer to update the setting" do
+        get admin_homepage_path
+        expect(response.body).to have_content("Please contact a developer to enable API access.")
+      end
+
+      context "when the user has the admin-area-settings permission" do
+        it "renders a link to the settings page" do
+          login_as(create(:signon_user, :admin_area_settings))
+          get admin_homepage_path
+          expect(response.body)
+            .to have_content("This can be changed in settings.")
+            .and have_link("settings", href: admin_settings_path)
+        end
       end
     end
 

--- a/spec/requests/admin/navigation_spec.rb
+++ b/spec/requests/admin/navigation_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe "Navigation bar" do
+  describe "Settings navigation item" do
+    it "renders an item which links to the Settings when the user has the admin-area-settings permission" do
+      login_as(create(:signon_user, :admin_area_settings))
+      get admin_homepage_path
+      expect(response.body)
+        .to have_selector(".govuk-header__navigation-item", text: "Settings")
+        .and have_link("Settings", href: admin_settings_path)
+    end
+
+    it "doesn't render an item for Settings when the user doesn't have the admin-area-settings permission" do
+      login_as(create(:signon_user, :admin))
+      get admin_homepage_path
+      expect(response.body)
+        .not_to have_selector(".govuk-header__navigation-item", text: "Settings")
+    end
+  end
+end

--- a/spec/requests/admin/settings/api_access_spec.rb
+++ b/spec/requests/admin/settings/api_access_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe "Admin::Settings::ApiAccessController" do
+  it_behaves_like "limits access to users with the admin-area-settings permission",
+                  routes: {
+                    admin_settings_edit_api_access_path: %i[get patch],
+                  }
+
   describe "GET :edit" do
     it "renders the edit page successfully" do
       get admin_settings_edit_api_access_path

--- a/spec/requests/admin/settings/web_access_spec.rb
+++ b/spec/requests/admin/settings/web_access_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe "Admin::Settings::WebAccessController" do
+  it_behaves_like "limits access to users with the admin-area-settings permission",
+                  routes: {
+                    admin_settings_edit_web_access_path: %i[get patch],
+                  }
+
   describe "GET :edit" do
     it "renders the edit page successfully" do
       get admin_settings_edit_web_access_path

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe "Admin::SettingsController" do
+  it_behaves_like "limits access to users with the admin-area-settings permission",
+                  routes: {
+                    admin_settings_path: [:get],
+                    admin_settings_audits_path: [:get],
+                  }
+
   describe "GET :show" do
     it "creates the settings singleton and renders the page successfully on first visit" do
       expect { get admin_settings_path }.to change(Settings, :count).by(1)

--- a/spec/support/admin_settings_examples.rb
+++ b/spec/support/admin_settings_examples.rb
@@ -1,0 +1,24 @@
+module AdminSettingsExamples
+  shared_examples "limits access to users with the admin-area-settings permission" do |routes:|
+    routes.each do |route, methods|
+      describe "responds with forbidden if user doesn't have admin-area-settings permission for #{route}" do
+        methods.each do |method|
+          it "returns forbidden for #{method} #{route} without the permission" do
+            login_as(create(:signon_user))
+            process(method.to_sym, public_send(route.to_sym))
+            expect(response).to have_http_status(:forbidden)
+          end
+
+          it "doesn't return foribidden for #{method} #{route} with the permission" do
+            user = create(:signon_user, :admin_area_settings)
+            login_as(user)
+
+            process(method.to_sym, public_send(route.to_sym))
+
+            expect(response).not_to have_http_status(:forbidden)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -36,6 +36,10 @@ module SystemSpecHelpers
     login_as(create(:signon_user, :admin))
   end
 
+  def given_i_am_an_admin_with_the_settings_permission
+    login_as(create(:signon_user, :admin_area_settings))
+  end
+
   def ur_question_first_option_text(question_label)
     Rails.configuration.pilot_user_research_questions.dig(question_label, :options, 0, :text)
   end

--- a/spec/system/admin/user_updates_settings_spec.rb
+++ b/spec/system/admin/user_updates_settings_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Admin user updates settings" do
   scenario do
-    given_i_am_an_admin
+    given_i_am_an_admin_with_the_settings_permission
     and_a_settings_instance_exists
 
     when_i_visit_the_settings_page


### PR DESCRIPTION
## Description 

This PR adds an additional permission to control access to our Settings pages in the Admin UI. For obvious reasons, we want to restrict access to being able to toggle web and the api on and off. This PR:

- Adds the permission to the SignonUser model
- Adds it to the user in the seed data
- Adds a trait to the factory for it
- Restricts access to the settings endpoints based on the presence of the permission
- Removes settings from the nav bar for users without the permission
- Updates the content of the homepage for users without the permission 

## Screenshot
### With permission 

<img width="673" alt="image" src="https://github.com/user-attachments/assets/2d6a3079-2c6a-46ed-aa5b-81f8723859a8" />

### Without permission 

<img width="607" alt="image" src="https://github.com/user-attachments/assets/afb42a9a-6cd7-4f00-9c1f-67a3cba416aa" />

## Trello card

https://trello.com/c/8HWP7hkt/2536-increase-number-of-permissions
