### PR TITLE
BigQuery: export conversation source and signon user

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -54,6 +54,7 @@ class Question < ApplicationRecord
   def serialize_for_export
     as_json.merge(
       "answer" => answer&.serialize_for_export,
+      "source" => conversation.source,
     )
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -55,6 +55,7 @@ class Question < ApplicationRecord
     as_json.merge(
       "answer" => answer&.serialize_for_export,
       "source" => conversation.source,
+      "signon_user_id" => conversation.signon_user_id,
     )
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -160,11 +160,12 @@ RSpec.describe Question do
     end
 
     context "when the question does not have an answer" do
-      it "returns a serialized question with its answer" do
+      it "returns a serialized question without its answer" do
         question = create(:question)
 
-        expect(question.serialize_for_export)
-          .to include(question.as_json)
+        export = question.serialize_for_export
+        expect(export).to include(question.as_json)
+        expect(export["answer"]).to be_nil
       end
     end
   end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -149,13 +149,15 @@ RSpec.describe Question do
   describe "#serialize_for_export" do
     context "when the question has an answer" do
       it "returns a serialized question" do
-        question = create(:question, :with_answer)
-        question.conversation = create(:conversation)
+        signon_user = build(:signon_user)
+        conversation = build(:conversation, signon_user:)
+        question = create(:question, :with_answer, conversation:)
 
         expect(question.serialize_for_export)
           .to include(question.as_json)
           .and include("answer" => question.answer.serialize_for_export)
           .and include("source" => "web")
+          .and include("signon_user_id" => signon_user.id)
       end
     end
 
@@ -166,6 +168,14 @@ RSpec.describe Question do
         export = question.serialize_for_export
         expect(export).to include(question.as_json)
         expect(export["answer"]).to be_nil
+      end
+    end
+
+    context "when the question does not have a signon_user" do
+      it "returns a serialized question without its signon user" do
+        question = create(:question)
+
+        expect(question.serialize_for_export["signon_user_id"]).to be_nil
       end
     end
   end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -148,13 +148,14 @@ RSpec.describe Question do
 
   describe "#serialize_for_export" do
     context "when the question has an answer" do
-      it "returns a serialized question with its answer" do
+      it "returns a serialized question" do
         question = create(:question, :with_answer)
         question.conversation = create(:conversation)
 
         expect(question.serialize_for_export)
           .to include(question.as_json)
           .and include("answer" => question.answer.serialize_for_export)
+          .and include("source" => "web")
       end
     end
 


### PR DESCRIPTION

https://trello.com/c/yp95vKmF/2533

Exports the conversation source and signon user to BigQuery. If the
conversation doesn't have a signon user, it will be set to nil.
