### PR TITLE
Remove Banned Status from answer status enum and config

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -46,7 +46,6 @@ class Answer < ApplicationRecord
   enum :status,
        {
          answered: "answered",
-         banned: "banned",
          clarification: "clarification",
          error_answer_guardrails: "error_answer_guardrails",
          error_answer_service_error: "error_answer_service_error",

--- a/config/answer_statuses.yml
+++ b/config/answer_statuses.yml
@@ -48,11 +48,6 @@ guardrails_question_routing:
   label_colour: "yellow"
   description: "question routing guardrails triggered"
   label_and_description: "Guardrails - question routing guardrails triggered"
-banned:
-  label: "Banned"
-  label_colour: "purple"
-  description: "user cannot generate answers due to shadow banning"
-  label_and_description: "Banned - user cannot generate answers due to shadow banning"
 error_answer_guardrails:
   label: "Error"
   label_colour: "red"


### PR DESCRIPTION
This PR drops the now‐unused banned value from our answer_status configuration. We’ve already rebuilt the enum type itself to exclude 'banned' as part of PR #375   , so this change cleans up the corresponding YAML and model definitions.

