### PR TITLE
Revert "Bump govuk_chat_private to 719b81e"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/alphagov/govuk_chat_private.git
-  revision: 719b81edece559e36a786df4dabbbf46f9d0acf2
+  revision: 008c3b09cf17e99a3974fb6f867356ab822839b4
   specs:
     govuk_chat_private (0.0.1)
       activesupport (>= 8)


### PR DESCRIPTION
Reverts alphagov/govuk-chat#386

We need to temporarily revert this to make a few changes. We added a couple of new question routing labels and removed one. So if that intent get's called it won't find the canned response in the prompt since it has been stripped out