### PR TITLE
[DO NOT MERGE] Add answer sources URL and Signon user email to BigQuery export

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -140,7 +140,10 @@ class Answer < ApplicationRecord
   end
 
   def serialize_for_export
-    as_json.merge("sources" => sources.map(&:serialize_for_export))
+    message_with_prod_source_links = {
+      "message" => message.gsub("https://www.integration.publishing.service.gov.uk/", "https://www.gov.uk/"),
+    }
+    as_json.merge("sources" => sources.map(&:serialize_for_export)).merge(message_with_prod_source_links)
   end
 
   def assign_metrics(namespace, values)

--- a/app/models/answer_source.rb
+++ b/app/models/answer_source.rb
@@ -9,6 +9,8 @@ class AnswerSource < ApplicationRecord
   end
 
   def serialize_for_export
-    as_json
+    as_json.merge(
+      "url" => "https://www.gov.uk#{exact_path}",
+    )
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -24,6 +24,7 @@ class Question < ApplicationRecord
 
   scope :exportable, lambda { |start_date, end_date|
                        joins(:conversation, :answer)
+                       .includes(conversation: :signon_user)
                        .preload(:conversation, answer: %i[sources])
                        .where("answer.created_at": start_date...end_date)
                      }
@@ -57,6 +58,7 @@ class Question < ApplicationRecord
       "answer" => answer&.serialize_for_export,
       "source" => conversation.source,
       "signon_user_id" => conversation.signon_user_id,
+      "signon_user_email" => conversation.signon_user&.email,
       "end_user_id" => conversation.hashed_end_user_id,
     )
   end

--- a/lib/bigquery/individual_export.rb
+++ b/lib/bigquery/individual_export.rb
@@ -36,7 +36,12 @@ module Bigquery
       return Result.new(tempfile: nil, count: 0) unless export_data
 
       tempfile = Tempfile.new
-      export_data.each { |record| tempfile.puts(record.to_json) }
+      export_data.each do |record|
+        if record.dig("answer", "llm_responses", "answer_guardrails").is_a?(String)
+          record["answer"]["llm_responses"]["answer_guardrails"] = nil
+        end
+        tempfile.puts(record.to_json)
+      end
       tempfile.rewind
 
       Result.new(tempfile:, count: export_data.count)

--- a/spec/lib/bigquery/individual_export_spec.rb
+++ b/spec/lib/bigquery/individual_export_spec.rb
@@ -65,10 +65,11 @@ RSpec.describe Bigquery::IndividualExport do
 
       it "returns a result with the count of the items from the timeframe" do
         create_list(:answer, 3, created_at: 2.hours.ago)
+        create(:answer, :with_sources, created_at: 2.hours.ago)
 
         result = described_class.call(table_name, export_from:, export_until:)
 
-        expect(result.count).to eq(3)
+        expect(result.count).to eq(4)
       end
 
       it "has a tempfile containing JSON of the models serialized for export with nil values removed" do

--- a/spec/models/answer_source_spec.rb
+++ b/spec/models/answer_source_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe AnswerSource do
   end
 
   describe "#serialize for export" do
-    it "returns a source serialzed as json" do
-      source = create(:answer_feedback)
-      expect(source.serialize_for_export).to eq(source.as_json)
+    it "returns a source and it's full production url serialized as json" do
+      source = create(:answer_source)
+      expected_json = source.as_json.merge("url" => "https://www.gov.uk#{source.exact_path}")
+      expect(source.serialize_for_export).to eq(expected_json)
     end
   end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe Answer do
         .to include(answer.as_json)
         .and include("sources" => answer.sources.map(&:serialize_for_export))
     end
+
+    it "gsubs links to production URLs" do
+      answer = create(:answer, message: "https://www.integration.publishing.service.gov.uk/some-path")
+      serialized_answer = answer.serialize_for_export
+
+      expect(serialized_answer["message"]).to eq("https://www.gov.uk/some-path")
+    end
   end
 
   describe "#assign_metrics" do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Question do
           .and include("source" => "web")
           .and include("signon_user_id" => signon_user.id)
           .and include("end_user_id" => conversation.hashed_end_user_id)
+          .and include("signon_user_email" => signon_user.email)
       end
     end
 


### PR DESCRIPTION
## Description

This is a temporary change to help with manual evaluation. We want to be able to easily link users to the sources used on integration and be able to send users a list of their questions based on their email address.

We should revert this change and clean up the data to remove the columns after manual evaluation is complete. 
## Trello card

https://trello.com/c/5PzKEFnr/2629-set-up-chat-version-in-integration-export-of-conversation-logs-for-rainbow-team-manul-eval-red-teaming