### PR TITLE
Consider signon ID when rate limiting end user ID

### DIFF
--- a/spec/support/rack_attack_examples.rb
+++ b/spec/support/rack_attack_examples.rb
@@ -94,6 +94,11 @@ module RackAttackExamples
             )
           end
 
+          it "doesn't reject a request to #{method} #{path} with a different signon ID" do
+            login_as(create(:signon_user))
+            expect_not_throttled_response(method, path)
+          end
+
           it "doesn't reject a request to #{method} #{path} after the time period" do
             travel_to(Time.current + period + 1.second) do
               expect_not_throttled_response(method, path, headers)
@@ -111,6 +116,19 @@ module RackAttackExamples
                   a_string_matching(/govuk-end-user-id-(read|write)-ratelimit-reset/),
                 )
             end
+          end
+        end
+
+        context "when the end user ID header is not present" do
+          let(:headers) { {} }
+
+          it "doesn't reject a request to #{method} #{path} when the signon ID is set" do
+            login_as(create(:signon_user))
+            expect_not_throttled_response(method, path)
+          end
+
+          it "doesn't reject a request to #{method} #{path} when the signon ID is not set" do
+            expect_not_throttled_response(method, path)
           end
         end
       end


### PR DESCRIPTION
https://trello.com/c/I8oJMVpN/2597

When we rate limit the end user ID, we're just rate limiting whatever ID
the client gives us.

This opens up the possibility of a clash of IDs if/when we support
multiple clients.

To mitigate this, the key we use to throttle a request should include
the signon ID too. That way we'll get unique keys for users across
clients.