### PR TITLE
Update env-example to include optional env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,15 @@
 ## variables for working with OpenAI
 OPENAI_ACCESS_TOKEN=
+
+## Opensearch configuration. Not required for local development using govuk-docker
+OPENSEARCH_URL=
+OPENSEARCH_USERNAME=
+OPENSEARCH_PASSWORD=
+
+## Optional variables to use models hosted on Amazon Bedrock instead of OpenAI
+# ANSWER_STRATEGY=claude_answer_strategy
+# EMBEDDING_PROVIDER=titan
+
+## Optional variables to configure AWS Bedrock interactions
+# CLAUDE_SONNET_MODEL_ID=
+# CLAUDE_AWS_REGION=


### PR DESCRIPTION
We have some additional environment variables that are useful for local development. Particuarly those related to Amazon Bedrock models.

These can be used to toggle the answer stratgey and embedding provider to use Amazon Bedrock models (Claude Sonnet and Titan) instead of OpenAI.

There's also some env vars for Opensearch. Those are only required if you're not using govuk-docker.