### PR TITLE
Normalise newlines in user questions

### DIFF
--- a/app/models/form/create_question.rb
+++ b/app/models/form/create_question.rb
@@ -12,7 +12,7 @@ class Form::CreateQuestion
   USER_QUESTION_PII_ERROR_MESSAGE = "Personal data has been detected in your question. Please remove it and try asking again.".freeze
   UNANSWERED_QUESTION_ERROR_MESSAGE = "Previous question pending. Please wait for a response".freeze
 
-  before_validation :sanitise_user_question
+  before_validation :sanitise_user_question, :normalise_newlines
 
   validates :user_question, presence: { message: USER_QUESTION_PRESENCE_ERROR_MESSAGE }
   validates :user_question, length: { maximum: USER_QUESTION_LENGTH_MAXIMUM, message: USER_QUESTION_LENGTH_ERROR_MESSAGE }
@@ -41,6 +41,10 @@ private
 
     @unsanitised_user_question = user_question if user_question&.match?(UnicodeTags::MATCH_REGEX)
     @sanitised_user_question = user_question&.gsub(UnicodeTags::MATCH_REGEX, "")
+  end
+
+  def normalise_newlines
+    user_question&.gsub!("\r\n", "\n")
   end
 
   def all_questions_answered?

--- a/spec/models/form/create_question_spec.rb
+++ b/spec/models/form/create_question_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe Form::CreateQuestion do
           .to change(form, :valid?).to(false)
       end
     end
+
+    describe "normalise newlines" do
+      it "removes carriage returns before running validations" do
+        user_question = "#{'s' * (described_class::USER_QUESTION_LENGTH_MAXIMUM - 1)}\r\n"
+        form = described_class.new(
+          conversation:,
+          user_question:,
+        )
+        form.validate
+
+        expect(form).to be_valid
+      end
+    end
   end
 
   describe "#submit" do


### PR DESCRIPTION
## Description 

Now we're using a textarea and consuming questions via our API users can add newlines to their questions.

This has presented an issue where the character count component gets out of sync with the submitted character count.

I was able to replicate this on chrome by using shift enter to add a newline, which added a carriage return character before each "\n".

Because these are counted during the character length validation in the form, it would cause the validation to fail when the character count component indicated they were within the limit.

This updates the CreateQuestion form to normalise newlines before validation by removing carriage return characters.

This won't affect rendering, but it will ensure that the character count validation works as expected for users.

## Trello card

https://trello.com/c/egCTZWN5/2699-deal-with-problems-now-we-can-have-new-lines-in-chat-messages