### PR TITLE
Recognise /auth/gds as API requests

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,7 +1,7 @@
 GDS::SSO.config do |config|
   config.intercept_401_responses = false
   config.user_model = "SignonUser"
-  config.api_request_matcher = ->(request) { request.path.start_with?("/api/") }
+  config.api_request_matcher = ->(request) { request.path.start_with?("/api/") || request.path.start_with?("/auth/gds/api/") }
   # despite the broad name this config option only applies to the dummy bearer token user created in dev/test
   config.additional_mock_permissions_required = %w[conversation-api]
 end


### PR DESCRIPTION
Requests to /auth/gds/api are authenticated with a bearer token and are currently raising errors as they are failing.

This acts as a quick fix to stop the errors occurring while I put together a more substantial fix in GDS SSO.