### PR TITLE
Use correct tool prompt for Claude structured answer

### DIFF
--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -108,7 +108,7 @@ module AnswerComposition::Pipeline
       end
 
       def tools
-        [prompt_config[:anthropic_sdk_tool_spec]]
+        [prompt_config[:tool_spec]]
       end
     end
   end

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -101,7 +101,7 @@ module StubClaudeMessages
     tools = Rails.configuration
                  .govuk_chat_private
                  .llm_prompts
-                 .claude[:structured_answer][:anthropic_sdk_tool_spec]
+                 .claude[:structured_answer][:tool_spec]
 
     allow(Rails.configuration.govuk_chat_private.llm_prompts.claude)
       .to receive(:structured_answer)
@@ -109,7 +109,7 @@ module StubClaudeMessages
         {
           cached_system_prompt: "Static portion",
           context_system_prompt: "Dynamic portion",
-          anthropic_sdk_tool_spec: tools,
+          tool_spec: tools,
         },
       )
 


### PR DESCRIPTION
Now we've updated the private gem to have two duplicate prompts

- tool_spec
- anthropic_sdk_tool_spec

we can port over to using tool_spec. After that we can remove anthropic_sdk_tool_spec from the private gem.