### PR TITLE
Render question message using Govspeak component

### DIFF
--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -58,7 +58,7 @@ module Admin
         },
         {
           field: "Question",
-          value: question.message,
+          value: escaped_simple_format(question.message),
         },
         (
           if question.unsanitised_message.present?


### PR DESCRIPTION
## Description 

On the question show page on the Admin UI we probably want to capture the format the user submitted their question in. Including newlines.

This updates the row to use the Govspeak component to render the question message and updates the AnswersHelper to MessagesHelper to reflect that it's now used for both questions and answers.

## Screenshot

<img width="660" height="381" alt="image" src="https://github.com/user-attachments/assets/9b34bce7-b738-4193-8123-735f1f0a8d4e" />


## Trello card

https://trello.com/c/egCTZWN5/2699-deal-with-problems-now-we-can-have-new-lines-in-chat-messages