### PR TITLE
Add note about soft line breaks to OpenAPI spec

### DIFF
--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -599,6 +599,8 @@ components:
         message:
           description: |
             The LLM generated answer returned in markdown format.
+
+            Soft line breaks should not be treated as hard line breaks.
           type: string
         useful:
           description: |


### PR DESCRIPTION
The markdown produced by GOV.UK Chat is formatted [1] as part of link preservation. Kramdown seems to be opinionated on that formatting producing markdown with soft line breaks (and also reference links). 

To reflect this I've added a note about soft line breaks as we have encountered a markdown renderer that treats these as hard line breaks automatically [2] and caused confusion.

We don't consider it an issue currently that we do have these soft line breaks as they're ok in the common mark spec [3], but they are a bit annoying.

[1]: https://github.com/alphagov/govuk-chat/blob/2697d2f65899cb96da0d551cd4f765f0e01a1f32/lib/answer_composition/link_token_mapper.rb#L48
[2]: https://github.com/jeziellago/compose-markdown/blob/d385910662348bf5e054efe53bc99e6de28f8205/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt#L46
[3]: https://spec.commonmark.org/0.28/#soft-line-breaks