### PR TITLE
Implement text area

### DIFF
--- a/app/assets/javascripts/components/question-form.js
+++ b/app/assets/javascripts/components/question-form.js
@@ -10,7 +10,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     constructor (module) {
       this.module = module
       this.form = module.querySelector('.js-question-form')
-      this.input = module.querySelector('.js-question-form-input')
+      this.textarea = module.querySelector('.js-question-form-textarea')
+      this.textareaWrapper = module.querySelector('.js-question-form-textarea-wrapper')
       this.button = module.querySelector('.js-question-form-button')
       this.buttonResponseStatus = module.querySelector('.js-question-form-button__response-status')
       this.errorsWrapper = module.querySelector('.js-question-form-errors-wrapper')
@@ -30,6 +31,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.module.dispatchEvent(new Event('init'))
 
       new window.GOVUKFrontend.CharacterCount(this.module) // eslint-disable-line no-new
+
+      this.enableTextareaResizing(this.textareaWrapper)
+      this.submitTextAreaOnEnter(this.textarea)
     }
 
     handleSubmit (event) {
@@ -41,14 +45,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       const errors = []
 
-      if (this.input.value.trim() === '') {
+      if (this.textarea.value.trim() === '') {
         errors.push(this.module.dataset.presenceErrorMessage)
       }
 
       this.replaceErrors(errors)
 
       const maxlength = parseInt(this.module.dataset.maxlength, 10)
-      const exceedsMaxLength = this.input.value.length > maxlength
+      const exceedsMaxLength = this.textarea.value.length > maxlength
 
       if (errors.length || exceedsMaxLength) {
         event.preventDefault()
@@ -63,7 +67,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     handleQuestionAccepted () {
       this.disableControls()
-      this.resetInput()
+      this.resetTextarea()
       this.handleButtonResponseStatus(this.buttonResponseStatus.dataset.loadingAnswerText)
     }
 
@@ -77,17 +81,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     handleAnswerReceived () {
-      this.resetInput()
+      this.resetTextarea()
       this.enableControls()
     }
 
     disableControls () {
-      this.input.readOnly = true
+      this.textarea.readOnly = true
       this.toggleDisabledSettings(true)
     }
 
     enableControls () {
-      this.input.readOnly = false
+      this.textarea.readOnly = false
       this.toggleDisabledSettings(false)
     }
 
@@ -106,11 +110,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     }
 
-    resetInput () {
-      this.input.value = ''
+    resetTextarea () {
+      this.textarea.value = ''
 
       // Trigger keyup event so the character-count component resets and clears the count hint
-      this.input.dispatchEvent(new Event('keyup'))
+      this.textarea.dispatchEvent(new Event('keyup'))
     }
 
     replaceErrors (errors) {
@@ -129,30 +133,36 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.toggleErrorStyles(errors.length)
 
       if (errors.length) {
-        this.attachInputDescriptions(this.errorsWrapper.id)
-        this.input.focus()
+        this.attachTextareaDescriptions(this.errorsWrapper.id)
+        this.textarea.focus()
       } else {
-        this.resetInputDescriptions()
+        this.resetTextareaDescriptions()
       }
     }
 
-    attachInputDescriptions () {
+    attachTextareaDescriptions () {
       const ids = [this.module.dataset.hintId, ...arguments].join(' ')
-      this.input.setAttribute('aria-describedby', ids)
+      this.textarea.setAttribute('aria-describedby', ids)
     }
 
-    resetInputDescriptions () {
-      this.input.setAttribute('aria-describedby', this.module.dataset.hintId)
+    resetTextareaDescriptions () {
+      this.textarea.setAttribute('aria-describedby', this.module.dataset.hintId)
     }
 
     toggleErrorStyles (hasErrors) {
       if (hasErrors) {
-        this.input.classList.add('app-c-question-form__input--error')
+        this.textarea.classList.add('app-c-question-form__textarea--error')
         this.formGroup.classList.add('app-c-question-form__form-group--error')
       } else {
-        this.input.classList.remove('app-c-question-form__input--error')
+        this.textarea.classList.remove('app-c-question-form__textarea--error')
         this.formGroup.classList.remove('app-c-question-form__form-group--error')
       }
+    }
+
+    enableTextareaResizing (textareaWrapper) {
+      this.textarea.addEventListener('input', () => {
+        textareaWrapper.dataset.replicatedValue = this.textarea.value
+      })
     }
   }
 

--- a/app/assets/javascripts/components/question-form.js
+++ b/app/assets/javascripts/components/question-form.js
@@ -33,7 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       new window.GOVUKFrontend.CharacterCount(this.module) // eslint-disable-line no-new
 
       this.enableTextareaResizing(this.textareaWrapper)
-      this.submitTextAreaOnEnter(this.textarea)
+      this.handleTextareaKeypress(this.textarea)
     }
 
     handleSubmit (event) {
@@ -112,6 +112,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     resetTextarea () {
       this.textarea.value = ''
+      this.textareaWrapper.dataset.replicatedValue = ''
 
       // Trigger keyup event so the character-count component resets and clears the count hint
       this.textarea.dispatchEvent(new Event('keyup'))
@@ -162,6 +163,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     enableTextareaResizing (textareaWrapper) {
       this.textarea.addEventListener('input', () => {
         textareaWrapper.dataset.replicatedValue = this.textarea.value
+      })
+    }
+
+    handleTextareaKeypress (textarea) {
+      textarea.addEventListener('keydown', e => {
+        // Submit form on enter; add newline on enter + shift key
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault()
+          // The following approach to form submission was chosen over this.form.requestSubmit()
+          // as requestSubmit() isn't supported in our grade C browsers
+          window.GOVUK.triggerEvent(this.form, 'submit')
+        }
       })
     }
   }

--- a/app/assets/stylesheets/components/_question-form.scss
+++ b/app/assets/stylesheets/components/_question-form.scss
@@ -33,7 +33,7 @@
   color: $govuk-error-colour
 }
 
-.app-c-question-form__input-wrapper {
+.app-c-question-form__textarea-wrapper {
   flex-grow: 1;
   margin-right: govuk-spacing(1);
 
@@ -43,13 +43,18 @@
   }
 }
 
-.app-c-question-form__input {
+.app-c-question-form__textarea {
   border: 2px solid govuk-colour("black");
   border-radius: 0;
   box-sizing: border-box;
-  padding: govuk-spacing(2);
+  padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(2);
   width: 100%;
   margin: 0;
+  resize: none;
+  grid-area: 1 / 1 / 2 / 2;
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(2) govuk-spacing(1) govuk-spacing(2) govuk-spacing(2);
+  }
   @include govuk-font($size: 19);
 
   &:focus {
@@ -59,12 +64,30 @@
   }
 
   &.govuk-textarea--error, // A class injected by the GOV.UK Frontend character-count component
-  &.app-c-question-form__input--error {
+  &.app-c-question-form__textarea--error {
     border-color: govuk-colour("red");
 
     &:focus {
       border-color: govuk-colour("black");
     }
+  }
+}
+
+.app-c-question-form__textarea-character-count-wrapper {
+  display: grid;
+
+  &::after {
+    content: attr(data-replicated-value) ""; // Note the weird space! Needed to preventy jumpy behavior
+    white-space: pre-wrap;  // This is how textarea text behaves
+    visibility: hidden; // Hidden from view, clicks, and screen readers
+    grid-area: 1 / 1 / 2 / 2;
+    max-height: 25dvh; // Set a max-height to prevent the textarea from growing too much
+
+    // Add identical border styling and (almost identical) padding so this grows aligned with the 
+    // textarea expansion
+    border: 2px solid govuk-colour("black");
+    padding: govuk-spacing(2);
+    @include govuk-font($size: 19);
   }
 }
 

--- a/app/assets/stylesheets/components/_question-form.scss
+++ b/app/assets/stylesheets/components/_question-form.scss
@@ -81,7 +81,10 @@
     white-space: pre-wrap;  // This is how textarea text behaves
     visibility: hidden; // Hidden from view, clicks, and screen readers
     grid-area: 1 / 1 / 2 / 2;
-    max-height: 25dvh; // Set a max-height to prevent the textarea from growing too much
+    max-height: 25vh; // Set a max-height to prevent the textarea from growing too much
+    @supports (max-height: 25dvh) {
+      max-height: 25dvh;
+    }
 
     // Add identical border styling and (almost identical) padding so this grows aligned with the 
     // textarea expansion

--- a/app/assets/stylesheets/objects/_conversation-layout.scss
+++ b/app/assets/stylesheets/objects/_conversation-layout.scss
@@ -13,8 +13,10 @@ $slide-in-out-translation-px: 67px;
   display: flex;
   flex-direction: column;
   height: 100%;
-  height: 100dvh;
-
+  height: 100vh;
+  @supports (height: 100dvh) {
+    height: 100dvh;
+  }
   @media print {
     height: auto;
   }

--- a/app/views/components/_question_form.html.erb
+++ b/app/views/components/_question_form.html.erb
@@ -1,5 +1,5 @@
 <%
-  input_id ||= "#{name.parameterize}-#{SecureRandom.hex(4)}"
+  textarea_id ||= "#{name.parameterize}-#{SecureRandom.hex(4)}"
   value ||= nil
 
   maxlength = Form::CreateQuestion::USER_QUESTION_LENGTH_MAXIMUM
@@ -8,14 +8,14 @@
   character_count_threshold = 80
 
   label_text = "Message"
-  secondary_label_id = "#{input_id}-secondary_label"
+  secondary_label_id = "#{textarea_id}-secondary_label"
 
   hint = "Please limit your question to #{maxlength} characters."
-  hint_id = "#{input_id}-info" # The character-count component relies on an element with this ID being present
+  hint_id = "#{textarea_id}-info" # The character-count component relies on an element with this ID being present
 
   error_items ||= []
   has_error ||= error_items.any?
-  error_id = "#{input_id}-error"
+  error_id = "#{textarea_id}-error"
 
   aria_described_by = []
   aria_described_by << secondary_label_id
@@ -34,8 +34,8 @@
   form_group_classes = " app-c-question-form__form-group js-question-form-group"
   form_group_classes << " app-c-question-form__form-group--error" if error_items.any?
 
-  input_classes = "app-c-question-form__input js-question-form-input govuk-js-character-count"
-  input_classes << " app-c-question-form__input--error" if error_items.any?
+  textarea_classes = "app-c-question-form__textarea js-question-form-textarea govuk-js-character-count"
+  textarea_classes << " app-c-question-form__textarea--error" if error_items.any?
 %>
 
 <%= tag.div class: "app-c-question-form js-question-form-container", data: data_attributes do %>
@@ -53,9 +53,9 @@
     <% end %>
 
     <%= content_tag :div, class: form_group_classes do %>
-      <%= content_tag :div, class: "app-c-question-form__input-wrapper" do %>
+      <%= content_tag :div, class: "app-c-question-form__textarea-wrapper" do %>
         <%= label_tag(
-          input_id,
+          textarea_id,
           label_text,
           class: "app-c-question-form__label govuk-visually-hidden",
         ) %>
@@ -65,16 +65,17 @@
         <%# Placeholder text is not an appropriate substitute for a persistent visible label. However, for this specific use case,
           DAC recommends maintaining this convention, as users are familiar with and intuitively know how to use it %>
 
-        <%= content_tag :div, class: "app-c-question-form__input-character-count-wrapper" do %>
-          <%= text_field_tag(
-            input_id,
+        <%= content_tag :div, class: "app-c-question-form__textarea-character-count-wrapper js-question-form-textarea-wrapper" do %>
+          <%= text_area_tag(
+            textarea_id,
             value,
-            class: input_classes,
+            class: textarea_classes,
             aria: {
               describedby: aria_described_by,
             },
             name: name,
             placeholder: label_text,
+            rows: 1,
           ) %>
         <% end %>
 

--- a/app/views/conversations/_form.html.erb
+++ b/app/views/conversations/_form.html.erb
@@ -1,7 +1,7 @@
   <%= render "components/question_form", {
     url: update_conversation_path,
     name: "create_question[user_question]",
-    input_id: "create_question_user_question",
+    textarea_id: "create_question_user_question",
     value: create_question.user_question,
     error_items: error_items(create_question, :user_question),
   } %>

--- a/spec/javascripts/components/question-form-spec.js
+++ b/spec/javascripts/components/question-form-spec.js
@@ -1,7 +1,7 @@
 describe('QuestionForm component', () => {
   'use strict'
 
-  let div, form, formGroup, input, button, buttonResponseStatus, presenceErrorMessage,
+  let div, form, formGroup, textarea, button, buttonResponseStatus, presenceErrorMessage,
     lengthErrorMessage, errorsWrapper, module
 
   beforeEach(function () {
@@ -16,7 +16,7 @@ describe('QuestionForm component', () => {
       <form class="js-question-form">
         <div class="js-question-form-group">
           <ul id="create_question_user_question-error" class="js-question-form-errors-wrapper" hidden="true"></ul>
-          <input type="text" class="js-question-form-input govuk-js-character-count" id="create_question_user_question" value="What is the VAT rate?">
+          <textarea class="js-question-form-textarea govuk-js-character-count" id="create_question_user_question">What is the VAT rate?</textarea>
           <div id="create_question_user_question-info" class="gem-c-hint govuk-hint govuk-visually-hidden">
             Please limit your question to 300 characters.
           </div>
@@ -29,7 +29,7 @@ describe('QuestionForm component', () => {
       <a href="/survey" class="js-survey-link">Survey</a>
     `
     form = div.querySelector('.js-question-form')
-    input = div.querySelector('.js-question-form-input')
+    textarea = div.querySelector('.js-question-form-textarea')
     button = div.querySelector('.js-question-form-button')
     button = div.querySelector('.js-question-form-button')
     buttonResponseStatus = div.querySelector('.js-question-form-button__response-status')
@@ -58,7 +58,7 @@ describe('QuestionForm component', () => {
     beforeEach(() => module.init())
 
     it('allows form submission when input is valid', () => {
-      input.value = 'valid input'
+      textarea.value = 'valid input'
       const submitSpy = jasmine.createSpy('submit event spy')
       form.addEventListener('submit', submitSpy)
 
@@ -68,7 +68,7 @@ describe('QuestionForm component', () => {
     })
 
     it('prevents form submission when the input is empty', () => {
-      input.value = ''
+      textarea.value = ''
       const submitSpy = jasmine.createSpy('submit event spy')
       form.addEventListener('submit', submitSpy)
       const event = new Event('submit')
@@ -82,7 +82,7 @@ describe('QuestionForm component', () => {
 
     it('prevents form submission when the input exceeds the max character count', () => {
       const maxlength = parseInt(div.dataset.maxlength, 10)
-      input.value = 'a'.repeat(maxlength + 1)
+      textarea.value = 'a'.repeat(maxlength + 1)
 
       const submitSpy = jasmine.createSpy('submit event spy')
       form.addEventListener('submit', submitSpy)
@@ -96,7 +96,7 @@ describe('QuestionForm component', () => {
     })
 
     it('shows an error when the user input is empty', () => {
-      input.value = ''
+      textarea.value = ''
       form.dispatchEvent(new Event('submit'))
       expect(errorsWrapper.hidden).toBe(false)
 
@@ -104,42 +104,42 @@ describe('QuestionForm component', () => {
         .toEqual(`<li class="app-c-question-form__error-message"><span class="govuk-visually-hidden">Error:</span>${presenceErrorMessage}</li>`)
     })
 
-    it('updates the input\'s aria-describedby attribute to also reference the error id when errors occur (e.g. input is empty)', () => {
-      input.value = ''
+    it('updates the textarea\'s aria-describedby attribute to also reference the error id when errors occur (e.g. input is empty)', () => {
+      textarea.value = ''
       form.dispatchEvent(new Event('submit'))
       expect(errorsWrapper.hidden).toBe(false)
-      expect(input.getAttribute('aria-describedby')).toBe('create_question_user_question-info create_question_user_question-error')
+      expect(textarea.getAttribute('aria-describedby')).toBe('create_question_user_question-info create_question_user_question-error')
     })
 
     it('adds the appropriate classes when there is a validation error', () => {
-      input.value = ''
+      textarea.value = ''
       form.dispatchEvent(new Event('submit'))
 
       expect(formGroup.classList).toContain('app-c-question-form__form-group--error')
-      expect(input.classList).toContain('app-c-question-form__input--error')
+      expect(textarea.classList).toContain('app-c-question-form__textarea--error')
     })
 
     it('removes any errors and error classes when input is valid', () => {
-      input.value = ''
+      textarea.value = ''
       form.dispatchEvent(new Event('submit'))
 
-      input.value = 'valid input'
+      textarea.value = 'valid input'
       form.dispatchEvent(new Event('submit'))
 
       expect(errorsWrapper.hidden).toBe(true)
       expect(errorsWrapper.innerHTML).toBe('')
       expect(formGroup.classList).not.toContain('app-c-question-form__form-group--error')
-      expect(input.classList).not.toContain('app-c-question-form__input--error')
+      expect(textarea.classList).not.toContain('app-c-question-form__textarea--error')
     })
 
-    it('resets the input\'s aria-describedby attribute to only reference the hint id when input is valid', () => {
-      input.value = ''
+    it('resets the textarea\'s aria-describedby attribute to only reference the hint id when input is valid', () => {
+      textarea.value = ''
       form.dispatchEvent(new Event('submit'))
 
-      input.value = 'valid input'
+      textarea.value = 'valid input'
       form.dispatchEvent(new Event('submit'))
 
-      expect(input.getAttribute('aria-describedby')).toBe('create_question_user_question-info')
+      expect(textarea.getAttribute('aria-describedby')).toBe('create_question_user_question-info')
     })
   })
 
@@ -149,17 +149,17 @@ describe('QuestionForm component', () => {
     it('disables the controls', () => {
       div.dispatchEvent(new Event('question-pending'))
 
-      expect(input.readOnly).toBe(true)
+      expect(textarea.readOnly).toBe(true)
       expect(button.hasAttribute('aria-disabled')).toBe(true)
       expect(button.classList).toContain('app-c-blue-button--disabled')
       expect(buttonResponseStatus.textContent).toContain('Loading your question')
     })
 
     it("doesn't update the input value", () => {
-      const value = input.value
+      const value = textarea.value
       div.dispatchEvent(new Event('question-pending'))
 
-      expect(input.value).toEqual(value)
+      expect(textarea.value).toEqual(value)
     })
   })
 
@@ -169,7 +169,7 @@ describe('QuestionForm component', () => {
     it('disables the controls', () => {
       div.dispatchEvent(new Event('question-accepted'))
 
-      expect(input.readOnly).toBe(true)
+      expect(textarea.readOnly).toBe(true)
       expect(button.hasAttribute('aria-disabled')).toBe(true)
       expect(button.classList).toContain('app-c-blue-button--disabled')
       expect(buttonResponseStatus.textContent).toContain('Generating your answer')
@@ -178,13 +178,13 @@ describe('QuestionForm component', () => {
     it('resets the input value', () => {
       div.dispatchEvent(new Event('question-accepted'))
 
-      expect(input.value).toEqual('')
+      expect(textarea.value).toEqual('')
     })
 
     it('hides the character count hint', () => {
       // Type in enough characters to make the hint show on screen
-      input.value = 'A'.repeat(280)
-      input.dispatchEvent(new Event('keyup'))
+      textarea.value = 'A'.repeat(280)
+      textarea.dispatchEvent(new Event('keyup'))
       expect(form.innerHTML).toContain('You have 20 characters remaining')
 
       div.dispatchEvent(new Event('question-accepted'))
@@ -206,24 +206,24 @@ describe('QuestionForm component', () => {
     })
 
     it('enables any disabled controls', () => {
-      input.readOnly = true
+      textarea.readOnly = true
       button.setAttribute('aria-disabled', true)
       button.classList.add('app-c-blue-button--disabled')
       buttonResponseStatus.textContent = 'Visually hidden text content'
 
       div.dispatchEvent(new CustomEvent('question-rejected', errorDetail))
 
-      expect(input.readOnly).toBe(false)
+      expect(textarea.readOnly).toBe(false)
       expect(button.hasAttribute('aria-disabled')).toBe(false)
       expect(button.classList).not.toContain('app-c-blue-button--disabled')
       expect(buttonResponseStatus.textContent).toEqual('')
     })
 
     it("doesn't update the input value", () => {
-      const value = input.value
+      const value = textarea.value
       div.dispatchEvent(new CustomEvent('question-rejected', errorDetail))
 
-      expect(input.value).toEqual(value)
+      expect(textarea.value).toEqual(value)
     })
 
     it('displays error messages provided by the event', () => {
@@ -242,7 +242,7 @@ describe('QuestionForm component', () => {
       div.dispatchEvent(event)
 
       expect(formGroup.classList).toContain('app-c-question-form__form-group--error')
-      expect(input.classList).toContain('app-c-question-form__input--error')
+      expect(textarea.classList).toContain('app-c-question-form__textarea--error')
     })
 
     it('replaces any existing error messages', () => {
@@ -273,14 +273,14 @@ describe('QuestionForm component', () => {
     beforeEach(() => module.init())
 
     it('enables any disabled controls', () => {
-      input.readOnly = true
+      textarea.readOnly = true
       button.setAttribute('aria-disabled', true)
       button.classList.add('app-c-blue-button--disabled')
       buttonResponseStatus.textContent = 'Visually hidden text content'
 
       div.dispatchEvent(new Event('answer-received'))
 
-      expect(input.readOnly).toBe(false)
+      expect(textarea.readOnly).toBe(false)
       expect(button.hasAttribute('aria-disabled')).toBe(false)
       expect(button.classList).not.toContain('app-c-blue-button--disabled')
       expect(buttonResponseStatus.textContent).toEqual('')
@@ -289,13 +289,13 @@ describe('QuestionForm component', () => {
     it('resets the value of the input', () => {
       div.dispatchEvent(new Event('answer-received'))
 
-      expect(input.value).toEqual('')
+      expect(textarea.value).toEqual('')
     })
 
     it('hides the character count hint', () => {
       // Type in enough characters to make the hint show on screen
-      input.value = 'A'.repeat(280)
-      input.dispatchEvent(new Event('keyup'))
+      textarea.value = 'A'.repeat(280)
+      textarea.dispatchEvent(new Event('keyup'))
       expect(form.innerHTML).toContain('You have 20 characters remaining')
 
       div.dispatchEvent(new Event('answer-received'))

--- a/spec/javascripts/components/question-form-spec.js
+++ b/spec/javascripts/components/question-form-spec.js
@@ -1,7 +1,7 @@
 describe('QuestionForm component', () => {
   'use strict'
 
-  let div, form, formGroup, textarea, button, buttonResponseStatus, presenceErrorMessage,
+  let div, form, formGroup, textareaWrapper, textarea, button, buttonResponseStatus, presenceErrorMessage,
     lengthErrorMessage, errorsWrapper, module
 
   beforeEach(function () {
@@ -16,9 +16,11 @@ describe('QuestionForm component', () => {
       <form class="js-question-form">
         <div class="js-question-form-group">
           <ul id="create_question_user_question-error" class="js-question-form-errors-wrapper" hidden="true"></ul>
-          <textarea class="js-question-form-textarea govuk-js-character-count" id="create_question_user_question">What is the VAT rate?</textarea>
-          <div id="create_question_user_question-info" class="gem-c-hint govuk-hint govuk-visually-hidden">
-            Please limit your question to 300 characters.
+          <div class="js-question-form-textarea-wrapper" data-replicated-value="What is the VAT rate?">
+            <textarea class="js-question-form-textarea govuk-js-character-count" id="create_question_user_question">What is the VAT rate?</textarea>
+            <div id="create_question_user_question-info" class="gem-c-hint govuk-hint govuk-visually-hidden">
+              Please limit your question to 300 characters.
+            </div>
           </div>
           <button class="js-question-form-button">
             Submit
@@ -30,6 +32,7 @@ describe('QuestionForm component', () => {
     `
     form = div.querySelector('.js-question-form')
     textarea = div.querySelector('.js-question-form-textarea')
+    textareaWrapper = div.querySelector('.js-question-form-textarea-wrapper')
     button = div.querySelector('.js-question-form-button')
     button = div.querySelector('.js-question-form-button')
     buttonResponseStatus = div.querySelector('.js-question-form-button__response-status')
@@ -51,6 +54,52 @@ describe('QuestionForm component', () => {
       module.init()
 
       expect(spy).toHaveBeenCalled()
+    })
+  })
+
+  describe('when the enter key is pressed', () => {
+    it('the form is submitted', () => {
+      module.init()
+
+      const submitSpy = jasmine.createSpy('submit event spy')
+      form.addEventListener('submit', submitSpy)
+
+      const enterKeydown = new KeyboardEvent('keydown', {
+        key: 'Enter'
+      })
+
+      textarea.dispatchEvent(enterKeydown)
+
+      expect(submitSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('when the enter key and shift key is pressed', () => {
+    it('the form is not submitted', () => {
+      module.init()
+
+      const submitSpy = jasmine.createSpy('submit event spy')
+      form.addEventListener('submit', submitSpy)
+
+      const enterAndShiftKeydown = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true
+      })
+
+      textarea.dispatchEvent(enterAndShiftKeydown)
+
+      expect(submitSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the textarea receives input', () => {
+    it('updates the wrapper data attribute', () => {
+      module.init()
+
+      textarea.value = 'valid input'
+      textarea.dispatchEvent(new Event('input'))
+
+      expect(textareaWrapper.dataset.replicatedValue).toEqual(textarea.value)
     })
   })
 
@@ -179,6 +228,12 @@ describe('QuestionForm component', () => {
       div.dispatchEvent(new Event('question-accepted'))
 
       expect(textarea.value).toEqual('')
+    })
+
+    it('resets the data-replicated-value attribute on the textarea wrapper', () => {
+      div.dispatchEvent(new Event('question-accepted'))
+
+      expect(textareaWrapper.dataset.replicatedValue).toEqual('')
     })
 
     it('hides the character count hint', () => {

--- a/spec/javascripts/modules/chat-conversation-spec.js
+++ b/spec/javascripts/modules/chat-conversation-spec.js
@@ -16,7 +16,7 @@ describe('ChatConversation module', () => {
       <div class="js-conversation-form-region">
         <div class="js-question-form-container">
           <form action="/conversation" class="js-question-form">
-            <input type="text" name="question" value="How can I setup a new business?">
+            <textarea name="question">How can I setup a new business?</textarea>
             <button class="js-question-form-button">Send</button>
           </form>
         </div>

--- a/spec/views/components/_question_form.html.erb_spec.rb
+++ b/spec/views/components/_question_form.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "components/_question_form.html.erb" do
   it "renders the conversation form component correctly" do
     render("components/question_form", {
       url: "/conversation",
-      input_id: "id",
+      textarea_id: "id",
       name: "name",
       value: "Value",
     })
@@ -10,8 +10,8 @@ RSpec.describe "components/_question_form.html.erb" do
     expect(rendered).to have_selector('.app-c-question-form__form[action="/conversation"]') do |rendered_form|
       expect(rendered_form)
         .to have_selector(".app-c-question-form__label.govuk-visually-hidden", text: /Message/)
-        .and have_selector(".app-c-question-form__input[placeholder=Message]")
-        .and have_selector(".app-c-question-form__input[id=id][name=name][value=Value]")
+        .and have_selector(".app-c-question-form__textarea[placeholder=Message]")
+        .and have_selector(".app-c-question-form__textarea[id=id][name=name]", text: "Value")
         .and have_selector(".gem-c-hint", text: /Please limit your question/)
         .and have_selector(".govuk-error-message[hidden]", visible: :hidden)
         .and have_selector(".app-c-blue-button")
@@ -22,7 +22,7 @@ RSpec.describe "components/_question_form.html.erb" do
   it "includes data attributes of server side validation parameters" do
     render("components/question_form", {
       url: "/conversation",
-      input_id: "id",
+      textarea_id: "id",
       name: "name",
       value: "Value",
     })
@@ -36,7 +36,7 @@ RSpec.describe "components/_question_form.html.erb" do
   it "renders error messages when there is a problem" do
     render("components/question_form", {
       url: "/conversation",
-      input_id: "id",
+      textarea_id: "id",
       name: "name",
       error_items: [
         {
@@ -48,6 +48,6 @@ RSpec.describe "components/_question_form.html.erb" do
     expect(rendered)
       .to have_selector(".app-c-question-form .govuk-error-message:not([hidden])", text: /Error:\s+Error 1/)
       .and have_selector(".app-c-question-form__error-message", text: /Error 1/)
-      .and have_selector(".app-c-question-form__input[aria-describedby~=id-error]")
+      .and have_selector(".app-c-question-form__textarea[aria-describedby~=id-error]")
   end
 end


### PR DESCRIPTION
## What
This PR switches out the input element for an expanding textarea element. The implementation was based on this [blog post](https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/).

I'm conscious that the placement of the `Send` button might be preferred at the bottom/aligned with the bottom of the text area. This seems to be a little tricky to achieve due to how our DOM is structured and it could involve a rework of the component. Therefore, I've opted for omitting that work from this PR to avoid holding it up. Happy to discuss.

## Why
[Trello card](https://trello.com/c/DqBmf2u3/2656-implement-text-area)

## Visual changes

### Desktop

| Chat UI input - before | Chat UI input - after |
|------------------------------|----------------------------------------|
| <img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/a754287c-2118-44fa-a73a-1c23af718cc8" /> | <img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/d0a9ce98-eb7d-4d4b-9fde-db579068732d" /> |

### Mobile

| Chat UI input - before | Chat UI input - after |
|------------------------------|----------------------------------------|
| <img width="350" height="757" alt="image" src="https://github.com/user-attachments/assets/cfee7eaa-0f21-4a14-a25a-ac51d1407a0f" /> | <img width="350" height="759" alt="image" src="https://github.com/user-attachments/assets/f1c26d2b-ea7e-4c36-8e94-a86dbcaa2ed5" /> |