### PR TITLE
Fix GenerateTextEmbeddingJob when updating documents

### DIFF
--- a/app/jobs/generate_text_embedding_job.rb
+++ b/app/jobs/generate_text_embedding_job.rb
@@ -13,15 +13,12 @@ class GenerateTextEmbeddingJob < ApplicationJob
 
     embedding = Search::TextToEmbedding.call(result.plain_content, llm_provider: :titan)
 
-    index_result = repository.index_document(
-      result._id,
-      { titan_embedding: embedding },
-    )
+    result = repository.update_document(document_id, { titan_embedding: embedding })
 
-    if %i[created updated].include?(index_result)
+    if %i[created updated].include?(result)
       Rails.logger.info("Successfully indexed document #{document_id} with new embedding.")
     else
-      Rails.logger.info("Failed to index document #{document_id}: unexpected result #{index_result}.")
+      Rails.logger.info("Failed to index document #{document_id}: unexpected result #{result}.")
     end
   end
 end

--- a/lib/search/chunked_content_repository.rb
+++ b/lib/search/chunked_content_repository.rb
@@ -112,6 +112,19 @@ module Search
       result["result"].to_sym
     end
 
+    def update_document(id, attributes)
+      result = client.update(
+        index:,
+        id:,
+        body: {
+          doc: attributes,
+        },
+        refresh: default_refresh_writes,
+      )
+
+      result["result"].to_sym
+    end
+
     def id_digest_hash(base_path, batch_size: 100)
       search_body = {
         query: { term: { base_path: } },

--- a/spec/jobs/generate_text_embedding_job_spec.rb
+++ b/spec/jobs/generate_text_embedding_job_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe GenerateTextEmbeddingJob, :chunked_content_index do
       described_class.new.perform("id1")
 
       updated_document = chunked_content_search_client.get(index: chunked_content_index, id: "id1")
-      expect(updated_document["_source"]["titan_embedding"]).to eq(mock_titan_embedding("Content"))
+      expect(updated_document["_source"]).to include({
+        "titan_embedding" => mock_titan_embedding("Content"),
+        "plain_content" => "Content",
+      })
     end
 
     it "logs an error if the indexing fails" do
@@ -41,7 +44,7 @@ RSpec.describe GenerateTextEmbeddingJob, :chunked_content_index do
 
       stub_bedrock_titan_embedding("Content")
 
-      allow(repository).to receive(:index_document).and_return(:failed)
+      allow(repository).to receive(:update_document).and_return(:failed)
 
       expect(Rails.logger).to receive(:info).with("Failed to index document id1: unexpected result failed.")
 

--- a/spec/lib/search/chunked_content_repository_spec.rb
+++ b/spec/lib/search/chunked_content_repository_spec.rb
@@ -178,6 +178,30 @@ RSpec.describe Search::ChunkedContentRepository, :chunked_content_index do
     end
   end
 
+  describe "#update_document" do
+    it "saves the given attributes" do
+      populate_chunked_content_index(
+        "id1" => build(
+          :chunked_content_record,
+          base_path: "/a",
+          document_type: "news_story",
+          parent_document_type: nil,
+        ),
+      )
+
+      repository.update_document(
+        "id1",
+        { base_path: "/b", parent_document_type: "news_article" },
+      )
+
+      chunk = repository.chunk("id1")
+
+      expect(chunk.base_path).to eq("/b")
+      expect(chunk.document_type).to eq("news_story")
+      expect(chunk.parent_document_type).to eq("news_article")
+    end
+  end
+
   describe "#id_digest_hash" do
     before do
       populate_chunked_content_index(


### PR DESCRIPTION

Previously this job would call `index_document` which I'd assumed would
just update a single field if passed in.

However what it actually does is overwrite the entire document instead.

This adds a new `update_document` method in the ChunkedContentRepository
which will retain the original fields but set/update the attributes
passed in.

This means that the Titan embeddings I did yesterday are actually broken, and
all the documents contain just the embeddings, no other data.

So what I'll need to do after this is create a new index from a snapshot, with
a blank `titan_embedding` field. Then I'll need to re-run the rake task that
generates the embeddings. After that I'll point the default index to the new
index.
