### PR TITLE
Add Rake task for generating Titan embeddings

### DIFF
--- a/app/jobs/generate_text_embedding_job.rb
+++ b/app/jobs/generate_text_embedding_job.rb
@@ -1,0 +1,27 @@
+class GenerateTextEmbeddingJob < ApplicationJob
+  queue_as :default
+
+  def perform(document_id)
+    repository = Search::ChunkedContentRepository.new
+
+    begin
+      result = repository.chunk(document_id)
+    rescue Search::ChunkedContentRepository::NotFound
+      Rails.logger.info("Document #{document_id} not found in the index.")
+      return
+    end
+
+    embedding = Search::TextToEmbedding.call(result.plain_content, llm_provider: :titan)
+
+    index_result = repository.index_document(
+      result._id,
+      { titan_embedding: embedding },
+    )
+
+    if %i[created updated].include?(index_result)
+      Rails.logger.info("Successfully indexed document #{document_id} with new embedding.")
+    else
+      Rails.logger.info("Failed to index document #{document_id}: unexpected result #{index_result}.")
+    end
+  end
+end

--- a/lib/tasks/embeddings.rake
+++ b/lib/tasks/embeddings.rake
@@ -1,0 +1,60 @@
+namespace :embeddings do
+  desc "Generate Titan embeddings for documents where the field is missing"
+  task generate_titan: :environment do
+    field_name = "titan_embedding"
+    scroll_size = 1000
+    batch_size = 10_000
+
+    repository = Search::ChunkedContentRepository.new
+    client = repository.client
+    index = repository.index
+
+    query = {
+      bool: {
+        must_not: [
+          { exists: { field: field_name } },
+        ],
+      },
+    }
+
+    response = client.count(
+      index:,
+      body: { query: },
+    )
+
+    puts "Documents missing #{field_name} field: #{response['count']}"
+
+    response = client.search(
+      index:,
+      scroll: "5m",
+      body: {
+        query:,
+        size: scroll_size,
+        _source: false,
+      },
+    )
+
+    document_ids = []
+    scroll_id = response["_scroll_id"]
+    documents = response.dig("hits", "hits") || []
+
+    document_ids.concat(documents.map { it["_id"] })
+
+    while document_ids.length < batch_size && documents.any?
+      response = client.scroll(
+        scroll_id: scroll_id,
+        scroll: "5m",
+      )
+      documents = response.dig("hits", "hits") || []
+      break if documents.empty?
+
+      document_ids.concat(documents.map { it["_id"] })
+    end
+
+    client.clear_scroll(scroll_id:)
+
+    document_ids.each do |id|
+      GenerateTextEmbeddingJob.perform_later(id)
+    end
+  end
+end

--- a/spec/jobs/generate_text_embedding_job_spec.rb
+++ b/spec/jobs/generate_text_embedding_job_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe GenerateTextEmbeddingJob, :chunked_content_index do
+  describe "#perform" do
+    it "logs an error if the document is not found" do
+      expect(Rails.logger).to receive(:info).with("Document non_existent_id not found in the index.")
+      described_class.new.perform("non_existent_id")
+    end
+
+    it "generates the embedding and indexes the document" do
+      document = build(:chunked_content_record, plain_content: "Content", titan_embedding: nil)
+      populate_chunked_content_index({ "id1" => document })
+      stub_bedrock_titan_embedding("Content")
+
+      expect(Rails.logger).to receive(:info).with("Successfully indexed document id1 with new embedding.")
+      described_class.new.perform("id1")
+
+      updated_document = chunked_content_search_client.get(index: chunked_content_index, id: "id1")
+      expect(updated_document["_source"]["titan_embedding"]).to eq(mock_titan_embedding("Content"))
+    end
+
+    it "overwrites the existing embedding" do
+      document = build(
+        :chunked_content_record,
+        plain_content: "Content",
+        titan_embedding: mock_titan_embedding("Old Content"),
+      )
+      populate_chunked_content_index({ "id1" => document })
+      stub_bedrock_titan_embedding("Content")
+
+      described_class.new.perform("id1")
+
+      updated_document = chunked_content_search_client.get(index: chunked_content_index, id: "id1")
+      expect(updated_document["_source"]["titan_embedding"]).to eq(mock_titan_embedding("Content"))
+    end
+
+    it "logs an error if the indexing fails" do
+      repository = instance_double(Search::ChunkedContentRepository)
+      allow(Search::ChunkedContentRepository).to receive(:new).and_return(repository)
+      allow(repository).to receive(:chunk).with("id1").and_return(
+        build(:chunked_content_search_result, plain_content: "Content"),
+      )
+
+      stub_bedrock_titan_embedding("Content")
+
+      allow(repository).to receive(:index_document).and_return(:failed)
+
+      expect(Rails.logger).to receive(:info).with("Failed to index document id1: unexpected result failed.")
+
+      described_class.new.perform("id1")
+    end
+  end
+end

--- a/spec/lib/tasks/embeddings_spec.rb
+++ b/spec/lib/tasks/embeddings_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "rake embeddings tasks", :chunked_content_index do
+  describe "embeddings:generate_titan" do
+    let(:task_name) { "embeddings:generate_titan" }
+    let(:documents) do
+      [
+        build(:chunked_content_record, plain_content: "Content 1", titan_embedding: nil),
+        build(:chunked_content_record, plain_content: "Content 2", titan_embedding: mock_titan_embedding("Content 2")),
+        build(:chunked_content_record, plain_content: "Content 3", titan_embedding: nil),
+      ]
+    end
+
+    before do
+      Rake::Task[task_name].reenable
+
+      populate_chunked_content_index({
+        "id1" => documents[0],
+        "id2" => documents[1],
+        "id3" => documents[2],
+      })
+
+      stub_bedrock_titan_embedding("Content 1")
+      stub_bedrock_titan_embedding("Content 3")
+    end
+
+    it "outputs a count of documents missing the titan_embedding field" do
+      expect { Rake::Task[task_name].invoke }
+        .to output(/Documents missing titan_embedding field: 2/).to_stdout
+    end
+
+    it "generates Titan embeddings for documents without existing embeddings" do
+      expect(GenerateTextEmbeddingJob).to receive(:perform_later).with("id1")
+      expect(GenerateTextEmbeddingJob).to receive(:perform_later).with("id3")
+      expect(GenerateTextEmbeddingJob).not_to receive(:perform_later).with("id2")
+
+      expect { Rake::Task[task_name].invoke }.to output.to_stdout
+    end
+  end
+end


### PR DESCRIPTION

This task will query for 10,000 documents in the OpenSearch index where
the `titan_embedding` field is blank. It does so using scrolling[1] so as to
make the query more efficient.

It builds up an array of 10,000 document IDs and loops through that
array, kicking off a background job for each document. That background
job will query the OpenSearch index for the document, generate the
embedding and write it back to the index.

The reason we're querying again is that we don't want to pass the full
text content of the document into the background job, as that'll mean
it's stored in Redis. Some content can be quite long so we want to avoid
storing potentially large amounts of data in Redis.

[1]: https://1291fa08092a4a2dfd6d43f11d7bbcf3f22bf569.opensearch.org/docs/1.1/opensearch/rest-api/scroll/
