### PR TITLE
Remove the Context length exceeded error state

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,9 +2,6 @@ class Answer < ApplicationRecord
   module CannedResponses
     NO_CONTENT_FOUND_REPONSE = "Sorry, I can’t find anything on GOV.UK to help me answer your question. " \
       "Please try asking a different question.".freeze
-    CONTEXT_LENGTH_EXCEEDED_RESPONSE = "Sorry, your last question was too complex for me to answer. " \
-      "Could you make your question more specific? You can also try splitting it into multiple " \
-      "smaller questions and asking them separately.".freeze
     ANSWER_SERVICE_ERROR_RESPONSE = <<~MESSAGE.freeze
       Sorry, something went wrong while trying to answer your question. Try again later.
 
@@ -63,7 +60,6 @@ class Answer < ApplicationRecord
          clarification: "clarification",
          error_answer_guardrails: "error_answer_guardrails",
          error_answer_service_error: "error_answer_service_error",
-         error_context_length_exceeded: "error_context_length_exceeded",
          error_jailbreak_guardrails: "error_jailbreak_guardrails",
          error_non_specific: "error_non_specific",
          error_question_routing_guardrails: "error_question_routing_guardrails",

--- a/config/answer_statuses.yml
+++ b/config/answer_statuses.yml
@@ -63,11 +63,6 @@ error_answer_service_error:
   label_colour: "red"
   description: "received error from LLM"
   label_and_description: "Error - received error from LLM"
-error_context_length_exceeded:
-  label: "Error"
-  label_colour: "red"
-  description: "too many tokens sent to LLM"
-  label_and_description: "Error - too many tokens sent to LLM"
 error_jailbreak_guardrails:
   label: "Error"
   label_colour: "red"

--- a/lib/answer_composition/pipeline_runner.rb
+++ b/lib/answer_composition/pipeline_runner.rb
@@ -16,13 +16,6 @@ module AnswerComposition
       end
 
       context.answer
-    rescue OpenAIClient::ContextLengthExceededError => e
-      GovukError.notify(e)
-      context.abort_pipeline(
-        message: Answer::CannedResponses::CONTEXT_LENGTH_EXCEEDED_RESPONSE,
-        status: "error_context_length_exceeded",
-        error_message: error_message(e),
-      )
     rescue OpenAIClient::RequestError => e
       GovukError.notify(e)
       context.abort_pipeline(

--- a/lib/openai_client.rb
+++ b/lib/openai_client.rb
@@ -4,17 +4,12 @@ class OpenAIClient
   class RequestError < Faraday::Error; end
   class ClientError < RequestError; end
   class ServerError < RequestError; end
-  class ContextLengthExceededError < ClientError; end
 
   class ErrorMiddleware < Faraday::Middleware
     def call(env)
       @app.call(env)
     rescue Faraday::ClientError => e
-      if error_code(e.response) == "context_length_exceeded"
-        raise ContextLengthExceededError.new(e, e.response)
-      else
-        raise ClientError.new(e, e.response)
-      end
+      raise ClientError.new(e, e.response)
     rescue Faraday::ServerError => e
       raise ServerError.new(e, e.response)
     rescue Faraday::Error => e

--- a/spec/lib/answer_composition/pipeline_runner_spec.rb
+++ b/spec/lib/answer_composition/pipeline_runner_spec.rb
@@ -47,28 +47,6 @@ RSpec.describe AnswerComposition::PipelineRunner do
       end
     end
 
-    context "when the step raises an OpenAIClient::ContextLengthExceededError" do
-      let(:error) { OpenAIClient::ContextLengthExceededError.new("error message") }
-      let(:pipeline_step) { ->(_context) { raise error } }
-
-      it "notifies sentry" do
-        expect(GovukError).to receive(:notify).with(error)
-        described_class.call(question:, pipeline: [pipeline_step])
-      end
-
-      it "returns the context's answer with the correct message, status and error_message" do
-        result = described_class.call(question:, pipeline: [pipeline_step])
-        expect(result)
-          .to be_a(Answer)
-          .and have_attributes(
-            question:,
-            status: "error_context_length_exceeded",
-            message: Answer::CannedResponses::CONTEXT_LENGTH_EXCEEDED_RESPONSE,
-            error_message: "class: OpenAIClient::ContextLengthExceededError message: error message",
-          )
-      end
-    end
-
     context "when the step raises an OpenAIClient::RequestError" do
       let(:error) do
         OpenAIClient::RequestError.new(

--- a/spec/lib/openai_client_spec.rb
+++ b/spec/lib/openai_client_spec.rb
@@ -44,15 +44,6 @@ RSpec.describe OpenAIClient do # rubocop:disable RSpec/SpecFilePathFormat
         .to raise_error(OpenAIClient::RequestError)
     end
 
-    it "raises an OpenAIClient::ContextLengthExceededError when user input exceeds allowed tokens" do
-      stub_openai_chat_completion_error(status: 400,
-                                        type: "invalid_request_error",
-                                        code: "context_length_exceeded")
-
-      expect { described_class.build.chat(parameters: chat_parameters) }
-        .to raise_error(OpenAIClient::ContextLengthExceededError)
-    end
-
     it "sets OpenAI chat completion rate limit Prometheus gauges" do
       allow(PrometheusMetrics).to receive(:gauge)
       stub_request(:post, /openai\.com/)

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -32,13 +32,12 @@ RSpec.describe Question do
       create(:answer, status: :guardrails_answer)
       create(:answer, status: :error_non_specific)
       create(:answer, status: :error_answer_service_error)
-      create(:answer, status: :error_context_length_exceeded)
 
       expect(described_class.group_by_aggregate_status.count).to eq({
         "answered" => 1,
         "unanswerable" => 1,
         "guardrails" => 1,
-        "error" => 3,
+        "error" => 2,
       })
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/Q428F5Og/2585-remove-the-context-length-exceeded-error-state

This PR removes the dedicated rescue branch for OpenAIClient::ContextLengthExceededError in AnswerComposition::PipelineRunner, allowing those errors to fall through to the existing generic error handler. Claude has context length errors as part of standard 400 errors, and we’ve never seen this error from OpenAI in practice, so unifying it all under one path simplifies the code.