### PR TITLE
Implement pulsing loading icon

### DIFF
--- a/app/assets/images/components/conversation_message/govuk-chat-message-loading-icon.svg
+++ b/app/assets/images/components/conversation_message/govuk-chat-message-loading-icon.svg
@@ -1,0 +1,40 @@
+<svg width="30" height="30" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id='gradient1' gradientUnits='objectBoundingBox' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0' stop-color='#00FFE0'>
+        <animate attributeName="stop-color"
+            values="#00FFE0;#0F385C;#1D70B8;#00FFE0;" dur="10s" repeatCount="indefinite">
+        </animate>
+      </stop>
+      <stop offset='.5' stop-color='#0F385C'>
+        <animate attributeName="stop-color"
+            values="#0F385C;#1D70B8;#00FFE0;#0F385C;" dur="10s" repeatCount="indefinite">
+        </animate>
+      </stop>
+      <stop offset='1' stop-color='#1D70B8'>
+        <animate attributeName="stop-color"
+            values="#1D70B8;#00FFE0;#0F385C;#1D70B8;" dur="10s" repeatCount="indefinite">
+        </animate>
+      </stop>
+      <animateTransform attributeName="gradientTransform" type="rotate" from="0 .5 .5" to="360 .5 .5"
+        dur="10s" repeatCount="indefinite" />
+    </linearGradient>
+    <linearGradient id='gradient2' gradientUnits='objectBoundingBox' x1='0' y1='1' x2='1' y2='1'>
+      <stop offset='0' stop-color='#00FFE0'>
+        <animate attributeName="stop-color"
+            values="#00FFE0;#0F385C;#1D70B8;#00FFE0;" dur="10s" repeatCount="indefinite">
+        </animate>
+      </stop>
+      <stop offset='1' stop-color='#0F385C' stop-opacity="0">
+        <animate attributeName="stop-color"
+            values="#0F385C;#1D70B8;#00FFE0;#0F385C;" dur="10s" repeatCount="indefinite">
+        </animate>
+      </stop>
+      <animateTransform attributeName="gradientTransform" type="rotate" values="360 .5 .5;0 .5 .5" class="ignore"
+        dur="10s" repeatCount="indefinite" />
+    </linearGradient>
+  </defs>
+  
+  <circle cx="50%" cy="50%" r="50%" fill="url(#gradient1)"/>
+  <circle cx="50%" cy="50%" r="50%" fill="url(#gradient2)"/>
+</svg>

--- a/app/assets/stylesheets/components/_conversation-message.scss
+++ b/app/assets/stylesheets/components/_conversation-message.scss
@@ -114,10 +114,45 @@ $message-container-spacing-mobile: 40px;
   outline-offset: -1px;
 }
 
+.app-c-conversation-message__body--loading-message {
+  padding-left: 0;
+}
+
 .app-c-conversation-message__body--user-message {
   background-color: govuk-tint(govuk-colour("light-blue"), 75%);
   outline: 1px solid govuk-tint(govuk-colour("light-blue"), 75%);
   outline-offset: -1px;
+}
+
+.app-c-conversation-message__loading-icon-container, .app-c-conversation-message__loading-icon {
+  width: govuk-spacing(6);
+  height: govuk-spacing(6);
+}
+
+.app-c-conversation-message__loading-icon-container {
+  margin: auto govuk-spacing(2) auto 0;
+
+  @media (prefers-reduced-motion: reduce) {
+    display: none;
+  }
+}
+
+.app-c-conversation-message__loading-icon {
+	animation: loading-icon-pulse 3s ease infinite;
+
+  @keyframes loading-icon-pulse {
+    0% {
+      transform: scale(0.6)
+    }
+    
+    50% {
+      transform: scale(1)
+    }
+    
+    100% {
+      transform: scale(0.6)
+    }
+  }
 }
 
 .app-c-conversation-message__loading-text {

--- a/app/views/components/_conversation_message.html.erb
+++ b/app/views/components/_conversation_message.html.erb
@@ -17,31 +17,39 @@
 <%= content_tag :li, id:, class: "app-c-conversation-message js-conversation-message", data: data_attributes do %>
   <%= content_tag :div, class: message_classes do %>
     <% if is_question %>
-      <div class="app-c-conversation-message__body app-c-conversation-message__body--user-message">
-        <%= content_tag :span, class: message_identifier_classes do %>
-          You
-        <% end %>
-        <% if is_loading %>
+      <% if is_loading %>
+        <div class="app-c-conversation-message__body app-c-conversation-message__body--user-message">
           <p class="app-c-conversation-message__loading-text govuk-body">
             Loading your question<span class="app-c-conversation-message__loading-ellipsis" aria-hidden="true">...</span>
           </p>
-        <% else %>
+        </div>
+      <% else %>
+        <div class="app-c-conversation-message__body app-c-conversation-message__body--user-message">
+          <%= content_tag :span, class: message_identifier_classes do %>
+            You
+          <% end %>
           <%= render "govuk_publishing_components/components/govspeak" do %>
             <%= escaped_simple_format(message) %>
           <% end %>
-        <% end %>
-      </div>
-
+        </div>
+      <% end %>
     <% else %>
-      <div class="app-c-conversation-message__body app-c-conversation-message__body--govuk-message">
-        <%= content_tag :span, class: message_identifier_classes do %>
-          GOV.UK Chat
-        <% end %>
-        <% if is_loading %>
+      <% if is_loading %>
+        <span class="app-c-conversation-message__loading-icon-container">
+          <%= inline_svg_tag "components/conversation_message/govuk-chat-message-loading-icon.svg", class: "app-c-conversation-message__loading-icon", aria_hidden: true %>
+        </span>
+
+        <div class="app-c-conversation-message__body app-c-conversation-message__body--loading-message">
           <p class="app-c-conversation-message__loading-text govuk-body">
             Generating your answer<span class="app-c-conversation-message__loading-ellipsis" aria-hidden="true">...</span>
           </p>
-        <% else %>
+        </div>
+      <% else %>
+        <div class="app-c-conversation-message__body app-c-conversation-message__body--govuk-message">
+          <%= content_tag :span, class: message_identifier_classes do %>
+            GOV.UK Chat
+          <% end %>
+
           <%= content_tag(
             :div,
             class: "app-c-conversation-message__answer",
@@ -64,8 +72,8 @@
               sources: sources,
             } %>
           <% end %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/spec/views/components/_conversation_message.html.erb_spec.rb
+++ b/spec/views/components/_conversation_message.html.erb_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "components/_conversation_message.html.erb" do
     end
 
     context "and is_loading is true" do
-      it "renders the loading text" do
+      it "renders the loading icon and text" do
         render("components/conversation_message", {
           id: "loading-answer",
           is_loading: true,
@@ -103,7 +103,9 @@ RSpec.describe "components/_conversation_message.html.erb" do
 
         expect(rendered).to have_selector("li.app-c-conversation-message#loading-answer") do |rendered_question|
           expect(rendered_question)
-            .to have_selector(".app-c-conversation-message__loading-text", text: "Generating your answer")
+            .to have_selector(".app-c-conversation-message__loading-icon-container")
+            .and have_selector(".app-c-conversation-message__loading-icon")
+            .and have_selector(".app-c-conversation-message__loading-text", text: "Generating your answer")
             .and have_selector(".app-c-conversation-message__loading-ellipsis", text: "...")
         end
       end


### PR DESCRIPTION
## What
This PR adds a loading animation for when an answer is being generated. It will be hidden from users that enable the `prefers-reduced-motion` media query.

## Why
[Trello card](https://trello.com/c/rTbWJvK8/2737-implement-loading-animation)

## Visual changes
### Loading message animation - before

https://github.com/user-attachments/assets/f8afed3f-18a4-401f-be3e-a54562dfc8d2

### Loading message animation - after

https://github.com/user-attachments/assets/82bbe788-f4e5-438e-bff7-bf1230439d96

