### PR TITLE
Remove embedding provider from evaluation task

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -82,15 +82,9 @@ namespace :evaluation do
   end
 
   desc "Produce the output of a RAG response for a user input"
-  task :generate_rag_structured_answer_response, %i[llm_provider embedding_provider] => :environment do |_, args|
+  task :generate_rag_structured_answer_response, %i[llm_provider] => :environment do |_, args|
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
     raise "Requires an llm provider" if args[:llm_provider].blank?
-
-    if args[:embedding_provider]
-      Rails.configuration.embedding_provider = args[:embedding_provider]
-    else
-      warn "No embedding_provider argument provided, using #{Rails.configuration.embedding_provider}"
-    end
 
     question = Question.new(message: ENV["INPUT"], conversation: Conversation.new)
 


### PR DESCRIPTION
https://trello.com/c/j7TmfsR6/2539

We only support one embedding provider now so there's no need to have this
configurable or output it in the evaluation task.

I'll follow up with another PR to remove the embedding provider config from
the code that does the embedding.