### PR TITLE
Search results eval: return weighted score

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -146,6 +146,7 @@ namespace :evaluation do
       {
         exact_path: result.exact_path,
         plain_content: result.plain_content,
+        weighted_score: result.weighted_score,
       }
     end
 

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -377,15 +377,22 @@ RSpec.describe "rake evaluation tasks" do
     it "outputs the response as JSON to stdout" do
       ClimateControl.modify(INPUT: input, EMBEDDING_PROVIDER: "openai") do
         search_results = [
-          build(
-            :chunked_content_search_result,
-            exact_path: "/path1",
-            plain_content: "Content 1",
+          Search::ResultsForQuestion::WeightedResult.new(
+            result: build(
+              :chunked_content_search_result,
+              exact_path: "/path1",
+              plain_content: "Content 1",
+            ),
+            weighted_score: 1.0,
           ),
-          build(
-            :chunked_content_search_result,
-            exact_path: "/path2",
-            plain_content: "Content 2",
+
+          Search::ResultsForQuestion::WeightedResult.new(
+            result: build(
+              :chunked_content_search_result,
+              exact_path: "/path2",
+              plain_content: "Content 2",
+            ),
+            weighted_score: 0.9,
           ),
         ]
         result_set = Search::ResultsForQuestion::ResultSet.new(
@@ -396,8 +403,8 @@ RSpec.describe "rake evaluation tasks" do
         allow(Search::ResultsForQuestion).to receive(:call).with(input).and_return(result_set)
 
         expected_output = [
-          { exact_path: "/path1", plain_content: "Content 1" },
-          { exact_path: "/path2", plain_content: "Content 2" },
+          { exact_path: "/path1", plain_content: "Content 1", weighted_score: 1.0 },
+          { exact_path: "/path2", plain_content: "Content 2", weighted_score: 0.9 },
         ].to_json
 
         expect { Rake::Task[task_name].invoke }


### PR DESCRIPTION
This evaluation task returns the search results for a given input. DS
want the weighted_score to be returned and included in the results in
the Python eval codebase to help identify/investigate any issues. See
[this comment][1]

It improves the spec a bit too as currently we're stubbing
`Search::ResultsForQuestion#call` to return an array of
`Search::ChunkedContentRepository::Result` objects, whereas in reality
the method returns an array of
`Search::ResultsForQuestion::WeightedResult`.

[1]: https://github.com/alphagov/govuk-chat-evaluation/pull/49/files#r2139699228