### PR TITLE
Add model to pipeline metrics

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/claude/question_rephraser.rb
@@ -38,6 +38,7 @@ module AnswerComposition::Pipeline
           llm_prompt_tokens: response[:usage][:input_tokens],
           llm_completion_tokens: response[:usage][:output_tokens],
           llm_cached_tokens: nil,
+          model: response[:model],
         }
       end
 

--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -164,6 +164,7 @@ module AnswerComposition::Pipeline
           llm_prompt_tokens: claude_response[:usage][:input_tokens],
           llm_completion_tokens: claude_response[:usage][:output_tokens],
           llm_cached_tokens: claude_response[:usage][:cache_read_input_tokens],
+          model: claude_response[:model],
         }
       end
     end

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -95,6 +95,7 @@ module AnswerComposition::Pipeline
           llm_prompt_tokens: response[:usage][:input_tokens],
           llm_completion_tokens: response[:usage][:output_tokens],
           llm_cached_tokens: response[:usage][:cache_read_input_tokens],
+          model: response[:model],
         }
       end
 

--- a/lib/answer_composition/pipeline/jailbreak_guardrails.rb
+++ b/lib/answer_composition/pipeline/jailbreak_guardrails.rb
@@ -39,6 +39,7 @@ module AnswerComposition
           llm_prompt_tokens: response_or_error.llm_prompt_tokens,
           llm_completion_tokens: response_or_error.llm_completion_tokens,
           llm_cached_tokens: response_or_error.llm_cached_tokens,
+          model: response_or_error.model,
         }
       end
     end

--- a/lib/answer_composition/pipeline/openai/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/openai/question_rephraser.rb
@@ -78,6 +78,7 @@ module AnswerComposition::Pipeline::OpenAI
         llm_prompt_tokens: openai_response.dig("usage", "prompt_tokens"),
         llm_completion_tokens: openai_response.dig("usage", "completion_tokens"),
         llm_cached_tokens: openai_response.dig("usage", "prompt_tokens_details", "cached_tokens"),
+        model: openai_response["model"],
       }
     end
   end

--- a/lib/answer_composition/pipeline/openai/question_router.rb
+++ b/lib/answer_composition/pipeline/openai/question_router.rb
@@ -179,6 +179,7 @@ module AnswerComposition::Pipeline::OpenAI
         llm_prompt_tokens: openai_response.dig("usage", "prompt_tokens"),
         llm_completion_tokens: openai_response.dig("usage", "completion_tokens"),
         llm_cached_tokens: openai_response.dig("usage", "prompt_tokens_details", "cached_tokens"),
+        model: openai_response["model"],
       }
     end
   end

--- a/lib/answer_composition/pipeline/openai/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/openai/structured_answer_composer.rb
@@ -114,6 +114,7 @@ module AnswerComposition::Pipeline::OpenAI
         llm_prompt_tokens: openai_response.dig("usage", "prompt_tokens"),
         llm_completion_tokens: openai_response.dig("usage", "completion_tokens"),
         llm_cached_tokens: openai_response.dig("usage", "prompt_tokens_details", "cached_tokens"),
+        model: openai_response["model"],
       }
     end
   end

--- a/lib/answer_composition/pipeline/output_guardrails.rb
+++ b/lib/answer_composition/pipeline/output_guardrails.rb
@@ -15,6 +15,7 @@ module AnswerComposition
           llm_prompt_tokens: response_or_error.llm_prompt_tokens,
           llm_completion_tokens: response_or_error.llm_completion_tokens,
           llm_cached_tokens: response_or_error.llm_cached_tokens,
+          model: response_or_error.model,
         }
       end
 

--- a/lib/guardrails/claude/jailbreak_checker.rb
+++ b/lib/guardrails/claude/jailbreak_checker.rb
@@ -20,6 +20,7 @@ module Guardrails::Claude
         llm_prompt_tokens: response[:usage][:input_tokens],
         llm_completion_tokens: response[:usage][:output_tokens],
         llm_cached_tokens: nil,
+        model: response[:model],
       }
     end
 

--- a/lib/guardrails/claude/multiple_checker.rb
+++ b/lib/guardrails/claude/multiple_checker.rb
@@ -31,6 +31,7 @@ module Guardrails
           llm_prompt_tokens: llm_token_usage[:input_tokens],
           llm_completion_tokens: llm_token_usage[:output_tokens],
           llm_cached_tokens: llm_token_usage[:cache_read_input_tokens],
+          model: claude_response[:model],
         }
       end
 

--- a/lib/guardrails/jailbreak_checker.rb
+++ b/lib/guardrails/jailbreak_checker.rb
@@ -1,17 +1,31 @@
 module Guardrails
   class JailbreakChecker
-    Result = Data.define(:triggered, :llm_response, :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens)
+    Result = Data.define(
+      :triggered,
+      :llm_response,
+      :llm_prompt_tokens,
+      :llm_completion_tokens,
+      :llm_cached_tokens,
+      :model,
+    )
 
     class ResponseError < StandardError
-      attr_reader :llm_guardrail_result, :llm_response, :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens
+      attr_reader :llm_guardrail_result, :llm_response, :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens, :model
 
-      def initialize(message, llm_guardrail_result:, llm_response:, llm_prompt_tokens:, llm_completion_tokens:, llm_cached_tokens:)
+      def initialize(message,
+                     llm_guardrail_result:,
+                     llm_response:,
+                     llm_prompt_tokens:,
+                     llm_completion_tokens:,
+                     llm_cached_tokens:,
+                     model:)
         super(message)
         @llm_guardrail_result = llm_guardrail_result
         @llm_response = llm_response
         @llm_prompt_tokens = llm_prompt_tokens
         @llm_completion_tokens = llm_completion_tokens
         @llm_cached_tokens = llm_cached_tokens
+        @model = model
       end
 
       def as_json
@@ -77,6 +91,7 @@ module Guardrails
         llm_prompt_tokens: result[:llm_prompt_tokens],
         llm_completion_tokens: result[:llm_completion_tokens],
         llm_cached_tokens: result[:llm_cached_tokens],
+        model: result[:model],
       }
     end
   end

--- a/lib/guardrails/multiple_checker.rb
+++ b/lib/guardrails/multiple_checker.rb
@@ -1,7 +1,7 @@
 module Guardrails
   class MultipleChecker
     Result = Data.define(:triggered, :guardrails, :llm_response, :llm_guardrail_result,
-                         :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens) do
+                         :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens, :model) do
       def triggered_guardrails
         return [] unless guardrails
 
@@ -10,14 +10,15 @@ module Guardrails
     end
 
     class ResponseError < StandardError
-      attr_reader :llm_response, :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens
+      attr_reader :llm_response, :llm_prompt_tokens, :llm_completion_tokens, :llm_cached_tokens, :model
 
-      def initialize(message, llm_response, llm_prompt_tokens, llm_completion_tokens, llm_cached_tokens)
+      def initialize(message, llm_response, llm_prompt_tokens, llm_completion_tokens, llm_cached_tokens, model)
         super(message)
         @llm_response = llm_response
         @llm_prompt_tokens = llm_prompt_tokens
         @llm_completion_tokens = llm_completion_tokens
         @llm_cached_tokens = llm_cached_tokens
+        @model = model
       end
     end
 
@@ -92,10 +93,15 @@ module Guardrails
 
   private
 
-    def parse_response(llm_response:, llm_guardrail_result:, llm_prompt_tokens:, llm_completion_tokens:, llm_cached_tokens:)
+    def parse_response(llm_response:, llm_guardrail_result:, llm_prompt_tokens:, llm_completion_tokens:, llm_cached_tokens:, model:)
       unless response_pattern =~ llm_guardrail_result
         raise ResponseError.new(
-          "Error parsing guardrail response", llm_guardrail_result, llm_prompt_tokens, llm_completion_tokens, llm_cached_tokens
+          "Error parsing guardrail response",
+          llm_guardrail_result,
+          llm_prompt_tokens,
+          llm_completion_tokens,
+          llm_cached_tokens,
+          model,
         )
       end
 
@@ -111,6 +117,7 @@ module Guardrails
         llm_prompt_tokens: llm_prompt_tokens,
         llm_completion_tokens: llm_completion_tokens,
         llm_cached_tokens: llm_cached_tokens,
+        model:,
       )
     end
 

--- a/lib/guardrails/openai/jailbreak_checker.rb
+++ b/lib/guardrails/openai/jailbreak_checker.rb
@@ -30,6 +30,7 @@ module Guardrails::OpenAI
         llm_prompt_tokens: llm_token_usage["prompt_tokens"],
         llm_completion_tokens: llm_token_usage["completion_tokens"],
         llm_cached_tokens: llm_token_usage.dig("prompt_tokens_details", "cached_tokens"),
+        model: openai_response["model"],
       }
     end
 

--- a/lib/guardrails/openai/multiple_checker.rb
+++ b/lib/guardrails/openai/multiple_checker.rb
@@ -21,6 +21,7 @@ module Guardrails
           llm_prompt_tokens: llm_token_usage["prompt_tokens"],
           llm_completion_tokens: llm_token_usage["completion_tokens"],
           llm_cached_tokens: llm_token_usage.dig("prompt_tokens_details", "cached_tokens"),
+          model: openai_response["model"],
         }
       end
 

--- a/spec/factories/output_guardrail_result_factory.rb
+++ b/spec/factories/output_guardrail_result_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     llm_prompt_tokens { 13 }
     llm_completion_tokens { 7 }
     llm_cached_tokens { 10 }
+    model { "gpt-4o-mini-2024-07-18" }
 
     llm_response do
       {

--- a/spec/lib/answer_composition/pipeline/answer_guardrails_spec.rb
+++ b/spec/lib/answer_composition/pipeline/answer_guardrails_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe AnswerComposition::Pipeline::AnswerGuardrails do
         llm_prompt_tokens: 13,
         llm_completion_tokens: 7,
         llm_cached_tokens: 10,
+        model: "gpt-4o-mini-2024-07-18",
       })
     end
   end

--- a/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_rephraser_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRephraser, :aws_cred
         llm_prompt_tokens: 10,
         llm_completion_tokens: 20,
         llm_cached_tokens: nil,
+        model: BedrockModels::CLAUDE_SONNET,
       })
     end
   end

--- a/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRouter, :aws_credent
         llm_prompt_tokens: 10,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
+        model: BedrockModels::CLAUDE_SONNET,
       })
     end
 

--- a/spec/lib/answer_composition/pipeline/claude/structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/structured_answer_composer_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::StructuredAnswerComposer, :a
         llm_prompt_tokens: 10,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
+        model: BedrockModels::CLAUDE_SONNET,
       )
     end
 
@@ -113,6 +114,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::StructuredAnswerComposer, :a
           llm_prompt_tokens: 10,
           llm_completion_tokens: 20,
           llm_cached_tokens: 20,
+          model: BedrockModels::CLAUDE_SONNET,
         )
       end
     end

--- a/spec/lib/answer_composition/pipeline/jailbreak_guardrails_spec.rb
+++ b/spec/lib/answer_composition/pipeline/jailbreak_guardrails_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
   let(:llm_prompt_tokens) { 10 }
   let(:llm_completion_tokens) { 5 }
   let(:llm_cached_tokens) { 0 }
+  let(:model) { Guardrails::OpenAI::JailbreakChecker::OPENAI_MODEL }
 
   context "when the guardrails are not triggered" do
     before do
@@ -28,6 +29,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
                       llm_prompt_tokens:,
                       llm_completion_tokens:,
                       llm_cached_tokens:,
+                      model:,
                     ))
     end
 
@@ -64,6 +66,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
         llm_prompt_tokens: 10,
         llm_completion_tokens: 5,
         llm_cached_tokens: 0,
+        model:,
       })
     end
   end
@@ -78,6 +81,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
                       llm_prompt_tokens:,
                       llm_completion_tokens:,
                       llm_cached_tokens:,
+                      model:,
                     ))
     end
 
@@ -108,6 +112,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
         llm_prompt_tokens: 10,
         llm_completion_tokens: 5,
         llm_cached_tokens: 0,
+        model:,
       })
     end
   end
@@ -121,6 +126,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
         llm_prompt_tokens:,
         llm_completion_tokens:,
         llm_cached_tokens:,
+        model:,
       )
       allow(Guardrails::JailbreakChecker).to receive(:call).and_raise(error)
     end
@@ -149,6 +155,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails do
         llm_prompt_tokens: 10,
         llm_completion_tokens: 5,
         llm_cached_tokens: 0,
+        model:,
       })
     end
   end

--- a/spec/lib/answer_composition/pipeline/openai/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai/question_rephraser_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRephraser do # ruboc
         llm_prompt_tokens: 13,
         llm_completion_tokens: 7,
         llm_cached_tokens: 10,
+        model: "gpt-4o-mini-2024-07-18",
       })
     end
   end

--- a/spec/lib/answer_composition/pipeline/openai/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai/question_router_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::QuestionRouter do # rubocop:
         llm_prompt_tokens: 13,
         llm_completion_tokens: 7,
         llm_cached_tokens: 10,
+        model: "gpt-4o-mini-2024-07-18",
       })
     end
 

--- a/spec/lib/answer_composition/pipeline/openai/structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/openai/structured_answer_composer_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer, :c
           llm_prompt_tokens: 13,
           llm_completion_tokens: 7,
           llm_cached_tokens: 10,
+          model: "gpt-4o-mini-2024-07-18",
         })
       end
 
@@ -131,6 +132,7 @@ RSpec.describe AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer, :c
             llm_prompt_tokens: 13,
             llm_completion_tokens: 7,
             llm_cached_tokens: 10,
+            model: "gpt-4o-mini-2024-07-18",
           })
         end
       end

--- a/spec/lib/guardrails/claude/jailbreak_checker_spec.rb
+++ b/spec/lib/guardrails/claude/jailbreak_checker_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Guardrails::Claude::JailbreakChecker, :aws_credentials_stubbed do
       expect(result[:llm_cached_tokens]).to be_nil
     end
 
+    it "returns the model used" do
+      stub_claude_jailbreak_guardrails(input, triggered: false)
+      result = described_class.call(input)
+      expect(result[:model]).to eq(BedrockModels::CLAUDE_SONNET)
+    end
+
     it "returns the LLM response" do
       stub_claude_jailbreak_guardrails(input, triggered: false)
 

--- a/spec/lib/guardrails/claude/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/claude/multiple_checker_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Guardrails::Claude::MultipleChecker, :aws_credentials_stubbed do
         expect(result[:llm_prompt_tokens]).to eq(10)
         expect(result[:llm_completion_tokens]).to eq(20)
         expect(result[:llm_cached_tokens]).to eq(20)
+        expect(result[:model]).to eq(BedrockModels::CLAUDE_SONNET)
+      end
+
+      it "returns the model used" do
+        stub_claude_output_guardrails(input, "False | None")
+
+        result = described_class.call(input, prompt)
+
+        expect(result[:model]).to eq(BedrockModels::CLAUDE_SONNET)
       end
 
       it "uses an overridden AWS region if set" do

--- a/spec/lib/guardrails/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/multiple_checker_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Guardrails::MultipleChecker do
         llm_prompt_tokens: 13,
         llm_completion_tokens: 7,
         llm_cached_tokens: 10,
+        model: "gpt-4o-mini-2024-07-18",
       }
     end
     let(:guardrail_result) { build(:guardrails_multiple_checker_result, :pass) }

--- a/spec/lib/guardrails/open_ai/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/open_ai/multiple_checker_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Guardrails::OpenAI::MultipleChecker do
         expect(result[:llm_cached_tokens]).to eq(10)
       end
 
+      it "returns the model used" do
+        stub_openai_output_guardrail(input)
+        result = described_class.call(input, prompt)
+
+        expect(result[:model]).to eq("gpt-4o-mini-2024-07-18")
+      end
+
       context "when :question_routing_guardrails is passed in as the llm_prompt_name" do
         let(:llm_prompt_name) { :question_routing_guardrails }
         let(:guardrail_definitions) do

--- a/spec/lib/guardrails/openai/jailbreak_checker_spec.rb
+++ b/spec/lib/guardrails/openai/jailbreak_checker_spec.rb
@@ -21,5 +21,27 @@ RSpec.describe Guardrails::OpenAI::JailbreakChecker do # rubocop:disable RSpec/S
       described_class.call(input)
       expect(openai_request).to have_been_made
     end
+
+    it "returns the LLM token usage" do
+      stub_openai_chat_completion(
+        input,
+        answer: Guardrails::JailbreakChecker.pass_value,
+        chat_options: { model: described_class::OPENAI_MODEL },
+      )
+
+      result = described_class.call(input)
+
+      expect(result[:llm_prompt_tokens]).to eq(13)
+      expect(result[:llm_completion_tokens]).to eq(7)
+      expect(result[:llm_cached_tokens]).to eq(10)
+    end
+
+    it "returns the model used" do
+      stub_openai_chat_completion(input)
+
+      result = described_class.call(input)
+
+      expect(result[:model]).to eq("gpt-4o-mini-2024-07-18")
+    end
   end
 end

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe "rake evaluation tasks" do
             llm_prompt_tokens: 100,
             llm_completion_tokens: 100,
             llm_cached_tokens: 0,
+            model: Guardrails::OpenAI::JailbreakChecker::OPENAI_MODEL,
           )
           allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :openai).and_return(result)
           expected = { success: result }.to_json
@@ -200,6 +201,7 @@ RSpec.describe "rake evaluation tasks" do
             llm_prompt_tokens: 100,
             llm_completion_tokens: 100,
             llm_cached_tokens: 0,
+            model: Guardrails::OpenAI::JailbreakChecker::OPENAI_MODEL,
           )
           allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :openai).and_raise(error)
 

--- a/spec/support/guardrails_examples.rb
+++ b/spec/support/guardrails_examples.rb
@@ -33,6 +33,7 @@ module GuardrailsExamples
         llm_prompt_tokens: 13,
         llm_completion_tokens: 7,
         llm_cached_tokens: 10,
+        model: "gpt-4o-mini-2024-07-18",
       })
     end
   end
@@ -46,8 +47,12 @@ module GuardrailsExamples
           .to receive(:call)
           .and_raise(
             Guardrails::MultipleChecker::ResponseError.new(
-              "An error occurred", 'False | "1, 2"',
-              13, 7, 10
+              "An error occurred",
+              'False | "1, 2"',
+              13,
+              7,
+              10,
+              "gpt-4o-mini-2024-07-18",
             ),
           )
       end
@@ -77,6 +82,7 @@ module GuardrailsExamples
           llm_prompt_tokens: 13,
           llm_completion_tokens: 7,
           llm_cached_tokens: 10,
+          model: "gpt-4o-mini-2024-07-18",
         })
       end
     end


### PR DESCRIPTION
## Description 

We want to store the model that was used for our calls in the metrics so it's easy to see which answer strat/model was used for each LLM call since we're testing different models pretty often.

While you could get this information from the LLM response details tab. You'd have to dig through it to find it. This just feels easier.

In terms of implementation. I've grouped the straightforward ones (question rephraser, question routing and structured answer composer) together for each answer strat as these only touch a single class. 

The guardrails pipeline steps use checkers which call different classes based on the answer strat so i've done the work for both strats for each guardrails in separate commits.

## Screenshot 

<img width="550" height="884" alt="image" src="https://github.com/user-attachments/assets/a4fe74f9-25b3-4d96-acf8-c0bb4c8f6dc9" />

## Trello card

https://trello.com/c/2C46VxAk/2601-log-model-used-in-llm-metrics
