### PR TITLE
Send rate limit usage to Prometheus for API user

### DIFF
--- a/lib/prometheus_metrics.rb
+++ b/lib/prometheus_metrics.rb
@@ -17,6 +17,14 @@ class PrometheusMetrics
       name: "openai_requests_used_percentage",
       description: "The percentage of available requests for the OpenAI API that have been used",
     },
+    {
+      name: "rate_limit_api_user_read_percentage_used",
+      description: "The percentage of request quota used for the API user for read requests",
+    },
+    {
+      name: "rate_limit_api_user_write_percentage_used",
+      description: "The percentage of request quota used for the API user for write requests",
+    },
   ].freeze
 
   def self.register


### PR DESCRIPTION
This extends the current rate limiting middleware to log rate limit
usage for an API user.

We want some way of knowing how close API users are to their request
quota, and doing this via Prometheus/Grafana seems like a good way to
go.

So in the middleware we inspect the rate limit data we've got from
Rack::Attack. If the rate limit data is related to the throttling for
the API user's read methods (and it's a read method) then we log the
percentage of read requests remaining for that user in Prometheus. Same
for write requests.

We could log the raw number, i.e. the number of requests remaining, but
this would be a bit meaningless when looking at the chart in Grafana
unless you know the actual rate limit figures. It feels like logging the
percentage remaining means we can create a chart that's easily
understandable at a glance.

Using a percentage as the metric also means that if we change the rate
limits, we just need to change one number in this app and we won't need
to make any changes to the chart.

Note that we're just logging the percentage remaining for the API user here,
not the end user. It feels like it'd be tricky to create a readable chart for
all the end users. We'll only have one API user to begin with (the mobile app),
so the chart will be simple.
