### PR TITLE
Add E2E test for Conversation API

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -28,7 +28,13 @@ class Conversation < ApplicationRecord
       scope = scope.where("questions.created_at > ?", after_timestamp)
     end
 
-    scope.last(limit || Rails.configuration.conversations.max_question_count)
+    scope = scope.limit(limit || Rails.configuration.conversations.max_question_count)
+
+    if before_id.blank? && after_id.present?
+      scope.order(created_at: :asc)
+    else
+      scope.order(created_at: :desc).reverse
+    end
   end
 
   def active_answered_questions_before?(timestamp)

--- a/spec/models/conversations_spec.rb
+++ b/spec/models/conversations_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe Conversation do
           conversation.questions_for_showing_conversation(after_id: 9999)
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      context "and there are more questions than the limit" do
+        it "returns the first N questions created after the given question's id" do
+          create(:question, conversation:, created_at: 1.minute.ago)
+          expected = [
+            create(:question, conversation:, created_at: 2.hours.ago),
+            create(:question, conversation:, created_at: 1.hour.ago),
+          ]
+          after_question = create(:question, conversation:, created_at: 3.hours.ago)
+
+          questions = conversation.reload.questions_for_showing_conversation(
+            after_id: after_question.id,
+          )
+          expect(questions).to eq(expected)
+        end
+      end
     end
 
     context "when a limit is provided" do

--- a/spec/requests/api/v0/conversation_flow_spec.rb
+++ b/spec/requests/api/v0/conversation_flow_spec.rb
@@ -1,0 +1,138 @@
+## These tests are designed to test E2E intercations with the the conversation API.
+## While they are requests specs and use the interface provided by request specs
+## we have chosen to use the system spec conventions for the tests.
+## Tests in this file should follow system spec conventions such as the given/when/then
+## syntax, instance variables over lets, and given over before blocks. This will help
+## the tests more readable and better express the intent of the tests since they each
+## cover multiple requests.
+
+# rubocop:disable RSpec/NoExpectationExample, RSpec/InstanceVariable
+RSpec.describe "Conversation API flow" do
+  describe "API user conducts a conversation" do
+    it "allows user to interact with the conversation API E2E" do
+      given_i_am_a_signed_in_api_user
+      when_i_create_a_conversation
+      and_i_poll_for_an_answer
+      then_i_see_the_question_has_been_accepted
+
+      when_the_question_is_answered
+      and_i_poll_for_an_answer
+      then_i_receive_that_answer
+
+      when_i_add_another_question_to_the_conversation
+      and_i_poll_for_an_answer
+      then_i_see_the_question_has_been_accepted
+
+      when_i_attempt_to_submit_another_question_again
+      then_i_receive_an_unprocessable_entity_response
+
+      when_the_question_is_answered
+      and_i_poll_for_an_answer
+      then_i_receive_that_answer
+    end
+  end
+
+  describe "API user paginates through a long conversation" do
+    it "allows user to paginate through the conversation" do
+      given_i_am_a_signed_in_api_user
+      and_i_have_a_conversation_with_many_questions
+      when_i_make_a_request_for_the_conversation
+      then_i_receive_a_successful_response
+
+      when_i_request_the_earlier_page_of_questions
+      then_i_receive_a_successful_response
+
+      when_i_request_the_earlier_page_of_questions
+      then_i_receive_a_successful_response
+      and_there_is_no_earlier_questions_url
+
+      when_i_request_the_later_page_of_questions
+      then_i_receive_a_successful_response
+
+      when_i_request_the_later_page_of_questions
+      then_i_receive_a_successful_response
+      and_there_is_no_later_questions_url
+    end
+  end
+
+  def given_i_am_a_signed_in_api_user
+    @api_user = create(:signon_user, :conversation_api)
+    login_as(@api_user)
+  end
+
+  def when_i_create_a_conversation
+    allow(AnswerComposition::Composer).to receive(:call) do |question|
+      question.build_answer(
+        message: "Stubbed answer for #{question.message}",
+        status: :answered,
+      )
+    end
+    post api_v0_create_conversation_path,
+         params: { user_question: "What is the capital of France?" },
+         as: :json
+    @conversation_id = JSON.parse(response.body)["conversation_id"]
+    @answer_url = JSON.parse(response.body)["answer_url"]
+  end
+
+  def and_i_poll_for_an_answer
+    get @answer_url
+  end
+
+  def then_i_see_the_question_has_been_accepted
+    expect(response).to have_http_status(:accepted)
+  end
+
+  def when_the_question_is_answered
+    execute_queued_sidekiq_jobs
+  end
+
+  def then_i_receive_that_answer
+    expect(response).to have_http_status(:ok)
+  end
+  alias_method :then_i_receive_a_successful_response, :then_i_receive_that_answer
+
+  def when_i_add_another_question_to_the_conversation
+    put api_v0_update_conversation_path(@conversation_id),
+        params: { user_question: "What is the capital of Spain?" },
+        as: :json
+    @answer_url = JSON.parse(response.body)["answer_url"]
+  end
+
+  def when_i_attempt_to_submit_another_question_again
+    put api_v0_update_conversation_path(@conversation_id),
+        params: { user_question: "What is the capital of Spain?" },
+        as: :json
+  end
+
+  def then_i_receive_an_unprocessable_entity_response
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  def and_i_have_a_conversation_with_many_questions
+    @conversation = create(:conversation, :api, signon_user: @api_user)
+    5.times { create(:question, :with_answer, conversation: @conversation) }
+  end
+
+  def when_i_make_a_request_for_the_conversation
+    allow(Rails.configuration.conversations).to receive(:api_questions_per_page).and_return(2)
+    get api_v0_show_conversation_path(@conversation)
+  end
+
+  def when_i_request_the_earlier_page_of_questions
+    get JSON.parse(response.body)["earlier_questions_url"]
+  end
+  alias_method :when_i_request_the_earliest_page_of_questions, :when_i_request_the_earlier_page_of_questions
+
+  def and_there_is_no_earlier_questions_url
+    expect(JSON.parse(response.body)["earlier_questions_url"]).to be_nil
+  end
+
+  def when_i_request_the_later_page_of_questions
+    get JSON.parse(response.body)["later_questions_url"]
+  end
+
+  def and_there_is_no_later_questions_url
+    expect(JSON.parse(response.body)["later_questions_url"]).to be_nil
+  end
+end
+# rubocop:enable RSpec/NoExpectationExample, RSpec/InstanceVariable


### PR DESCRIPTION
## Description 

We've had a few issues with the conversation API, around the link we return for the answer_url. Our current tests check individual endpoints, and don't check that the answer_url actaully works when used.

This adds an end-to-end test that checks the conversation API actually works as expected when the requests are chained together.

I've chosen to go with a multi-request request spec rather than a system spec. The reasoning for this is system specs really should be driven by the user interface, which obviously an API doesn't have. We could have added 'type: :request' to a system spec, but the fact we would have had to do that to get it working is a sign that it doesn't really fit the intended use.

There's also prior art for a multi-request request spec in various gov.uk code bases.

This PR does 3 things:

1. adds a flow test for conducting a conversation 
2. paginating back and forth through a long conversation
3. fixes a bug with the `later_questions_url` always returning the latest page of N questions

## Trello card

https://trello.com/c/OZnoMvIy/2619-add-test-that-checks-full-api-flow