### PR TITLE
Tidy up strict loading in specs

### DIFF
--- a/spec/blueprints/answer_blueprint_spec.rb
+++ b/spec/blueprints/answer_blueprint_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AnswerBlueprint do
         created_at: answer.created_at.iso8601,
         message: answer.message,
       }.as_json
-      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+      output_json = described_class.render_as_json(answer)
 
       expect(output_json).to eq(expected_json)
     end
@@ -27,14 +27,14 @@ RSpec.describe AnswerBlueprint do
           },
         ],
       }.as_json
-      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+      output_json = described_class.render_as_json(answer)
 
       expect(output_json).to eq(expected_json)
     end
 
     it "does not include unused sources in the JSON" do
       create(:answer_source, answer:, used: false)
-      output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+      output_json = described_class.render_as_json(answer)
       expect(output_json.keys).not_to include("sources")
     end
 
@@ -47,7 +47,7 @@ RSpec.describe AnswerBlueprint do
           message: answer.message,
           useful: true,
         }.as_json
-        output_json = described_class.render_as_json(Answer.includes(%i[sources feedback]).find(answer.id))
+        output_json = described_class.render_as_json(answer.reload)
 
         expect(output_json).to eq(expected_json)
       end

--- a/spec/blueprints/conversation_blueprint_spec.rb
+++ b/spec/blueprints/conversation_blueprint_spec.rb
@@ -26,12 +26,10 @@ RSpec.describe ConversationBlueprint do
     context "with answered questions and a pending question" do
       it "generates the correct JSON" do
         pending_question = create(:question, conversation:)
-        answered_question1 = create(:question, :with_answer, conversation:)
-        answered_question2 = create(:question, :with_answer, conversation:)
-
-        answered_questions = Question.where(id: [answered_question1.id, answered_question2.id])
-                                     .includes(answer: %i[sources feedback])
-        pending_question = Question.includes(answer: %i[sources feedback]).find(pending_question.id)
+        answered_questions = [
+          create(:question, :with_answer, conversation:),
+          create(:question, :with_answer, conversation:),
+        ]
 
         expected_json = {
           id: conversation.id,
@@ -55,19 +53,18 @@ RSpec.describe ConversationBlueprint do
     context "with no pending question passed in" do
       it "omits pending_question from the output" do
         answered_question = create(:question, :with_answer, conversation:)
-        eager_loaded_answered = Question.includes(answer: %i[sources feedback]).find(answered_question.id)
 
         expected_json = {
           id: conversation.id,
           created_at: conversation.created_at.iso8601,
           answered_questions: [
-            QuestionBlueprint.render_as_hash(eager_loaded_answered, view: :answered),
+            QuestionBlueprint.render_as_hash(answered_question, view: :answered),
           ],
         }.as_json
 
         output_json = described_class.render_as_json(
           conversation,
-          answered_questions: [eager_loaded_answered],
+          answered_questions: [answered_question],
           pending_question: nil,
         )
 

--- a/spec/blueprints/question_blueprint_spec.rb
+++ b/spec/blueprints/question_blueprint_spec.rb
@@ -16,18 +16,17 @@ RSpec.describe QuestionBlueprint do
     describe "view :answered" do
       it "includes the answer" do
         question = create(:question, :with_answer)
-        answer = Answer.includes(%i[sources feedback]).find(question.answer.id)
 
         expected_json = {
           id: question.id,
           conversation_id: question.conversation_id,
           created_at: question.created_at.iso8601,
           message: question.message,
-          answer: AnswerBlueprint.render_as_hash(answer),
+          answer: AnswerBlueprint.render_as_hash(question.answer),
         }.as_json
 
         output_json = described_class.render_as_json(
-          Question.includes(answer: %i[sources feedback]).find(question.id),
+          question,
           view: :answered,
         )
 

--- a/spec/factories/answer_factory.rb
+++ b/spec/factories/answer_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:message) { |n| "Answer #{n}" }
     status { :answered }
     sources { [] }
+    feedback { nil }
 
     trait :with_sources do
       sources do

--- a/spec/requests/api/v0/conversations_spec.rb
+++ b/spec/requests/api/v0/conversations_spec.rb
@@ -217,11 +217,8 @@ RSpec.describe "Api::V0::ConversationsController" do
         create(:question, :with_answer, conversation:),
       ]
 
-      expected_questions = Question.where(id: questions.map(&:id))
-                           .includes(answer: %i[sources feedback])
-
       expected_response = ConversationQuestions.new(
-        questions: expected_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
+        questions: questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
       ).to_json
 
       get api_v0_conversation_questions_path(conversation)
@@ -247,10 +244,8 @@ RSpec.describe "Api::V0::ConversationsController" do
       ]
       create(:question, :with_answer, conversation:, created_at: 1.minute.ago)
 
-      expected_questions = Question.where(id: recent_questions.map(&:id))
-                                   .includes(answer: %i[sources feedback])
       expected_response = ConversationQuestions.new(
-        questions: expected_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
+        questions: recent_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
         later_questions_url: api_v0_conversation_questions_path(conversation, after: recent_questions.last.id),
       ).to_json
 
@@ -267,10 +262,8 @@ RSpec.describe "Api::V0::ConversationsController" do
       ]
       create(:question, :with_answer, conversation:, created_at: 20.minutes.ago)
 
-      expected_questions = Question.where(id: later_questions.map(&:id))
-                                   .includes(answer: %i[sources feedback])
       expected_response = ConversationQuestions.new(
-        questions: expected_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
+        questions: later_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
         earlier_questions_url: api_v0_conversation_questions_path(conversation, before: later_questions.first.id),
       ).to_json
 
@@ -286,10 +279,8 @@ RSpec.describe "Api::V0::ConversationsController" do
       before_question = create(:question, :with_answer, conversation:, created_at: 7.minutes.ago)
       create(:question, :with_answer, conversation:, created_at: 6.minutes.ago)
 
-      loaded_questions = Question.where(id: expected_question.id)
-                                 .includes(answer: %i[sources feedback])
       expected_response = ConversationQuestions.new(
-        questions: loaded_questions.map { QuestionBlueprint.render_as_hash(_1, view: :answered) },
+        questions: [QuestionBlueprint.render_as_hash(expected_question, view: :answered)],
         earlier_questions_url: api_v0_conversation_questions_path(conversation, before: expected_question.id),
         later_questions_url: api_v0_conversation_questions_path(conversation, after: expected_question.id),
       ).to_json
@@ -545,8 +536,7 @@ RSpec.describe "Api::V0::ConversationsController" do
       it "returns the expected JSON" do
         get api_v0_answer_question_path(conversation, question), as: :json
 
-        eager_loaded_answer = Answer.includes(:sources, :feedback).find(answer.id)
-        expected_response = AnswerBlueprint.render_as_json(eager_loaded_answer)
+        expected_response = AnswerBlueprint.render_as_json(answer)
         expect(JSON.parse(response.body)).to eq(expected_response)
       end
 


### PR DESCRIPTION

Because the answer factory doesn't set a `feedback` attribute, we often
need to do this trick in the specs to get around eager loading where we
have to re-query the database using `includes`.

If we just set a `nil` value in the factory, we can use the records
created using the factory and avoid a bunch of querying.
