### PR TITLE
Fix missing space in exception message

### DIFF
--- a/spec/support/web_mock_not_allowed_override_message.rb
+++ b/spec/support/web_mock_not_allowed_override_message.rb
@@ -3,7 +3,7 @@ module WebMockNotAllowedMessage
     return super unless ENV["CI"]
 
     "An unregistered HTTP request was made which WebMock raised an exception for.\n\n" \
-    "The details of this exception have been suppressed in CI to prevent" \
+    "The details of this exception have been suppressed in CI to prevent " \
     "public disclosure. Replicate this exception locally for further details."
   end
 end


### PR DESCRIPTION
Thanks to Jack 🕵🏻‍♂️ for spotting.