### PR TITLE
Fix error message display bug in grade C browsers

### DIFF
--- a/app/assets/javascripts/components/question-form.js
+++ b/app/assets/javascripts/components/question-form.js
@@ -129,7 +129,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return li
       })
 
-      this.errorsWrapper.replaceChildren(...elements)
+      this.errorsWrapper.innerHTML = ''
+
+      elements.forEach(index => {
+        this.errorsWrapper.appendChild(index)
+      })
 
       this.toggleErrorStyles(errors.length)
 


### PR DESCRIPTION
## What
We're using the `replaceChildren()` function to display error messages, however this JS isn't compatible with grade C browsers (which should support JS enhancements). Therefore, an alternative approach has been implemented that works in these browsers.

Tested in Chrome 61, Edge 16 and 80, Firefox 60, and Safari 11 and everything seems to work okay.

## Why
[Trello card](https://trello.com/c/H7fBI1tX/2701-bug-error-messages-not-rendering-in-grade-c-browsers)

## Visual changes
Error messages now display in grade C browsers.