### PR TITLE
Add e2e system spec to track user interactions in admin area

### DIFF
--- a/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
+++ b/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe "Users interactions with chat are shown in admin area", :aws_credentials_stubbed, :chunked_content_index do
+  scenario do
+    given_i_am_an_admin_with_the_web_chat_permission
+    when_i_visit_the_conversation_page
+    and_i_enter_a_question
+    and_the_answer_is_generated
+    and_i_click_on_the_check_answer_button
+    and_i_click_that_the_answer_was_useful
+    then_i_see_that_my_feedback_was_submitted
+
+    when_i_visit_the_admin_area
+    and_i_browse_to_the_questions_section
+    and_i_click_on_my_question
+    then_i_see_the_answer
+    and_i_see_the_answer_feedback
+    and_i_see_the_topics_have_been_tagged
+  end
+
+  def given_i_am_an_admin_with_the_web_chat_permission
+    login_as(create(:signon_user, permissions: %w[admin-area web-chat]))
+  end
+
+  def when_i_visit_the_conversation_page
+    visit show_conversation_path
+  end
+
+  def and_i_enter_a_question
+    @question = "Should I open a business and what benefits could I claim if I do?"
+    fill_in "Message", with: @question
+    click_on "Send"
+  end
+
+  def and_the_answer_is_generated
+    titan_embedding = mock_titan_embedding(@question)
+    allow(Search::TextToEmbedding)
+      .to receive(:call)
+      .and_return(titan_embedding)
+
+    populate_chunked_content_index([
+      build(:chunked_content_record, titan_embedding:, exact_path: "/pay-more-tax#yes-really"),
+    ])
+
+    @answer = "Maybe. You could get some benefits."
+
+    stub_claude_jailbreak_guardrails(@question, triggered: false)
+    stub_claude_question_routing(@question)
+    stub_claude_structured_answer(@question, @answer)
+    stub_claude_output_guardrails(@answer, "False | None")
+    stub_claude_messages_topic_tagger(@question)
+
+    execute_queued_sidekiq_jobs
+  end
+
+  def and_i_click_on_the_check_answer_button
+    click_on "Check if an answer has been generated"
+  end
+
+  def and_i_click_that_the_answer_was_useful
+    click_on "Useful"
+  end
+
+  def then_i_see_that_my_feedback_was_submitted
+    expect(page).to have_content("Feedback submitted successfully.")
+  end
+
+  def when_i_visit_the_admin_area
+    visit admin_homepage_path
+  end
+
+  def and_i_browse_to_the_questions_section
+    click_link "Questions"
+  end
+
+  def and_i_click_on_my_question
+    click_link @question
+  end
+
+  def then_i_see_the_answer
+    expect(page).to have_content(@answer)
+  end
+
+  def and_i_see_the_answer_feedback
+    expect(page).to have_content("Useful")
+  end
+
+  def and_i_see_the_topics_have_been_tagged
+    expect(page).to have_content("Business")
+    expect(page).to have_content("Benefits")
+  end
+end


### PR DESCRIPTION
## Description

We have tests that cover a users interactions with chat e2e and we have tests that check when conversation data is present it is displayed correctly in the admin area. But we don't have one that checks the end-to-end flow of user interactions from the chat interface to the admin area.

This adds a test that:
- logs you in as admin with the web app permission
- asks a question
- gets an answer
- gives feedback on the answer
- visits the admin area
- navigates to the question show page
- checks the answer, feedback and topics are displayed

## Trello card

https://trello.com/c/Lj6yUvvm/2748-add-additional-system-specs-to-check-user-interactions-are-displayed-in-admin-area