### PR TITLE
Allow overriding of Claude Bedrock config via env vars

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/claude/question_rephraser.rb
@@ -11,7 +11,7 @@ module AnswerComposition::Pipeline
       def call
         response = bedrock_client.converse(
           system: [{ text: config[:system_prompt] }],
-          model_id: BedrockModels::CLAUDE_3_7_SONNET, # TODO: change this to a more basic model
+          model_id: BedrockModels::CLAUDE_SONNET, # TODO: change this to a more basic model
           messages:,
           inference_config:,
         )
@@ -28,7 +28,9 @@ module AnswerComposition::Pipeline
       attr_reader :question_message, :message_records
 
       def bedrock_client
-        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new(
+          region: ENV.fetch("CLAUDE_AWS_REGION", "eu-west-1"),
+        )
       end
 
       def build_metrics(response)

--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -77,13 +77,15 @@ module AnswerComposition::Pipeline
       end
 
       def bedrock_client
-        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new(
+          region: ENV.fetch("CLAUDE_AWS_REGION", "eu-west-1"),
+        )
       end
 
       def bedrock_response
         @bedrock_response ||= bedrock_client.converse(
           system: [{ text: prompt_config[:system_prompt] }],
-          model_id: BedrockModels::CLAUDE_3_7_SONNET,
+          model_id: BedrockModels::CLAUDE_SONNET,
           messages:,
           inference_config:,
           tool_config:,

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -13,7 +13,7 @@ module AnswerComposition::Pipeline
 
         response = bedrock_client.converse(
           system: [{ text: system_prompt }],
-          model_id: BedrockModels::CLAUDE_3_7_SONNET,
+          model_id: BedrockModels::CLAUDE_SONNET,
           messages:,
           inference_config:,
           tool_config:,
@@ -69,7 +69,9 @@ module AnswerComposition::Pipeline
       end
 
       def bedrock_client
-        @bedrock_client ||= Aws::BedrockRuntime::Client.new
+        @bedrock_client ||= Aws::BedrockRuntime::Client.new(
+          region: ENV.fetch("CLAUDE_AWS_REGION", "eu-west-1"),
+        )
       end
 
       def set_context_sources(sources_used)

--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -1,4 +1,4 @@
 module BedrockModels
-  CLAUDE_3_7_SONNET = "eu.anthropic.claude-3-7-sonnet-20250219-v1:0".freeze
+  CLAUDE_SONNET = ENV.fetch("CLAUDE_SONNET_MODEL_ID", "eu.anthropic.claude-3-7-sonnet-20250219-v1:0").freeze
   TITAN_EMBED_V2 = "amazon.titan-embed-text-v2:0".freeze
 end

--- a/lib/guardrails/claude/jailbreak_checker.rb
+++ b/lib/guardrails/claude/jailbreak_checker.rb
@@ -9,7 +9,7 @@ module Guardrails::Claude
     def call
       response = bedrock_client.converse(
         system: [{ text: system_prompt }],
-        model_id: BedrockModels::CLAUDE_3_7_SONNET,
+        model_id: BedrockModels::CLAUDE_SONNET,
         messages:,
         inference_config:,
       )
@@ -36,7 +36,9 @@ module Guardrails::Claude
     end
 
     def bedrock_client
-      @bedrock_client ||= Aws::BedrockRuntime::Client.new
+      @bedrock_client ||= Aws::BedrockRuntime::Client.new(
+        region: ENV.fetch("CLAUDE_AWS_REGION", "eu-west-1"),
+      )
     end
 
     def inference_config

--- a/lib/guardrails/claude/multiple_checker.rb
+++ b/lib/guardrails/claude/multiple_checker.rb
@@ -8,13 +8,15 @@ module Guardrails
       def initialize(input, prompt)
         @input = input
         @prompt = prompt
-        @bedrock_client = Aws::BedrockRuntime::Client.new
+        @bedrock_client = Aws::BedrockRuntime::Client.new(
+          region: ENV.fetch("CLAUDE_AWS_REGION", "eu-west-1"),
+        )
       end
 
       def call
         claude_response = bedrock_client.converse(
           system: [{ text: prompt.system_prompt }],
-          model_id: BedrockModels::CLAUDE_3_7_SONNET,
+          model_id: BedrockModels::CLAUDE_SONNET,
           messages: [{ role: "user", content: [{ text: prompt.user_prompt(input) }] }],
           inference_config: {
             max_tokens: MAX_TOKENS,


### PR DESCRIPTION
https://trello.com/c/qMYt0Bvy/2543

Claude Sonnet 4 is currently only available in US regions, which means
we need to set the AWS region to `us-east-1` in order to use it.

But we don't need to change the region for testing other Claude
versions, or any other Bedrock API calls.

This commit allows both the `CLAUDE_AWS_REGION` and
`CLAUDE_SONNET_MODEL_ID` env vars to be set so that you can test using
Claude Sonnet 4 by using:

```
CLAUDE_AWS_REGION=us-east-1 CLAUDE_SONNET_MODEL_ID=us.anthropic.claude-sonnet-4-20250514-v1:0 <cmd>
```
