### PR TITLE
Retry Titan embedding generation

### DIFF
--- a/lib/search/text_to_embedding/titan.rb
+++ b/lib/search/text_to_embedding/titan.rb
@@ -1,6 +1,9 @@
 class Search::TextToEmbedding
   class Titan
+    class InputTextTokenLimitExceededError < StandardError; end
+
     INPUT_TEXT_LENGTH_LIMIT = 50_000
+    RETRY_COUNT = 5
 
     def self.call(...) = new(...).call
 
@@ -10,13 +13,7 @@ class Search::TextToEmbedding
     end
 
     def call
-      # For strings longer than the embedding model limit we have to truncate
-      # the text.
-      # This is done silently and in future we may want to log this in a
-      # database or log a warning.
-      to_embed = text_collection.map(&method(:keep_input_within_text_limit))
-
-      embeddings = convert_text_to_embeddings(to_embed)
+      embeddings = text_collection.map(&method(:convert_text_to_embeddings))
 
       # return just first embedding rather than an array of embeddings if we
       # weren't given an array input
@@ -31,21 +28,46 @@ class Search::TextToEmbedding
       @bedrock_client ||= Aws::BedrockRuntime::Client.new
     end
 
-    def keep_input_within_text_limit(text)
-      text[0...INPUT_TEXT_LENGTH_LIMIT]
+    def convert_text_to_embeddings(text)
+      # Titan has a limit of 50,000 characters or 8,192 tokens for the input text.
+      # We have no way of knowing how many tokens the text will be, so we'll first
+      # truncate the text to 50,000 characters as we know we can't exceed that limit.
+      text = text[0...INPUT_TEXT_LENGTH_LIMIT]
+
+      # Now we'll try to embed the text. If it fails due to exceeding the token limit,
+      # we'll truncate the text further and try again, up to {RETRY_COUNT} times.
+      tries = 0
+
+      while tries < RETRY_COUNT
+        text = text[0...(text.length * 0.8)] if tries.positive? # Truncate to 80% of the current length
+
+        begin
+          return generate_embedding(text)
+        rescue Aws::BedrockRuntime::Errors::ValidationException => e
+          unless e.message =~ /too many input tokens/i
+            raise e
+          end
+
+          tries += 1
+
+          if tries >= RETRY_COUNT
+            raise(
+              InputTextTokenLimitExceededError,
+              "Failed to generate Titan embedding after #{RETRY_COUNT} attempts. #{e.message}",
+            )
+          end
+        end
+      end
     end
 
-    def convert_text_to_embeddings(to_embed_collection)
-      to_embed_collection.map do |text|
-        response = bedrock_client.invoke_model(
-          model_id: BedrockModels::TITAN_EMBED_V2,
-          body: {
-            inputText: text,
-          }.to_json,
-        )
-
-        JSON.parse(response.body.read)["embedding"]
-      end
+    def generate_embedding(text)
+      response = bedrock_client.invoke_model(
+        model_id: BedrockModels::TITAN_EMBED_V2,
+        body: {
+          inputText: text,
+        }.to_json,
+      )
+      JSON.parse(response.body.read)["embedding"]
     end
   end
 end

--- a/spec/lib/search/text_to_embedding/titan_spec.rb
+++ b/spec/lib/search/text_to_embedding/titan_spec.rb
@@ -25,10 +25,8 @@ RSpec.describe Search::TextToEmbedding::Titan do
       expect(embedding).to eq([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     end
 
-    it "truncates input text to the length limit" do
-      client = stub_bedrock_invoke_model(
-        bedrock_titan_embedding_response([1.0, 2.0, 3.0]),
-      )
+    it "truncates input text to the character length limit" do
+      client = stub_bedrock_titan_embedding
 
       long_text = "a" * (described_class::INPUT_TEXT_LENGTH_LIMIT + 1)
       described_class.call(long_text)
@@ -41,6 +39,70 @@ RSpec.describe Search::TextToEmbedding::Titan do
 
       expect(request_body["inputText"].length)
         .to eq(described_class::INPUT_TEXT_LENGTH_LIMIT)
+    end
+
+    it "retries embedding generation if the input exceeds the token limit" do
+      client = Aws::BedrockRuntime::Client.new(stub_responses: true)
+      allow(Aws::BedrockRuntime::Client).to receive(:new).and_return(client)
+      client.stub_responses(
+        :invoke_model,
+        [
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          bedrock_titan_embedding_response([1.0, 2.0, 3.0]),
+        ],
+      )
+
+      long_text = "a" * described_class::INPUT_TEXT_LENGTH_LIMIT
+      described_class.call(long_text)
+
+      expect(client.api_requests.size).to eq(3)
+
+      request_input_text_lengths = client.api_requests.map do |request|
+        JSON.parse(request.dig(:params, :body))["inputText"].length
+      end
+
+      expect(request_input_text_lengths).to eq([50_000, 40_000, 32_000])
+    end
+
+    it "raises an error if embedding generation fails after max number of retries" do
+      client = Aws::BedrockRuntime::Client.new(stub_responses: true)
+      allow(Aws::BedrockRuntime::Client).to receive(:new).and_return(client)
+      client.stub_responses(
+        :invoke_model,
+        [
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "400 Bad Request: Too many input tokens."),
+          bedrock_titan_embedding_response([1.0, 2.0, 3.0]),
+        ],
+      )
+
+      long_text = "a" * described_class::INPUT_TEXT_LENGTH_LIMIT
+
+      expect { described_class.call(long_text) }.to raise_error(
+        described_class::InputTextTokenLimitExceededError,
+        /Failed to generate Titan embedding after 5 attempts/,
+      )
+
+      expect(client.api_requests.size).to eq(5)
+    end
+
+    it "raises the original error if it is not a token limit error" do
+      client = Aws::BedrockRuntime::Client.new(stub_responses: true)
+      allow(Aws::BedrockRuntime::Client).to receive(:new).and_return(client)
+      client.stub_responses(
+        :invoke_model,
+        [
+          Aws::BedrockRuntime::Errors::ValidationException.new({}, "503 Service Unavailable"),
+        ],
+      )
+
+      expect { described_class.call("text") }.to raise_error(
+        Aws::BedrockRuntime::Errors::ValidationException,
+      )
     end
   end
 end


### PR DESCRIPTION
We've had an exception come through when generating Titan embeddings
where the input text exceeded the input token limit on Titan [1].

Titan supports either 50,000 characters OR 8,192 tokens for input [2]. We
already truncate to 50,000 characters, but there's no way for us to
know how many input tokens our text would convert to. So it's possible
that the input text is less than 50,000 characters but more than 8,192
tokens.

We used Tiktoken to calculate this for our OpenAI embeddings, but
there's no equivalent for other providers.

Currently an exception will just be raised if the token count is too
high, so this is an attempt to fix that. It will always truncate to
50,000 characters still, then it'll attempt an embedding on the
truncated text. If that fails, we'll try truncating to 80% of the
original text length. We'll continue truncating to 80% for 5 attempts.
If it's still too long then an exception is raised.

These numbers might need tweaking, but it feels like a good place to
start.

The vast majority of our chunks are within the limits, but sometimes a
bit chunk of HTML comes along (e.g. this content item [3]), which pushes it
over the limit.

[1]: https://govuk.sentry.io/issues/6726533431
[2]: https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html
[3]: https://www.gov.uk/api/content/government/publications/balai-directive-approved-premises/list-of-bodies-institutes-and-centres-approved-for-intra-community-trade-in-animals
