### PR TITLE
Fix Content Error Response Typo

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,6 +1,6 @@
 class Answer < ApplicationRecord
   module CannedResponses
-    NO_CONTENT_FOUND_REPONSE = "Sorry, I can’t find anything on GOV.UK to help me answer your question. " \
+    NO_CONTENT_FOUND_RESPONSE = "Sorry, I can’t find anything on GOV.UK to help me answer your question. " \
       "Please try asking a different question.".freeze
     CONTEXT_LENGTH_EXCEEDED_RESPONSE = "Sorry, your last question was too complex for me to answer. " \
       "Could you make your question more specific? You can also try splitting it into multiple " \

--- a/lib/answer_composition/pipeline/search_result_fetcher.rb
+++ b/lib/answer_composition/pipeline/search_result_fetcher.rb
@@ -14,7 +14,7 @@ module AnswerComposition
 
         if search_results.blank?
           context.abort_pipeline!(
-            message: Answer::CannedResponses::NO_CONTENT_FOUND_REPONSE,
+            message: Answer::CannedResponses::NO_CONTENT_FOUND_RESPONSE,
             status: "unanswerable_no_govuk_content",
             metrics: { "search_results" => build_metrics(start_time) },
           )

--- a/spec/lib/answer_composition/pipeline/search_result_fetcher_spec.rb
+++ b/spec/lib/answer_composition/pipeline/search_result_fetcher_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AnswerComposition::Pipeline::SearchResultFetcher, :chunked_conten
     it "aborts the pipeline and updates the answer's status and message attributes" do
       expect { described_class.call(context) }.to throw_symbol(:abort)
         .and change { context.answer.status }.to("unanswerable_no_govuk_content")
-        .and change { context.answer.message }.to(Answer::CannedResponses::NO_CONTENT_FOUND_REPONSE)
+        .and change { context.answer.message }.to(Answer::CannedResponses::NO_CONTENT_FOUND_RESPONSE)
     end
 
     it "assigns metrics to the answer" do


### PR DESCRIPTION
This PR corrects a typo in the codebase, changing the incorrect "NO_CONTENT_FOUND_REPONSE" to "NO_CONTENT_FOUND_RESPONSE"