### PR TITLE
Switch to using claude_structured_answer as default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,7 @@ module GovukChat
 
     config.bigquery_dataset_id = ENV["BIGQUERY_DATASET"]
 
-    config.answer_strategy = ENV.fetch("ANSWER_STRATEGY", "openai_structured_answer")
+    config.answer_strategy = ENV.fetch("ANSWER_STRATEGY", "claude_structured_answer")
     config.embedding_provider = ENV.fetch("EMBEDDING_PROVIDER", "openai")
   end
 end

--- a/db/migrate/20250708100656_change_default_answer_strategy.rb
+++ b/db/migrate/20250708100656_change_default_answer_strategy.rb
@@ -1,0 +1,8 @@
+class ChangeDefaultAnswerStrategy < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default(:questions,
+                          :answer_strategy,
+                          from: "openai_structured_answer",
+                          to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_27_132815) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_08_100656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -100,7 +100,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_27_132815) do
     t.string "message", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "answer_strategy", default: "openai_structured_answer", null: false
+    t.string "answer_strategy", null: false
     t.string "unsanitised_message"
     t.index ["conversation_id"], name: "index_questions_on_conversation_id"
     t.index ["created_at"], name: "index_questions_on_created_at"

--- a/spec/factories/question_factory.rb
+++ b/spec/factories/question_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :question do
     conversation
     sequence(:message) { |n| "Message #{n}" }
-    answer_strategy { :openai_structured_answer }
+    answer_strategy { :claude_structured_answer }
 
     trait :with_answer do
       after(:build) do |question|

--- a/spec/lib/evaluation/report_generator_spec.rb
+++ b/spec/lib/evaluation/report_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
     [
       build(
         :answer,
-        message: "First answer from OpenAI",
+        message: "First answer",
         sources: [
           build(
             :answer_source,
@@ -36,7 +36,7 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
       ),
       build(
         :answer,
-        message: "Second answer from OpenAI",
+        message: "Second answer",
         sources: [
           build(:answer_source, title: "Check if you need a visa", content_chunk_id: "id3", content_chunk_digest: "digest3"),
         ],
@@ -93,8 +93,8 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
       expect(items).to match([
         {
           question: "How do I pay VAT?",
-          answer: hash_including("message" => "First answer from OpenAI"),
-          answer_strategy: "openai_structured_answer",
+          answer: hash_including("message" => "First answer"),
+          answer_strategy: Rails.configuration.answer_strategy,
           retrieved_context: [
             hash_including(title: "Late payments", used: true),
             hash_including(title: "Pay your VAT bill online", used: true),
@@ -103,8 +103,8 @@ RSpec.describe Evaluation::ReportGenerator, :chunked_content_index do
         },
         {
           question: "Do I need a visa?",
-          answer: hash_including("message" => "Second answer from OpenAI"),
-          answer_strategy: "openai_structured_answer",
+          answer: hash_including("message" => "Second answer"),
+          answer_strategy: Rails.configuration.answer_strategy,
           retrieved_context: [hash_including(title: "Check if you need a visa", used: true)],
         },
       ])

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "rake evaluation tasks" do
 
     it "outputs the answer_strategy and embedding_provider to stdout" do
       expect { Rake::Task[task_name].invoke("input.yml") }
-        .to output(/Generating report with answer strategy: openai_structured_answer and embedding provider: openai/).to_stdout
+        .to output(/Generating report with answer strategy: \S* and embedding provider: \S*/).to_stdout
     end
 
     it "generates the results as JSONL and prints them" do

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -97,7 +97,7 @@ module StubClaudeMessages
     )
   end
 
-  def stub_claude_structured_answer(question_or_history, answer, answered: true)
+  def stub_claude_structured_answer(question_or_history, answer, answered: true, sources_used: %w[link_1])
     tools = Rails.configuration
                  .govuk_chat_private
                  .llm_prompts
@@ -126,7 +126,7 @@ module StubClaudeMessages
     stub_claude_messages_response(
       question_or_history,
       content: [claude_messages_tool_use_block(
-        input: { answer:, answered:, sources_used: %w[link_1] },
+        input: { answer:, answered:, sources_used: },
         name: "output_schema",
       )],
       system:,

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -10,6 +10,12 @@ module SystemSpecHelpers
       .and_return("claude_structured_answer")
   end
 
+  def given_i_am_using_the_openai_structured_answer_strategy
+    allow(Rails.configuration)
+      .to receive(:answer_strategy)
+      .and_return("openai_structured_answer")
+  end
+
   def dismiss_cookie_banner
     visit homepage_path
 

--- a/spec/system/conversation_with_open_ai_with_structured_answer_spec.rb
+++ b/spec/system/conversation_with_open_ai_with_structured_answer_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe "Conversation with OpenAI with a structured answer", :chunked_content_index do
   scenario do
+    given_i_am_using_the_openai_structured_answer_strategy
+
     when_i_visit_the_conversation_page
     and_i_enter_a_question
     then_i_see_the_answer_is_pending


### PR DESCRIPTION
This changes our default answer strategy to be using Anthropic Claude rather than OpenAI. This has been changed to reflect that it is now the exception rather than the norm that we run this app with the OpenAI strategy and thus making this change reduces developer friction.