### PR TITLE
Configure Rails/SaveBang to reduce inline rubocop disabling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,9 @@ inherit_mode:
 #
 # See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
 # **************************************************************
+
+# This cop is easily triggered on non-Active Record APIs, by excluding certain
+# domain specific receivers we can reduce the need to disable this cop inline.
+Rails/SaveBang:
+  AllowedReceivers:
+    - indices

--- a/lib/search/chunked_content_repository.rb
+++ b/lib/search/chunked_content_repository.rb
@@ -51,7 +51,7 @@ module Search
 
     def create_index(index_name: default_index_name, create_alias: true)
       aliases = create_alias ? { index.to_sym => {} } : {}
-      client.indices.create( # rubocop:disable Rails/SaveBang
+      client.indices.create(
         index: index_name,
         body: {
           settings: {


### PR DESCRIPTION
This adds Rails/SaveBang AllowedReceivers option as a way for us to flag attribute names that are unlikely to be ActiveRecord objects. This prevents them from having Rails/SaveBang enforced on them.

Rails/SaveBang is a bit of a clunky rule as just about any attribute could be an ActiveRecord object and the method names (save, update, create) are super common.

We can only really customise this rule in individual applications as the AllowedReceivers are domain specific.

While this only adds one usage, the expectation is that config and messages will also be added to support: https://github.com/alphagov/govuk-chat/pull/304