### PR TITLE
Add middleware to normalise path in Rack

### DIFF
--- a/config/initializers/path_normaliser.rb
+++ b/config/initializers/path_normaliser.rb
@@ -1,0 +1,15 @@
+require "path_normaliser_middleware"
+
+# This app has a number of Rack middleware's that make use of the path (Warden,
+# Rack::Attack, Committee) and Rack::Attack performs path normalisation [1]
+# to make the Rack path consistent with what Rails uses.
+#
+# This risks subtle bugs in this app as it means that middleware that runs
+# before Rack::Attack may match paths different to those that run after it.
+#
+# To resolve this we've got our own middleware to normalise the path that we
+# run before any of are other middleware with path concerns, this ensures they
+# consistently have the same path value.
+#
+# [1]: https://github.com/rack/rack-attack/blob/467770882daa6f3865cc207c8b5dfdbc4028d7cb/lib/rack/attack.rb#L108
+Rails.application.config.middleware.insert_before Warden::Manager, PathNormaliserMiddleware

--- a/lib/path_normaliser_middleware.rb
+++ b/lib/path_normaliser_middleware.rb
@@ -1,0 +1,14 @@
+class PathNormaliserMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  # This middleware is used to change the Rack env["PATH_INFO"] to be the same
+  # path that Rails will normalise the path to for routing. This allows middleware
+  # after this has run and the Rails app itself to have a consistent path.
+  def call(env)
+    env["PATH_INFO"] = ::ActionDispatch::Journey::Router::Utils.normalize_path(env["PATH_INFO"].to_s)
+
+    @app.call(env)
+  end
+end

--- a/spec/lib/path_normaliser_middleware_spec.rb
+++ b/spec/lib/path_normaliser_middleware_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe PathNormaliserMiddleware do
+  let(:mock_app) { ->(_env) { [200, { "Content-Type" => "application/json" }, ["{}"]] } }
+  let(:middleware) { described_class.new(mock_app) }
+
+  describe "#call" do
+    it "changes env['PATH_INFO'] value of requests with Rails compatible but un-normal paths" do
+      env = { "PATH_INFO" => "//api//route/" }
+
+      expect { middleware.call(env) }
+        .to change { env["PATH_INFO"] }
+        .to("/api/route")
+    end
+
+    it "doesn't change env['PATH_INFO'] for regular Rails compatible paths" do
+      env = { "PATH_INFO" => "/api/route" }
+
+      expect { middleware.call(env) }
+        .not_to(change { env["PATH_INFO"] })
+    end
+  end
+end


### PR DESCRIPTION
When load testing GOV.UK Chat we noticed that we were getting uncaught exceptions. These were occurring because an unusual path had been used for the load test //api/conversation/e4abee9c-1f11-4dec-9cb5-c20ed4b55f92.

What was interesting about this was that this request was raising an error due to failing to match the Api::AuthMiddleware [1] but managing to match the Rack::Attack middleware [2]. It transpired that these different pieces of middleware were using a different value for path as Rack::Attack normalises the path [3] before passing it on to other middleware.

As this inconsistency risks subtle bugs, and because Rails itself does a normalising process at the point of routing a request, I've added additional middleware to normalise a path before we make any middleware decisions based on the path. Warden::Manager is the first piece of middleware that makes use of it as it uses to be determine whether we have an API request or not.

I've worked on additional specs for this but they require a GDS SSO bump so I'm opening them as a separate PR.

[1]: https://github.com/alphagov/govuk-chat/blob/0a81713ce586a3f8e69fbbcd940125d33cccb7f6/lib/api/auth_middleware.rb#L9-L11
[2]: https://github.com/alphagov/govuk-chat/blob/0a81713ce586a3f8e69fbbcd940125d33cccb7f6/config/initializers/rack_attack.rb#L11-L15
[3]: https://github.com/rack/rack-attack/blob/467770882daa6f3865cc207c8b5dfdbc4028d7cb/lib/rack/attack.rb#L108