### PR TITLE
Remove chat history message on homepage

### DIFF
--- a/app/assets/stylesheets/components/_chat-introduction.scss
+++ b/app/assets/stylesheets/components/_chat-introduction.scss
@@ -6,11 +6,3 @@
     margin-bottom: govuk-spacing(4);
   }
 }
-
-.app-c-chat-introduction__info_text {
-  margin-top: govuk-spacing(8);
-
-  @include govuk-media-query($from: tablet) {
-    @include govuk-font-size(24, $line-height: false, $important: false);
-  }
-}

--- a/app/views/components/_chat_introduction.html.erb
+++ b/app/views/components/_chat_introduction.html.erb
@@ -1,6 +1,5 @@
 <%
   start_button_href ||= Rails.application.routes.url_helpers.show_conversation_path
-  info_text_classes = "app-c-chat-introduction__info_text govuk-body"
 %>
 
 <%= content_tag :div, class: "app-c-chat-introduction" do %>
@@ -13,15 +12,9 @@
     text: "Ask a question",
     href: start_button_href,
     start: true,
-    aria_describedby: "info-text",
     data_attributes: {
       "module": "ga4-link-tracker",
       "ga4-link": '{ "event_name": "navigation", "type": "start button", "index_link": 1, "index_total": 1, "section": "Landing page" }',
     },
   } %>
-
-  <% info_text = "Your chat history will be available for #{Rails.configuration.conversations.max_question_age_days} days" %>
-  <div class="govuk-!-width-three-quarters">
-    <%= content_tag(:p, info_text, { id: "info-text", class: info_text_classes}) %>
-  </div>
 <% end %>

--- a/spec/views/components/_chat_introduction.html.erb_spec.rb
+++ b/spec/views/components/_chat_introduction.html.erb_spec.rb
@@ -2,13 +2,11 @@ RSpec.describe "components/_chat_introduction.html.erb" do
   it "renders the chat introduction component correctly" do
     render("components/chat_introduction")
 
-    max_days = Rails.configuration.conversations.max_question_age_days
     expect(rendered)
       .to have_selector(".app-c-chat-introduction")
       .and have_selector(".app-c-chat-introduction-title__svg-container")
       .and have_selector(".app-c-chat-introduction-title__title", text: "Get quick answers from GOV.UK Chat")
       .and have_selector(".app-c-chat-introduction-title__lead-paragraph", text: "Use GOV.UK's experimental AI tool to easily find out more about topics, services and information on GOV.UK.")
       .and have_link("Ask a question")
-      .and have_selector("#info-text", text: "Your chat history will be available for #{max_days} days")
   end
 end


### PR DESCRIPTION
## What
Removes the chat history message on the homepage.

## Why
As per UCD discussion.

## Visual changes
The chat history message is no longer displayed on the homepage.