### PR TITLE
Allow filtering of web created questions by signon user

### DIFF
--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -121,7 +121,7 @@ private
   def signon_user_scope(scope)
     return scope if signon_user_id.blank?
 
-    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id, source: :api })
+    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id })
   end
 
   def end_user_id_scope(scope)

--- a/app/views/admin/questions/_question_filters.html.erb
+++ b/app/views/admin/questions/_question_filters.html.erb
@@ -6,7 +6,7 @@
 <%= form_with(url: admin_questions_path, method: :get) do %>
   <% if signon_user.present? %>
     <p class="govuk-body">
-      Filtering by API user: <%= signon_user.name %>
+      Filtering by Signon user: <%= signon_user.name %>
     </p>
     <%= hidden_field_tag(:signon_user_id, params[:signon_user_id]) %>
   <% end %>

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -221,23 +221,15 @@ RSpec.describe Admin::Filters::QuestionsFilter do
     it "filters the results by signon user" do
       alice = create(:signon_user, email: "alice@example.com")
       bob = create(:signon_user, email: "bob@example.com")
-      alice_question = create(:question, conversation: create(:conversation, :api, signon_user: alice))
-      bob_question = create(:question, conversation: create(:conversation, :api, signon_user: bob))
+      alice_question = create(:question, conversation: create(:conversation, signon_user: alice))
+      bob_question_created_via_api = create(:question, conversation: create(:conversation, :api, signon_user: bob))
+      bob_question_created_via_web = create(:question, conversation: create(:conversation, signon_user: bob))
 
       filter = described_class.new(signon_user_id: alice.id)
       expect(filter.results).to eq([alice_question])
 
       filter = described_class.new(signon_user_id: bob.id)
-      expect(filter.results).to eq([bob_question])
-    end
-
-    it "filters out results assoicated with a signon user that weren't created via the API" do
-      signon_user = create(:signon_user)
-      create(:question, conversation: create(:conversation, signon_user:))
-
-      filter = described_class.new(signon_user_id: signon_user.id)
-
-      expect(filter.results).to eq([])
+      expect(filter.results).to eq([bob_question_created_via_api, bob_question_created_via_web])
     end
 
     it "filters the results by end_user_id" do

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       expect(filter.results).to eq([alice_question])
 
       filter = described_class.new(signon_user_id: bob.id)
-      expect(filter.results).to eq([bob_question_created_via_api, bob_question_created_via_web])
+      expect(filter.results).to contain_exactly(bob_question_created_via_api, bob_question_created_via_web)
     end
 
     it "filters the results by end_user_id" do

--- a/spec/requests/admin/questions_spec.rb
+++ b/spec/requests/admin/questions_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Admin::QuestionsController" do
         get admin_questions_path(signon_user_id: signon_user.id)
 
         expect(response.body.squish)
-          .to have_content("Filtering by API user: #{signon_user.name}")
+          .to have_content("Filtering by Signon user: #{signon_user.name}")
       end
 
       it "renders the end user details when filtering by end_user_id" do

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -122,12 +122,8 @@ RSpec.describe "Admin user filters questions" do
     end
   end
 
-  def then_i_see_that_users_details_in_the_sidebar
-    expect(page).to have_content("Filtering by user: #{@user.email}")
-  end
-
   def then_i_see_that_signon_users_details_in_the_sidebar
-    expect(page).to have_content("Filtering by API user: #{@signon_user.name}")
+    expect(page).to have_content("Filtering by Signon user: #{@signon_user.name}")
   end
 
   def and_i_see_all_the_questions_for_that_user


### PR DESCRIPTION
## Description 

I'm not really sure why this was added. I'm assuming it was before we associated a Signon User with a conversation created via the web inferface.

I think it's probably because we expect there to be no user when/if we go into Public Beta, but for now we since conversations can be only be created with a Signon User we should allow filtering by that user in both instances.

## Screenshots 
### Before

<img width="632" height="487" alt="image" src="https://github.com/user-attachments/assets/2685652f-0c04-4d06-95ca-3e084ddb08a3" />


### After

<img width="840" height="410" alt="image" src="https://github.com/user-attachments/assets/ed3a9eeb-340d-4d3d-804b-22a013d47ae8" />
