### PR TITLE
Conversation questions pagination spike

### DIFF
--- a/app/blueprints/conversation_blueprint.rb
+++ b/app/blueprints/conversation_blueprint.rb
@@ -19,4 +19,11 @@ class ConversationBlueprint < Blueprinter::Base
   ) do |_conversation, options|
     options[:pending_question]
   end
+
+  field(
+    :earlier_questions_url,
+    if: ->(_field_name, _conversation, options) { options[:earlier_questions_url].present? },
+  ) do |_conversation, options|
+    options[:earlier_questions_url]
+  end
 end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -97,10 +97,11 @@ class Api::V0::ConversationsController < Api::BaseController
       limit: Rails.configuration.conversations.api_questions_per_page,
     )
 
-    render(
-      json: QuestionBlueprint.render(questions, view: :answered),
-      status: :ok,
-    )
+    json = ConversationQuestions.new(
+      questions: QuestionBlueprint.render_as_hash(questions, view: :answered),
+    ).to_json
+
+    render(json:, status: :ok)
   end
 
 private

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -19,14 +19,15 @@ class Api::V0::ConversationsController < Api::BaseController
   end
 
   def show
+    limit = Rails.configuration.conversations.api_questions_per_page
     answered_questions = @conversation.questions_for_showing_conversation(
       only_answered: true,
-      limit: Rails.configuration.conversations.api_questions_per_page,
+      limit:,
     )
     pending_question = @conversation.questions.unanswered.last
     answer_url = pending_question ? answer_path(pending_question) : nil
 
-    earlier_questions_url = if @conversation.active_answered_questions_before?(answered_questions.first&.created_at)
+    earlier_questions_url = if answered_questions.size == limit && @conversation.active_answered_questions_before?(answered_questions.first&.created_at)
                               api_v0_conversation_questions_path(
                                 @conversation, before: answered_questions.first.id
                               )
@@ -97,8 +98,24 @@ class Api::V0::ConversationsController < Api::BaseController
       limit: Rails.configuration.conversations.api_questions_per_page,
     )
 
+    earlier_url = if @conversation.active_answered_questions_before?(questions.first&.created_at)
+                    api_v0_conversation_questions_path(
+                      @conversation,
+                      before: questions.first.id,
+                    )
+                  end
+
+    later_url = if @conversation.active_answered_questions_after?(questions.last&.created_at)
+                  api_v0_conversation_questions_path(
+                    @conversation,
+                    after: questions.last.id,
+                  )
+                end
+
     json = ConversationQuestions.new(
       questions: QuestionBlueprint.render_as_hash(questions, view: :answered),
+      earlier_questions_url: earlier_url,
+      later_questions_url: later_url,
     ).to_json
 
     render(json:, status: :ok)

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -1,6 +1,6 @@
 class Api::V0::ConversationsController < Api::BaseController
   before_action { authorise_user!(SignonUser::Permissions::CONVERSATION_API) }
-  before_action :find_conversation, only: %i[show update answer answer_feedback]
+  before_action :find_conversation, only: %i[show update answer answer_feedback questions]
 
   def create
     conversation = Conversation.new(signon_user: current_user, source: :api)
@@ -76,6 +76,15 @@ class Api::V0::ConversationsController < Api::BaseController
         errors: feedback_form.errors.messages,
       ), status: :unprocessable_entity
     end
+  end
+
+  def questions
+    questions = @conversation.questions_for_showing_conversation(only_answered: true)
+
+    render(
+      json: QuestionBlueprint.render(questions, view: :answered),
+      status: :ok,
+    )
   end
 
 private

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -94,6 +94,7 @@ class Api::V0::ConversationsController < Api::BaseController
       only_answered: true,
       before_id: params[:before].presence,
       after_id: params[:after].presence,
+      limit: Rails.configuration.conversations.api_questions_per_page,
     )
 
     render(

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -79,7 +79,11 @@ class Api::V0::ConversationsController < Api::BaseController
   end
 
   def questions
-    questions = @conversation.questions_for_showing_conversation(only_answered: true)
+    questions = @conversation.questions_for_showing_conversation(
+      only_answered: true,
+      before_id: params[:before].presence,
+      after_id: params[:after].presence,
+    )
 
     render(
       json: QuestionBlueprint.render(questions, view: :answered),

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -19,13 +19,24 @@ class Api::V0::ConversationsController < Api::BaseController
   end
 
   def show
-    answered_questions = @conversation.questions_for_showing_conversation(only_answered: true)
+    answered_questions = @conversation.questions_for_showing_conversation(
+      only_answered: true,
+      limit: Rails.configuration.conversations.api_questions_per_page,
+    )
     pending_question = @conversation.questions.unanswered.last
     answer_url = pending_question ? answer_path(pending_question) : nil
+
+    earlier_questions_url = if @conversation.active_answered_questions_before?(answered_questions.first&.created_at)
+                              api_v0_conversation_questions_path(
+                                @conversation, before: answered_questions.first.id
+                              )
+                            end
+
     options = {
       answered_questions:,
       pending_question:,
       answer_url:,
+      earlier_questions_url:,
     }
 
     render(

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -12,11 +12,22 @@ class Conversation < ApplicationRecord
        },
        prefix: true
 
-  def questions_for_showing_conversation(only_answered: false)
+  def questions_for_showing_conversation(only_answered: false, before_id: nil, after_id: nil)
     scope = Question.where(conversation: self)
                   .includes(answer: %i[feedback sources])
                   .active
     scope = scope.joins(:answer) if only_answered
+
+    if before_id.present?
+      before_timestamp = scope.where(id: before_id).pick(:created_at) || raise(ActiveRecord::RecordNotFound)
+      scope = scope.where("questions.created_at < ?", before_timestamp)
+    end
+
+    if after_id.present?
+      after_timestamp = scope.where(id: after_id).pick(:created_at) || raise(ActiveRecord::RecordNotFound)
+      scope = scope.where("questions.created_at > ?", after_timestamp)
+    end
+
     scope.last(Rails.configuration.conversations.max_question_count)
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -12,7 +12,7 @@ class Conversation < ApplicationRecord
        },
        prefix: true
 
-  def questions_for_showing_conversation(only_answered: false, before_id: nil, after_id: nil)
+  def questions_for_showing_conversation(only_answered: false, before_id: nil, after_id: nil, limit: nil)
     scope = Question.where(conversation: self)
                   .includes(answer: %i[feedback sources])
                   .active
@@ -28,6 +28,10 @@ class Conversation < ApplicationRecord
       scope = scope.where("questions.created_at > ?", after_timestamp)
     end
 
-    scope.last(Rails.configuration.conversations.max_question_count)
+    scope.last(limit || Rails.configuration.conversations.max_question_count)
+  end
+
+  def active_answered_questions_before?(timestamp)
+    questions.active.answered.where("questions.created_at < ?", timestamp).exists?
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -34,4 +34,8 @@ class Conversation < ApplicationRecord
   def active_answered_questions_before?(timestamp)
     questions.active.answered.where("questions.created_at < ?", timestamp).exists?
   end
+
+  def active_answered_questions_after?(timestamp)
+    questions.active.answered.where("questions.created_at > ?", timestamp).exists?
+  end
 end

--- a/app/models/conversation_questions.rb
+++ b/app/models/conversation_questions.rb
@@ -1,5 +1,13 @@
-ConversationQuestions = Data.define(:questions) do
+ConversationQuestions = Data.define(
+  :questions,
+  :earlier_questions_url,
+  :later_questions_url,
+) do
+  def initialize(questions: [], earlier_questions_url: nil, later_questions_url: nil)
+    super
+  end
+
   def to_json(*_args)
-    to_h.to_json
+    to_h.compact.to_json
   end
 end

--- a/app/models/conversation_questions.rb
+++ b/app/models/conversation_questions.rb
@@ -1,0 +1,5 @@
+ConversationQuestions = Data.define(:questions) do
+  def to_json(*_args)
+    to_h.to_json
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -15,6 +15,7 @@ class Question < ApplicationRecord
   has_one :answer, strict_loading: false
 
   scope :unanswered, -> { where.missing(:answer) }
+  scope :answered, -> { where.associated(:answer) }
 
   scope :group_by_aggregate_status, lambda {
     left_outer_joins(:answer)

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,7 @@ module GovukChat
       max_question_count: 500,
       max_questions_per_user: 70,
       question_warning_threshold: 20,
+      api_questions_per_page: 50,
     )
 
     config.openai_access_token = ENV["OPENAI_ACCESS_TOKEN"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
       post "/conversation", to: "conversations#create", as: :create_conversation
       get "/conversation/:conversation_id", to: "conversations#show", as: :show_conversation
       put "/conversation/:conversation_id", to: "conversations#update", as: :update_conversation
+      get "/conversation/:conversation_id/questions", to: "conversations#questions", as: :conversation_questions
       get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
       post "/conversation/:conversation_id/answers/:answer_id/feedback", to: "conversations#answer_feedback", as: :answer_feedback
     end

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -10,7 +10,7 @@ info:
     Worth noting that onboarding aspects of conversation (Informing user of
     limitations and accepting) are not included as within GOV.UK Chat these
     are a UI construct and not a part of core domain constructs.
-  version: "0.1.0"
+  version: "0.2.0"
 servers:
   - url: https://chat.publishing.service.gov.uk/api/v0
 paths:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -247,6 +247,18 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
         - $ref: "#/components/parameters/DeviceIdHeader"
       responses:
         "200":
@@ -275,7 +287,9 @@ paths:
               $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitReset'
         "404":
           description: |
-            Either a conversation never existed with this id or has now expired
+            Either a conversation never existed with this id or has now expired.
+            Will also be rendered if the `before` or `after` parameters reference
+            records that do not exist.
           content:
             application/json:
               schema:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -263,7 +263,7 @@ paths:
       responses:
         "200":
           description: |
-            Returns an array of AnsweredQuestions. Is limited to returning 500
+            Returns an array of AnsweredQuestions. Is limited to returning 50
             questions for a conversation and only questions asked within last
             90 days.
           content:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -234,6 +234,82 @@ paths:
             Govuk-Client-Device-Id-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukClientDeviceIdWriteRateLimitReset'
 
+  /conversation/{conversation_id}/questions:
+    get:
+      summary: Retrieve a conversation's answered questions
+      description: |
+        Accesses the answered questions of a conversation should a conversation with
+        the id be available.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/DeviceIdHeader"
+      responses:
+        "200":
+          description: |
+            Returns an array of AnsweredQuestions. Is limited to returning 500
+            questions for a conversation and only questions asked within last
+            90 days.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AnsweredQuestion"
+          headers:
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-Client-Device-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitLimit'
+            Govuk-Client-Device-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitRemaining'
+            Govuk-Client-Device-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitReset'
+        "404":
+          description: |
+            Either a conversation never existed with this id or has now expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+          headers:
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-Client-Device-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitLimit'
+            Govuk-Client-Device-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitRemaining'
+            Govuk-Client-Device-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitReset'
+        "429":
+          description: |
+            Too many requests to read endpoints from an Api User or Device ID
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-Client-Device-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitLimit'
+            Govuk-Client-Device-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitRemaining'
+            Govuk-Client-Device-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukClientDeviceIdReadRateLimitReset'
+
   /conversation/{conversation_id}/questions/{question_id}/answer:
     get:
       summary: Look up the answer to a question

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -269,9 +269,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/AnsweredQuestion"
+                $ref: "#/components/schemas/ConversationQuestions"
           headers:
             Govuk-Api-User-Read-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
@@ -630,6 +628,15 @@ components:
             Will be null if there are no earlier questions.
           type: string
           format: url
+    ConversationQuestions:
+      type: object
+      required:
+        - questions
+      properties:
+        questions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnsweredQuestion"
     AnsweredQuestion:
       type: object
       required:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -637,6 +637,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AnsweredQuestion"
+        earlier_questions_url:
+          description: |
+            A relative URL that can be used to retrieve earlier questions in the conversation.
+            Will be null if there are no earlier questions.
+          type: string
+          format: url
+        later_questions_url:
+          description: |
+            A relative URL that can be used to retrieve later questions in the conversation.
+            Will be null if there are no later questions.
+          type: string
+          format: url
     AnsweredQuestion:
       type: object
       required:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -101,7 +101,7 @@ paths:
         "200":
           description: |
             Returns a list of AnsweredQuestions with potentially one PendingQuestion.
-            Is limited to returning 500 questions for a conversation and only
+            Is limited to returning 50 questions for a conversation and only
             questions asked within last 90 days.
           content:
             application/json:
@@ -624,6 +624,12 @@ components:
         created_at:
           type: string
           format: date-time
+        earlier_questions_url:
+          description: |
+            A relative URL that can be used to retrieve earlier questions in the conversation.
+            Will be null if there are no earlier questions.
+          type: string
+          format: url
     AnsweredQuestion:
       type: object
       required:

--- a/spec/models/conversation_questions_spec.rb
+++ b/spec/models/conversation_questions_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe ConversationQuestions do
+  describe ".to_json" do
+    it "returns all attributes as JSON" do
+      obj = described_class.new(
+        questions: [build(:question)],
+      )
+      expected_json = {
+        questions: obj.questions,
+      }.to_json
+
+      expect(obj.to_json).to eq(expected_json)
+    end
+  end
+end

--- a/spec/models/conversation_questions_spec.rb
+++ b/spec/models/conversation_questions_spec.rb
@@ -3,9 +3,27 @@ RSpec.describe ConversationQuestions do
     it "returns all attributes as JSON" do
       obj = described_class.new(
         questions: [build(:question)],
+        earlier_questions_url: "/earlier",
+        later_questions_url: "/later",
       )
       expected_json = {
         questions: obj.questions,
+        earlier_questions_url: "/earlier",
+        later_questions_url: "/later",
+      }.to_json
+
+      expect(obj.to_json).to eq(expected_json)
+    end
+
+    it "removes nil attributes from JSON" do
+      obj = described_class.new(
+        questions: [build(:question)],
+        earlier_questions_url: nil,
+        later_questions_url: "/later",
+      )
+      expected_json = {
+        questions: obj.questions,
+        later_questions_url: "/later",
       }.to_json
 
       expect(obj.to_json).to eq(expected_json)

--- a/spec/models/conversations_spec.rb
+++ b/spec/models/conversations_spec.rb
@@ -153,4 +153,31 @@ RSpec.describe Conversation do
       expect(conversation.active_answered_questions_before?(question.created_at)).to be(false)
     end
   end
+
+  describe "#active_answered_questions_after?" do
+    let(:conversation) { create(:conversation) }
+
+    it "returns true if there are newer questions" do
+      question = create(:question, :with_answer, conversation:, created_at: 2.days.ago)
+      create(:question, :with_answer, conversation:,  created_at: 3.days.ago)
+      create(:question, :with_answer, conversation:,  created_at: 1.day.ago)
+
+      expect(conversation.active_answered_questions_after?(question.created_at)).to be(true)
+    end
+
+    it "returns false if there are no newer questions" do
+      create(:question, :with_answer, conversation:, created_at: 4.days.ago)
+      question = create(:question, :with_answer, conversation:, created_at: 3.days.ago)
+
+      expect(conversation.active_answered_questions_after?(question.created_at)).to be(false)
+    end
+
+    it "only includes active questions with answers" do
+      question = create(:question, :with_answer, conversation:, created_at: 5.years.ago)
+      create(:question, :with_answer, conversation:, created_at: 4.years.ago)
+      create(:question, created_at: 1.day.ago)
+
+      expect(conversation.active_answered_questions_after?(question.created_at)).to be(false)
+    end
+  end
 end

--- a/spec/models/conversations_spec.rb
+++ b/spec/models/conversations_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Conversation do
 
     it "returns the last N active questions based on the configuration value" do
       create(:question, conversation:)
-      expected = 2.times.map do |_|
+      expected = 2.times.map do
         create(:question, conversation:)
       end
       expect(conversation.reload.questions_for_showing_conversation).to eq(expected)
@@ -48,12 +48,70 @@ RSpec.describe Conversation do
     context "when only_answered is true" do
       it "returns the last N active answered questions based on the configuration value" do
         create(:question, :with_answer, conversation:)
-        expected = 2.times.map do |_|
+        expected = 2.times.map do
           create(:question, :with_answer, conversation:)
         end
         create(:question, conversation:)
 
         expect(conversation.reload.questions_for_showing_conversation(only_answered: true)).to eq(expected)
+      end
+    end
+
+    context "when before_id is provided" do
+      it "returns questions created before the given question's id" do
+        create(:question, conversation:, created_at: 2.hours.ago)
+        expected = [
+          create(:question, conversation:, created_at: 7.hours.ago),
+          create(:question, conversation:, created_at: 6.hours.ago),
+        ]
+        before_question = create(:question, conversation:, created_at: 3.hours.ago)
+
+        questions = conversation.reload.questions_for_showing_conversation(
+          before_id: before_question.id,
+        )
+        expect(questions).to eq(expected)
+      end
+
+      it "raises NotFound if the before_id does not exist" do
+        expect {
+          conversation.questions_for_showing_conversation(before_id: 9999)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when after_id is provided" do
+      it "returns questions created after the given question's id" do
+        create(:question, conversation:, created_at: 7.hours.ago)
+        expected = create(:question, conversation:, created_at: 2.hours.ago)
+        after_question = create(:question, conversation:, created_at: 3.hours.ago)
+
+        questions = conversation.reload.questions_for_showing_conversation(
+          after_id: after_question.id,
+        )
+        expect(questions).to eq([expected])
+      end
+
+      it "raises NotFound if the after_id does not exist" do
+        expect {
+          conversation.questions_for_showing_conversation(after_id: 9999)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when both before_id and after_id are provided" do
+      it "returns all questions created between the two records" do
+        after_question = create(:question, conversation:, created_at: 10.hours.ago)
+        expected = [
+          create(:question, conversation:, created_at: 7.hours.ago),
+          create(:question, conversation:, created_at: 6.hours.ago),
+        ]
+        before_question = create(:question, conversation:, created_at: 2.hours.ago)
+
+        questions = conversation.reload.questions_for_showing_conversation(
+          before_id: before_question.id,
+          after_id: after_question.id,
+        )
+        expect(questions).to eq(expected)
       end
     end
   end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Question do
     end
   end
 
+  describe ".answered" do
+    it "returns all questions with an answer" do
+      create(:question)
+      question = create(:question, :with_answer)
+
+      expect(described_class.answered).to eq [question]
+    end
+  end
+
   describe ".group_by_aggregate_status" do
     it "groups unanswered questions into a 'pending' group" do
       create(:question)

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -159,6 +159,23 @@ RSpec.describe "Api::V0::ConversationsController" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "returns a URL to earlier questions if present" do
+      allow(Rails.configuration.conversations).to receive(:api_questions_per_page).and_return(2)
+
+      create(:question, :with_answer, conversation:, created_at: 1.minute.ago)
+      oldest_in_page = create(:question, :with_answer, conversation:, created_at: 2.minutes.ago)
+      create(:question, :with_answer, conversation:, created_at: 3.minutes.ago)
+
+      get api_v0_show_conversation_path(conversation)
+
+      earlier_questions_url = api_v0_conversation_questions_path(
+        conversation, before: oldest_in_page.id
+      )
+
+      expect(JSON.parse(response.body)["earlier_questions_url"]).to eq(earlier_questions_url)
+      expect(response).to have_http_status(:ok)
+    end
+
     it "returns a 404 if the conversation cannot be found" do
       get api_v0_show_conversation_path(SecureRandom.uuid)
 

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -225,6 +225,16 @@ RSpec.describe "Api::V0::ConversationsController" do
       expect(JSON.parse(response.body)).to eq(expected_response)
     end
 
+    it "limits the number of questions returned" do
+      allow(Rails.configuration.conversations).to receive(:api_questions_per_page).and_return(2)
+      create(:question, :with_answer, conversation:)
+      create(:question, :with_answer, conversation:)
+      create(:question, :with_answer, conversation:)
+
+      get api_v0_conversation_questions_path(conversation)
+      expect(JSON.parse(response.body).size).to eq(2)
+    end
+
     it "returns the questions before a given question ID" do
       before_question = create(:question, :with_answer, conversation:, created_at: 2.minutes.ago)
       recent_questions = [


### PR DESCRIPTION
https://trello.com/c/vxAFbLGm/2537

This changes the `/api/v0/conversation/:id` endpoint to only return the most recent 50 questions.

It then adds a new `/api/v0/conversation/:id/questions` endpoint which returns pages of 50 answered questions for that conversation. This endpoint optionally takes 2 new parameters: `before` and `after`. These are UUIDs for records and will return the previous/next up to 50 records from the given ID.

The idea is that a client will:

1. Make a request to `/api/v0/conversation/:id`. They get some questions in the response to render. 
2. If the JSON response contains an `earlier_questions_url` field, the client knows there are more questions in the conversation
3. The client makes a request to the `earlier_questions_url` which gives them back the previous 50 questions (or less if there isn't 50)
4. The above response will contain another `earlier_questions_url` field if there are still more questions to load.
5. The client continues requesting pages until there aren't any records left

