### PR TITLE
Move tag component stylesheet to admin area

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -22,6 +22,7 @@
 @import "govuk_publishing_components/components/success-alert";
 @import "govuk_publishing_components/components/summary-list";
 @import "govuk_publishing_components/components/table";
+@import "govuk_publishing_components/components/tag";
 @import "govuk_publishing_components/components/notice";
 @import "govuk_publishing_components/components/warning-text";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,7 +16,6 @@
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/skip-link";
 @import "govuk_publishing_components/components/success-alert";
-@import "govuk_publishing_components/components/tag";
 @import "govuk_publishing_components/components/warning-text";
 
 @import "objects/conversation-layout";


### PR DESCRIPTION
This was mistakenly added to the application.scss file when it is expected to only be needed in the admin area where the layout-header component is used.

It is needed because recent changes to the layout-header component have removed the import of a tag stylesheet which now needs to be imported manually [1].

Before:
<img width="984" height="150" alt="Screenshot 2025-07-21 at 19 27 21" src="https://github.com/user-attachments/assets/de93acd2-708f-4084-a4ce-5ad1ed389407" />

After:
<img width="993" height="160" alt="Screenshot 2025-07-21 at 19 26 53" src="https://github.com/user-attachments/assets/1d08f4ef-40cc-4fe4-b3ec-1e7de5c73c59" />

[1]: https://github.com/alphagov/govuk_publishing_components/pull/4914