### PR TITLE
Rename Total Prompt Tokens Method

### DIFF
--- a/lib/answer_composition/pipeline/claude/question_router.rb
+++ b/lib/answer_composition/pipeline/claude/question_router.rb
@@ -161,7 +161,7 @@ module AnswerComposition::Pipeline
       def build_metrics(start_time)
         {
           duration: Clock.monotonic_time - start_time,
-          llm_prompt_tokens: BedrockModels.total_prompt_tokens(claude_response[:usage]),
+          llm_prompt_tokens: BedrockModels.claude_total_prompt_tokens(claude_response[:usage]),
           llm_completion_tokens: claude_response[:usage][:output_tokens],
           llm_cached_tokens: claude_response[:usage][:cache_read_input_tokens],
           model: claude_response[:model],

--- a/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/claude/structured_answer_composer.rb
@@ -92,7 +92,7 @@ module AnswerComposition::Pipeline
       def build_metrics(start_time, response)
         {
           duration: Clock.monotonic_time - start_time,
-          llm_prompt_tokens: BedrockModels.total_prompt_tokens(response[:usage]),
+          llm_prompt_tokens: BedrockModels.claude_total_prompt_tokens(response[:usage]),
           llm_completion_tokens: response[:usage][:output_tokens],
           llm_cached_tokens: response[:usage][:cache_read_input_tokens],
           model: response[:model],

--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -2,7 +2,7 @@ module BedrockModels
   CLAUDE_SONNET = ENV.fetch("CLAUDE_SONNET_MODEL_ID", "eu.anthropic.claude-sonnet-4-20250514-v1:0").freeze
   TITAN_EMBED_V2 = "amazon.titan-embed-text-v2:0".freeze
 
-  def self.total_prompt_tokens(usage)
+  def self.claude_total_prompt_tokens(usage)
     usage[:input_tokens].to_i + usage[:cache_read_input_tokens].to_i + usage[:cache_write_input_tokens].to_i
   end
 end

--- a/lib/guardrails/claude/multiple_checker.rb
+++ b/lib/guardrails/claude/multiple_checker.rb
@@ -28,7 +28,7 @@ module Guardrails
         {
           llm_response:,
           llm_guardrail_result:,
-          llm_prompt_tokens: BedrockModels.total_prompt_tokens(claude_response[:usage]),
+          llm_prompt_tokens: BedrockModels.claude_total_prompt_tokens(claude_response[:usage]),
           llm_completion_tokens: llm_token_usage[:output_tokens],
           llm_cached_tokens: llm_token_usage[:cache_read_input_tokens],
           model: claude_response[:model],

--- a/spec/lib/bedrock_models_spec.rb
+++ b/spec/lib/bedrock_models_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe BedrockModels do
-  describe ".total_prompt_tokens" do
+  describe ".claude_total_prompt_tokens" do
     it "returns the total prompt tokens from usage" do
       usage = {
         input_tokens: 10,
         cache_read_input_tokens: 5,
         cache_write_input_tokens: 2,
       }
-      expect(described_class.total_prompt_tokens(usage)).to eq(17)
+      expect(described_class.claude_total_prompt_tokens(usage)).to eq(17)
     end
 
     it "returns 0 when no tokens are provided" do
       usage = {}
-      expect(described_class.total_prompt_tokens(usage)).to eq(0)
+      expect(described_class.claude_total_prompt_tokens(usage)).to eq(0)
     end
 
     it "handles nil values gracefully" do
@@ -20,7 +20,7 @@ RSpec.describe BedrockModels do
         cache_read_input_tokens: nil,
         cache_write_input_tokens: nil,
       }
-      expect(described_class.total_prompt_tokens(usage)).to eq(0)
+      expect(described_class.claude_total_prompt_tokens(usage)).to eq(0)
     end
   end
 end


### PR DESCRIPTION
This is a small PR that renames the 'total_prompt_tokens' method within lib/bedrock_models.rb to 'claude_total_prompt_tokens'. This is due to the method being applicable only to Claude models, so renaming it to be indicative of this fact would assist in the readability of the codebase.