### PR TITLE
Rename client* to end_user* for auth

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -18,15 +18,15 @@ class Rack::Attack
     end
   end
 
-  throttle(Api::RateLimit::GOVUK_CLIENT_USER_READ_THROTTLE_NAME, limit: 120, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME, limit: 120, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
-      request.get_header("HTTP_GOVUK_CHAT_CLIENT_USER_ID").presence
+      request.get_header("HTTP_GOVUK_CHAT_END_USER_ID").presence
     end
   end
 
-  throttle(Api::RateLimit::GOVUK_CLIENT_USER_WRITE_THROTTLE_NAME, limit: 20, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME, limit: 20, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
-      request.get_header("HTTP_GOVUK_CHAT_CLIENT_USER_ID").presence
+      request.get_header("HTTP_GOVUK_CHAT_END_USER_ID").presence
     end
   end
 

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -19,7 +19,7 @@ paths:
       summary: Start conversation
       description: Create a conversation by posting an initial question
       parameters:
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       requestBody:
         required: true
         content:
@@ -40,12 +40,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "422":
           description: |
             Validation error on question submission (such as PII in question)
@@ -60,15 +60,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or Client User ID
+            Too many requests to write endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -76,12 +76,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
 
   /conversation/{conversation_id}:
     get:
@@ -96,7 +96,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       responses:
         "200":
           description: |
@@ -114,12 +114,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "404":
           description: |
             Either a conversation never existed with this id or has now expired
@@ -134,15 +134,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or Client User ID
+            Too many requests to read endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -150,12 +150,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
 
     put:
       summary: Update a conversation with a new question
@@ -169,7 +169,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       requestBody:
         required: true
         content:
@@ -190,12 +190,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "422":
           description: |
             Validation error on question submission (such as PII in question
@@ -211,15 +211,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or Client User ID
+            Too many requests to write endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -227,12 +227,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
 
   /conversation/{conversation_id}/questions:
     get:
@@ -259,7 +259,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       responses:
         "200":
           description: |
@@ -277,12 +277,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "404":
           description: |
             Either a conversation never existed with this id or has now expired.
@@ -299,15 +299,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or Client User ID
+            Too many requests to read endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -315,12 +315,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
 
   /conversation/{conversation_id}/questions/{question_id}/answer:
     get:
@@ -341,7 +341,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       responses:
         "200":
           description: The answer is available and is returned
@@ -356,12 +356,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "202":
           description: The answer is still being generated
           headers:
@@ -371,12 +371,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "404":
           description: Conversation or question do not exist
           content:
@@ -390,15 +390,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or Client User ID
+            Too many requests to read endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -406,12 +406,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
-            Govuk-Client-User-Id-Read-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitLimit'
-            Govuk-Client-User-Id-Read-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitRemaining'
-            Govuk-Client-User-Id-Read-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
 
   /conversation/{conversation_id}/answers/{answer_id}/feedback:
     post:
@@ -432,7 +432,7 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/ClientUserIdHeader"
+        - $ref: "#/components/parameters/EndUserIdHeader"
       requestBody:
         required: true
         content:
@@ -454,12 +454,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "422":
           description: Validation error processing the feedback
           content:
@@ -473,12 +473,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "404":
           description: Conversation or answer does not exist
           content:
@@ -492,15 +492,15 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or Client User ID
+            Too many requests to write endpoints from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -508,12 +508,12 @@ paths:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
             Govuk-Api-User-Write-RateLimit-Reset:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-Client-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitLimit'
-            Govuk-Client-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitRemaining'
-            Govuk-Client-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukClientUserIdWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
 
 
 security:
@@ -527,8 +527,8 @@ components:
         client application (e.g. GOV.UK App) and not an individual end user
       scheme: bearer
   parameters:
-    ClientUserIdHeader:
-      name: Govuk-Chat-Client-User-Id
+    EndUserIdHeader:
+      name: Govuk-Chat-End-User-Id
       in: header
       required: false
       description: |
@@ -553,15 +553,15 @@ components:
         a 429 Too Many Requests response.
       schema:
         type: string
-    GovukClientUserIdReadRateLimitLimit:
+    GovukEndUserIdReadRateLimitLimit:
       description: The request limit for the User ID in the current period.
       schema:
         type: string
-    GovukClientUserIdReadRateLimitRemaining:
+    GovukEndUserIdReadRateLimitRemaining:
       description: The number of remaining requests for the User ID in the current period.
       schema:
         type: string
-    GovukClientUserIdReadRateLimitReset:
+    GovukEndUserIdReadRateLimitReset:
       description: |
         Time remaining in seconds until the read request limit is reset for the User ID.
         If the User ID is currently at the limit, this is the time until next request can be made without returning
@@ -583,15 +583,15 @@ components:
         a 429 Too Many Requests response.
       schema:
         type: string
-    GovukClientUserIdWriteRateLimitLimit:
+    GovukEndUserIdWriteRateLimitLimit:
       description: The request limit for User ID writes in the current period.
       schema:
         type: string
-    GovukClientUserIdWriteRateLimitRemaining:
+    GovukEndUserIdWriteRateLimitRemaining:
       description: The number of remaining User ID write requests in the current period.
       schema:
         type: string
-    GovukClientUserIdWriteRateLimitReset:
+    GovukEndUserIdWriteRateLimitReset:
       description: |
         Time remaining in seconds until the write request limit is reset for the User ID.
         If the User ID is currently at the limit, this is the time until next request can be made without returning

--- a/lib/api/rate_limit.rb
+++ b/lib/api/rate_limit.rb
@@ -1,6 +1,6 @@
 class Api::RateLimit
   GOVUK_API_USER_READ_THROTTLE_NAME = "read requests to Conversations API with token".freeze
   GOVUK_API_USER_WRITE_THROTTLE_NAME = "write method requests to Conversations API with token".freeze
-  GOVUK_CLIENT_USER_READ_THROTTLE_NAME = "read requests to Conversations API with user id".freeze
-  GOVUK_CLIENT_USER_WRITE_THROTTLE_NAME = "write requests to Conversations API with user id".freeze
+  GOVUK_END_USER_READ_THROTTLE_NAME = "read requests to Conversations API with user id".freeze
+  GOVUK_END_USER_WRITE_THROTTLE_NAME = "write requests to Conversations API with user id".freeze
 end

--- a/lib/api/rate_limit/middleware.rb
+++ b/lib/api/rate_limit/middleware.rb
@@ -2,8 +2,8 @@ class Api::RateLimit::Middleware
   THROTTLE_TO_PREFIX_MAPPING = {
     Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME => "Govuk-Api-User-Read",
     Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME => "Govuk-Api-User-Write",
-    Api::RateLimit::GOVUK_CLIENT_USER_READ_THROTTLE_NAME => "Govuk-Client-User-Id-Read",
-    Api::RateLimit::GOVUK_CLIENT_USER_WRITE_THROTTLE_NAME => "Govuk-Client-User-Id-Write",
+    Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME => "Govuk-End-User-Id-Read",
+    Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME => "Govuk-End-User-Id-Write",
   }.freeze
 
   delegate :logger, to: Rails

--- a/spec/lib/api/rate_limit/middleware_spec.rb
+++ b/spec/lib/api/rate_limit/middleware_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::RateLimit::Middleware do
             period: 60,
             epoch_time: current_time,
           },
-          Api::RateLimit::GOVUK_CLIENT_USER_READ_THROTTLE_NAME => {
+          Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME => {
             limit: 5,
             count: 5,
             period: 60,
@@ -32,9 +32,9 @@ RSpec.describe Api::RateLimit::Middleware do
         expect(headers["Govuk-Api-User-Read-RateLimit-Remaining"]).to eq("7")
         expect(headers["Govuk-Api-User-Read-RateLimit-Reset"]).to eq("60s")
 
-        expect(headers["Govuk-Client-User-Id-Read-RateLimit-Limit"]).to eq("5")
-        expect(headers["Govuk-Client-User-Id-Read-RateLimit-Remaining"]).to eq("0")
-        expect(headers["Govuk-Client-User-Id-Read-RateLimit-Reset"]).to eq("50s")
+        expect(headers["Govuk-End-User-Id-Read-RateLimit-Limit"]).to eq("5")
+        expect(headers["Govuk-End-User-Id-Read-RateLimit-Remaining"]).to eq("0")
+        expect(headers["Govuk-End-User-Id-Read-RateLimit-Reset"]).to eq("50s")
       end
     end
 
@@ -79,9 +79,9 @@ RSpec.describe Api::RateLimit::Middleware do
           "Govuk-Api-User-Read-RateLimit-Limit",
           "Govuk-Api-User-Read-RateLimit-Remaining",
           "Govuk-Api-User-Read-RateLimit-Reset",
-          "Govuk-Client-User-Id-Read-RateLimit-Limit",
-          "Govuk-Client-User-Id-Read-RateLimit-Remaining",
-          "Govuk-Client-User-Id-Read-RateLimit-Reset",
+          "Govuk-End-User-Id-Read-RateLimit-Limit",
+          "Govuk-End-User-Id-Read-RateLimit-Remaining",
+          "Govuk-End-User-Id-Read-RateLimit-Reset",
         )
       end
     end

--- a/spec/support/rack_attack_examples.rb
+++ b/spec/support/rack_attack_examples.rb
@@ -116,13 +116,13 @@ module RackAttackExamples
   RSpec.shared_examples "throttles traffic for a single user ID" do |routes:, period:|
     include_context "with rack attack helpers"
     let(:route_params) { {} }
-    let(:headers) { { "HTTP_GOVUK_CHAT_CLIENT_USER_ID" => "test-user-123" } }
+    let(:headers) { { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-123" } }
 
     before do
-      read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_CLIENT_USER_READ_THROTTLE_NAME]
+      read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME]
       allow(read_throttle).to receive(:limit).and_return(1)
 
-      write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_CLIENT_USER_WRITE_THROTTLE_NAME]
+      write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME]
       allow(write_throttle).to receive(:limit).and_return(1)
     end
 
@@ -139,7 +139,7 @@ module RackAttackExamples
             expect_not_throttled_response(
               method,
               path,
-              { "HTTP_GOVUK_CHAT_CLIENT_USER_ID" => "test-user-456" },
+              { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-456" },
             )
           end
 
@@ -155,9 +155,9 @@ module RackAttackExamples
 
               expect(response.headers.keys)
                 .to include(
-                  a_string_matching(/govuk-client-user-id-(read|write)-ratelimit-limit/),
-                  a_string_matching(/govuk-client-user-id-(read|write)-ratelimit-remaining/),
-                  a_string_matching(/govuk-client-user-id-(read|write)-ratelimit-reset/),
+                  a_string_matching(/govuk-end-user-id-(read|write)-ratelimit-limit/),
+                  a_string_matching(/govuk-end-user-id-(read|write)-ratelimit-remaining/),
+                  a_string_matching(/govuk-end-user-id-(read|write)-ratelimit-reset/),
                 )
             end
           end


### PR DESCRIPTION
This name is a bit easier to understand, as it's for a specific user,
whereas "client" suggests maybe a device or type of application.
