### PR TITLE
Generate Titan embeddings for seed data

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -60,7 +60,10 @@ namespace :search do
       end
     end
 
-    embeddings = Search::TextToEmbedding.call(chunks.map(&:plain_content), llm_provider: :openai)
+    embeddings = Search::TextToEmbedding.call(
+      chunks.map(&:plain_content),
+      llm_provider: :titan,
+    )
     repository = Search::ChunkedContentRepository.new
     indexed = 0
 
@@ -72,7 +75,9 @@ namespace :search do
     puts "#{deleted} conflicting chunks deleted"
 
     chunks.each.with_index do |chunk, index|
-      document = chunk.to_opensearch_hash.merge(openai_embedding: embeddings[index])
+      document = chunk.to_opensearch_hash.merge(
+        titan_embedding: embeddings[index],
+      )
       repository.index_document(chunk.id, document)
       indexed += 1
     end

--- a/spec/lib/tasks/search_spec.rb
+++ b/spec/lib/tasks/search_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe "rake search tasks" do
     before do
       Rake::Task[task_name].reenable
 
-      allow(Search::TextToEmbedding).to receive(:call) do |arg|
-        arg.map { |a| mock_openai_embedding(a) }
+      allow(Search::TextToEmbedding::Titan).to receive(:call) do |arg|
+        arg.map { |a| mock_titan_embedding(a) }
       end
     end
 


### PR DESCRIPTION
We're switching from OpenAI to Titan for all of our embeddings. This
changes the rake task which generates the seed data to use Titan over
OpenAI.

This assumes that the Titan embeddings field is present in the index.

To update your current index (i.e. to just add the mapping), run:

```bash
$ rake search:update_chunked_content_mappings
```

Or to nuke your current index and start fresh, run:

```bash
$ rake search:recreate_chunked_content_index
```

Then generate the seeds:

```bash
$ rake search:populate_chunked_content_index_from_seeds
```

To verify the embeddings are present, open up a Rails console and run:

```ruby
client = OpenSearch::Client.new(**Rails.configuration.opensearch.slice(:url, :user,
:password))

client.search(index: Rails.configuration.opensearch.chunked_content_index!)["hits"]["hits"][0]["_source"]["titan_embedding"][0..10]

```

And it should show you the first 10 values of the Titan embedding for the first document in the index.