### PR TITLE
Add postcode PII check to the PII validator

### DIFF
--- a/app/validators/pii_validator.rb
+++ b/app/validators/pii_validator.rb
@@ -34,11 +34,23 @@ module PiiValidator
                                     \b # word boundary
                                     /x
 
+  POSTCODE_REGEX = /
+                   \b # word boundary
+                   ([A-Z]{1,2} # 1 or 2 letters
+                   [0-9] # 1 digit
+                   [0-9A-Z]?) # optional second digit or letter
+                   \s? # optional single space
+                   ([0-9] # 1 digit
+                   [A-Z]{2}) # 2 letters
+                   \b # word boundary
+                   /xi # i for case insensitive
+
   PII_REGEXS = [
     EMAIL_REGEX,
     CREDIT_CARD_REGEX,
     PHONE_NUMBER_REGEX,
     NATIONAL_INSURANCE_NUMBER_REGEX,
+    POSTCODE_REGEX,
   ].freeze
 
   def self.invalid?(input)

--- a/spec/validators/pii_validator_spec.rb
+++ b/spec/validators/pii_validator_spec.rb
@@ -102,5 +102,26 @@ RSpec.describe PiiValidator do
         end
       end
     end
+
+    context "when the input contains a postcode" do
+      it "returns true" do
+        postcodes = [
+          "SW1A 1AA",
+          "SW1A1AA",
+          "sw1a 1aa",
+          "Sw1a 1Aa",
+          "W1A 0AX",
+          "M1 1AE",
+          "B33 8TH",
+          "CR2 6XH",
+          "DN55 1PT",
+        ]
+
+        postcodes.each do |postcode|
+          user_question = "My postcode is #{postcode}"
+          expect(described_class.invalid?(user_question)).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

We've been asked to add a check for UK postcodes to the PII validator. This adds a fairly simple regex to match on UK postcode formats.

It doesn't include a full list of actual postcodes and only checks for a very specific format (i.e.1 or no spaces between the first and second part of the postcode).

## Trello card

https://trello.com/c/d0njErJw/2687-add-postcode-to-pii-detection