### PR TITLE
Monkeypatch on WebMock for not allowed exception

### DIFF
--- a/spec/support/web_mock_not_allowed_override_message.rb
+++ b/spec/support/web_mock_not_allowed_override_message.rb
@@ -1,0 +1,14 @@
+module WebMockNotAllowedMessage
+  def message
+    return super unless ENV["CI"]
+
+    "An unregistered HTTP request was made which WebMock raised an exception for.\n\n" \
+    "The details of this exception have been suppressed in CI to prevent" \
+    "public disclosure. Replicate this exception locally for further details."
+  end
+end
+
+# Monkey patch this error as a means to prevent outputting full HTTP request
+# details in the CI environment. The motivation for this is to reduce the risk
+# that this could make a private prompt public.
+WebMock::NetConnectNotAllowedError.prepend(WebMockNotAllowedMessage)


### PR DESCRIPTION
As GOV.UK Chat has LLM prompt data that comes from a private_repo, govuk_chat_private, and that this data is used in a CI environment, there is an inherit and understood risk that aspects of this data could be output in the public CI environment.

While it is impossible to remove all these risks, we do try to reduce clear ones that are identified.

A recent one that was understood was that an unregistered HTTP call could be made and WebMock would output the full HTTP request parameters as part of an exception. Consider the non-sensitive example below:

```
➜  govuk-chat git:(check-webmock) ✗ rspec spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:63
not starting Prometheus metrics server: address already in use
Run options: include {locations: {"./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb" => [63]}}

Randomized with seed 58583
F

Failures:

  1) AnswerComposition::Pipeline::OpenAI::QuestionRouter.call sends OpenAI a series of messages combining system prompt and the user question
     Failure/Error: @app.call(env)

     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: POST https://api.openai.com/v1/chat/completions with body '{"model":"gpt-4o-mini","messages":[{"role":"system","content":"The system prompt"},{"role":"user","content":"Message 1"}],"temperature":0.0,"tools":[{"type":"function","function":{"name":"greetings","description":"A classification description","strict":true,"parameters":{"type":"object","additionalProperties":false,"properties":{"confidence":null,"answer":{"type":"string","description":"Answer the question."}},"required":["confidence","answer"]}}}],"tool_choice":"required","parallel_tool_calls":false,"max_completion_tokens":160}' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer fake-openai-access-token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}

       You can stub this request with the following snippet:

       stub_request(:post, "https://api.openai.com/v1/chat/completions").
         with(
           body: "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"system\",\"content\":\"The system prompt\"},{\"role\":\"user\",\"content\":\"Message 1\"}],\"temperature\":0.0,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"greetings\",\"description\":\"A classification description\",\"strict\":true,\"parameters\":{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"confidence\":null,\"answer\":{\"type\":\"string\",\"description\":\"Answer the question.\"}},\"required\":[\"confidence\",\"answer\"]}}}],\"tool_choice\":\"required\",\"parallel_tool_calls\":false,\"max_completion_tokens\":160}",
           headers: {
       	  'Accept'=>'*/*',
       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       	  'Authorization'=>'Bearer fake-openai-access-token',
       	  'Content-Type'=>'application/json',
       	  'User-Agent'=>'Ruby'
           }).
         to_return(status: 200, body: "", headers: {})

       registered request stubs:

       stub_request(:post, "https://api.openai.com/v1/chat/completions").
         with(
           body: hash_including({"max_completion_tokens" => 160, "messages" => [{"role" => "system", "content" => "The wrong system prompt"}, {"role" => "user", "content" => "Message 1"}], "model" => "gpt-4o-mini", "temperature" => 0.0, "tool_choice" => "required", "tools" => [{"type" => "function", "function" => {"name" => "greetings", "description" => "A classification description", "strict" => true, "parameters" => {"type" => "object", "properties" => {"answer" => {"type" => "string", "description" => "Answer the question."}, "confidence" => nil}, "required" => ["confidence", "answer"], "additionalProperties" => false}}}]}),
           headers: {
       	  'Authorization'=>'Bearer fake-openai-access-token',
       	  'Content-Type'=>'application/json'
           })

       ============================================================
     # ./lib/openai_client.rb:10:in 'OpenAIClient::ErrorMiddleware#call'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:98:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#openai_response'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:86:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#openai_response_choice'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:16:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#call'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:6:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter.call'
     # ./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:71:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:65:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:65:in 'block (2 levels) in <top (required)>'

Finished in 0.22663 seconds (files took 6.56 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:63 # AnswerComposition::Pipeline::OpenAI::QuestionRouter.call sends OpenAI a series of messages combining system prompt and the user question
```

I decided the best route to reduce this risk was to reach for Ruby's infamous monkeypatch. This was after ruling out that there wasn't a public API on WebMock for this (related options such as `hide_body_diff!` and `hide_stubbing_instructions!` are insufficient) and that the exception could be caught and a different output produced. I therefore took the route of overriding the message method.

This uses the existing and conventional approach of establishing the CI environment with the presence of a CI env var. When the above exception occurs again this is the output:

```
➜  govuk-chat git:(check-webmock) ✗ CI=true rspec spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:63
not starting Prometheus metrics server: address already in use
Run options: include {locations: {"./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb" => [63]}}

Randomized with seed 54375
F

Failures:

  1) AnswerComposition::Pipeline::OpenAI::QuestionRouter.call sends OpenAI a series of messages combining system prompt and the user question
     Failure/Error: @app.call(env)

     WebMock::NetConnectNotAllowedError:
       An unregistered HTTP request was made which WebMock raised an exception for.

       The details of this exception have been suppressed in CI to preventpublic disclosure. Replicate this exception locally for further details.
     # ./lib/openai_client.rb:10:in 'OpenAIClient::ErrorMiddleware#call'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:98:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#openai_response'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:86:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#openai_response_choice'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:16:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter#call'
     # ./lib/answer_composition/pipeline/openai/question_router.rb:6:in 'AnswerComposition::Pipeline::OpenAI::QuestionRouter.call'
     # ./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:71:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:65:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:65:in 'block (2 levels) in <top (required)>'

Finished in 0.12204 seconds (files took 12.34 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/answer_composition/pipeline/openai/question_router_spec.rb:63 # AnswerComposition::Pipeline::OpenAI::QuestionRouter.call sends OpenAI a series of messages combining system prompt and the user question
```