### PR TITLE
Update API to return answer path instead of URL for pending questions

### DIFF
--- a/app/blueprints/question_blueprint.rb
+++ b/app/blueprints/question_blueprint.rb
@@ -11,11 +11,10 @@ class QuestionBlueprint < Blueprinter::Base
 
   view :pending do
     field :answer_url do |question|
-      path = Rails.application.routes.url_helpers.api_v0_answer_question_path(
+      Rails.application.routes.url_helpers.api_v0_answer_question_path(
         question.conversation_id,
         question.id,
       )
-      "#{Plek.external_url_for('chat')}#{path}"
     end
   end
 end

--- a/app/blueprints/question_blueprint.rb
+++ b/app/blueprints/question_blueprint.rb
@@ -10,11 +10,8 @@ class QuestionBlueprint < Blueprinter::Base
   end
 
   view :pending do
-    field :answer_url do |question|
-      Rails.application.routes.url_helpers.api_v0_answer_question_path(
-        question.conversation_id,
-        question.id,
-      )
+    field :answer_url do |_question, options|
+      options[:answer_url]
     end
   end
 end

--- a/app/controllers/api/v0/conversations_controller.rb
+++ b/app/controllers/api/v0/conversations_controller.rb
@@ -8,7 +8,11 @@ class Api::V0::ConversationsController < Api::BaseController
 
     if form.valid?
       question = form.submit
-      render json: QuestionBlueprint.render(question, view: :pending), status: :created
+      render json: QuestionBlueprint.render(
+        question,
+        view: :pending,
+        answer_url: answer_path(question),
+      ), status: :created
     else
       render json: ValidationErrorBlueprint.render(errors: form.errors.messages), status: :unprocessable_entity
     end
@@ -17,9 +21,15 @@ class Api::V0::ConversationsController < Api::BaseController
   def show
     answered_questions = @conversation.questions_for_showing_conversation(only_answered: true)
     pending_question = @conversation.questions.unanswered.last
+    answer_url = pending_question ? answer_path(pending_question) : nil
+    options = {
+      answered_questions:,
+      pending_question:,
+      answer_url:,
+    }
 
     render(
-      json: ConversationBlueprint.render(@conversation, answered_questions:, pending_question:),
+      json: ConversationBlueprint.render(@conversation, options),
       status: :ok,
     )
   end
@@ -30,7 +40,11 @@ class Api::V0::ConversationsController < Api::BaseController
     if form.valid?
       question = form.submit
 
-      render json: QuestionBlueprint.render(question, view: :pending), status: :created
+      render json: QuestionBlueprint.render(
+        question,
+        view: :pending,
+        answer_url: answer_path(question),
+      ), status: :created
     else
       render json: ValidationErrorBlueprint.render(
         errors: form.errors.messages,
@@ -79,5 +93,12 @@ private
 
   def question_params
     params.permit(:user_question)
+  end
+
+  def answer_path(question)
+    api_v0_answer_question_path(
+      question.conversation_id,
+      question.id,
+    )
   end
 end

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -577,7 +577,7 @@ components:
           type: string
         answer_url:
           description: |
-            A URL that can be polled to check whether the answer is available
+            A relative URL that can be polled to check whether the answer is available
           type: string
           format: uri
         created_at:

--- a/spec/blueprints/question_blueprint_spec.rb
+++ b/spec/blueprints/question_blueprint_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe QuestionBlueprint do
           answer_url:,
         }.as_json
 
-        expect(described_class.render_as_json(question, view: :pending)).to eq(expected_json)
+        expect(described_class.render_as_json(question, view: :pending, answer_url:))
+          .to eq(expected_json)
       end
     end
   end

--- a/spec/blueprints/question_blueprint_spec.rb
+++ b/spec/blueprints/question_blueprint_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe QuestionBlueprint do
       it "includes the answer URL" do
         question = create(:question)
 
-        path = Rails.application.routes.url_helpers.api_v0_answer_question_path(
+        answer_url = Rails.application.routes.url_helpers.api_v0_answer_question_path(
           question.conversation_id,
           question.id,
         )
@@ -49,7 +49,7 @@ RSpec.describe QuestionBlueprint do
           conversation_id: question.conversation_id,
           created_at: question.created_at.iso8601,
           message: question.message,
-          answer_url: "#{Plek.external_url_for('chat')}#{path}",
+          answer_url:,
         }.as_json
 
         expect(described_class.render_as_json(question, view: :pending)).to eq(expected_json)

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe "Api::V0::ConversationsController" do
       expected_response = ConversationBlueprint.render_as_json(
         conversation,
         pending_question:,
+        answer_url: answer_path(pending_question),
       )
       expect(JSON.parse(response.body)).to eq(expected_response)
       expect(response).to have_http_status(:ok)
@@ -196,7 +197,11 @@ RSpec.describe "Api::V0::ConversationsController" do
         post api_v0_create_conversation_path, params: payload, as: :json
 
         question = Question.last
-        expected_payload = QuestionBlueprint.render_as_json(question, view: :pending)
+        expected_payload = QuestionBlueprint.render_as_json(
+          question,
+          view: :pending,
+          answer_url: answer_path(question),
+        )
 
         expect(JSON.parse(response.body)).to eq(expected_payload)
       end
@@ -270,9 +275,11 @@ RSpec.describe "Api::V0::ConversationsController" do
       it "returns the expected JSON" do
         put api_v0_update_conversation_path(conversation), params:, as: :json
 
+        question = conversation.questions.strict_loading(false).last
         expected_response = QuestionBlueprint.render_as_json(
           conversation.questions.strict_loading(false).last,
           view: :pending,
+          answer_url: answer_path(question),
         )
         expect(JSON.parse(response.body)).to eq(expected_response)
       end
@@ -388,5 +395,12 @@ RSpec.describe "Api::V0::ConversationsController" do
           )
       end
     end
+  end
+
+  def answer_path(question)
+    Rails.application.routes.url_helpers.api_v0_answer_question_path(
+      question.conversation_id,
+      question.id,
+    )
   end
 end


### PR DESCRIPTION
## Description 

The URLs returned from blueprints e.g: https://github.com/alphagov/govuk-chat/blob/6403285f34b713b1840d62ac2a4fb5db2cebf38c/app/blueprints/question_blueprint.rb#L14-L18 contain a hardcoded hostname and thus are incorrect if we are using an API gateway.

This PR does a couple of things:

1. updates the QuestionBlueprint to return the path instead of the URL
2. passes the view_context into the conversation and question blueprint instead of calling `Rails.application.routes.url_helpers.api_v0_answer_question_path` within the blueprints
3. configure blueprint specs to have `type: :default` so that we can scope helpers used by them to them in our spec_helper.

While we've updated the blueprints to only use a path. if we ever want to revert to using the full URL, passing in the view_context will mean that URLs are constructed using the request host meaning there won't be any need to munge the url in the app or gateway.

## Trello card

https://trello.com/c/KuJeWB28/2565-fix-host-specific-blueprint-links