### PR TITLE
Revisit Claude token usage to include cached tokens

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -161,7 +161,7 @@ module AnswerComposition::Pipeline
       def build_metrics(start_time)
         {
           duration: Clock.monotonic_time - start_time,
-          llm_prompt_tokens: claude_response[:usage][:input_tokens],
+          llm_prompt_tokens: BedrockModels.total_prompt_tokens(claude_response[:usage]),
           llm_completion_tokens: claude_response[:usage][:output_tokens],
           llm_cached_tokens: claude_response[:usage][:cache_read_input_tokens],
           model: claude_response[:model],

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -92,7 +92,7 @@ module AnswerComposition::Pipeline
       def build_metrics(start_time, response)
         {
           duration: Clock.monotonic_time - start_time,
-          llm_prompt_tokens: response[:usage][:input_tokens],
+          llm_prompt_tokens: BedrockModels.total_prompt_tokens(response[:usage]),
           llm_completion_tokens: response[:usage][:output_tokens],
           llm_cached_tokens: response[:usage][:cache_read_input_tokens],
           model: response[:model],

--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -1,4 +1,8 @@
 module BedrockModels
   CLAUDE_SONNET = ENV.fetch("CLAUDE_SONNET_MODEL_ID", "eu.anthropic.claude-sonnet-4-20250514-v1:0").freeze
   TITAN_EMBED_V2 = "amazon.titan-embed-text-v2:0".freeze
+
+  def self.total_prompt_tokens(usage)
+    usage[:input_tokens].to_i + usage[:cache_read_input_tokens].to_i + usage[:cache_write_input_tokens].to_i
+  end
 end

--- a/lib/guardrails/claude/multiple_checker.rb
+++ b/lib/guardrails/claude/multiple_checker.rb
@@ -28,7 +28,7 @@ module Guardrails
         {
           llm_response:,
           llm_guardrail_result:,
-          llm_prompt_tokens: llm_token_usage[:input_tokens],
+          llm_prompt_tokens: BedrockModels.total_prompt_tokens(claude_response[:usage]),
           llm_completion_tokens: llm_token_usage[:output_tokens],
           llm_cached_tokens: llm_token_usage[:cache_read_input_tokens],
           model: claude_response[:model],

--- a/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/question_router_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::QuestionRouter, :aws_credent
 
       expect(context.answer.metrics["question_routing"]).to eq({
         duration: 1.5,
-        llm_prompt_tokens: 10,
+        llm_prompt_tokens: 30,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
         model: BedrockModels::CLAUDE_SONNET,

--- a/spec/lib/answer_composition/pipeline/claude/structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/claude/structured_answer_composer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::StructuredAnswerComposer, :a
 
       expect(context.answer.metrics["structured_answer"]).to eq(
         duration: 1.5,
-        llm_prompt_tokens: 10,
+        llm_prompt_tokens: 30,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
         model: BedrockModels::CLAUDE_SONNET,
@@ -111,7 +111,7 @@ RSpec.describe AnswerComposition::Pipeline::Claude::StructuredAnswerComposer, :a
 
         expect(context.answer.metrics["structured_answer"]).to eq(
           duration: 1.5,
-          llm_prompt_tokens: 10,
+          llm_prompt_tokens: 30,
           llm_completion_tokens: 20,
           llm_cached_tokens: 20,
           model: BedrockModels::CLAUDE_SONNET,

--- a/spec/lib/bedrock_models_spec.rb
+++ b/spec/lib/bedrock_models_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe BedrockModels do
+  describe ".total_prompt_tokens" do
+    it "returns the total prompt tokens from usage" do
+      usage = {
+        input_tokens: 10,
+        cache_read_input_tokens: 5,
+        cache_write_input_tokens: 2,
+      }
+      expect(described_class.total_prompt_tokens(usage)).to eq(17)
+    end
+
+    it "returns 0 when no tokens are provided" do
+      usage = {}
+      expect(described_class.total_prompt_tokens(usage)).to eq(0)
+    end
+
+    it "handles nil values gracefully" do
+      usage = {
+        input_tokens: nil,
+        cache_read_input_tokens: nil,
+        cache_write_input_tokens: nil,
+      }
+      expect(described_class.total_prompt_tokens(usage)).to eq(0)
+    end
+  end
+end

--- a/spec/lib/guardrails/claude/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/claude/multiple_checker_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Guardrails::Claude::MultipleChecker, :aws_credentials_stubbed do
 
         result = described_class.call(input, prompt)
 
-        expect(result[:llm_prompt_tokens]).to eq(10)
+        expect(result[:llm_prompt_tokens]).to eq(30)
         expect(result[:llm_completion_tokens]).to eq(20)
         expect(result[:llm_cached_tokens]).to eq(20)
         expect(result[:model]).to eq(BedrockModels::CLAUDE_SONNET)


### PR DESCRIPTION
Trello: https://trello.com/c/UfBN7LZM/2611-revisit-tracking-claude-token-usage

Previously we only recorded the “fresh” prompt tokens sent to Claude (i.e. usage[:input_tokens]), ignoring any tokens read from or written to the cache. This meant our reported prompt token counts were too low whenever we used caching.

With this change we now calculate: 

`total_input = usage[:input_tokens] + usage[:cache_read_input_tokens] + usage[:cache_write_input_tokens]`

and store total_input as the true prompt token count.

The 3 pipeline steps that use caching have been updated to reflect this; QuestionRouter, StructuredAnswerComposer, and Guardrails::MultipleChecker.