### PR TITLE
Explicitly add nil cached tokens for claude question rephraser

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/claude/question_rephraser.rb
@@ -37,6 +37,7 @@ module AnswerComposition::Pipeline
         {
           llm_prompt_tokens: response[:usage][:input_tokens],
           llm_completion_tokens: response[:usage][:output_tokens],
+          llm_cached_tokens: nil,
         }
       end
 

--- a/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRephraser, :aws_cred
       expect(result.metrics).to eq({
         llm_prompt_tokens: 10,
         llm_completion_tokens: 20,
+        llm_cached_tokens: nil,
       })
     end
   end


### PR DESCRIPTION
All other Claude pipeline steps either return the cached number of tokens or nil if we aren't caching the request. This brings the question rephraser in line with the other steps.