### PR TITLE
Move shared .exportable functionality into shared example

### DIFF
--- a/spec/models/answer_analysis_spec.rb
+++ b/spec/models/answer_analysis_spec.rb
@@ -4,26 +4,14 @@ RSpec.describe AnswerAnalysis do
   end
 
   describe ".exportable" do
-    let!(:new_answer_analysis) { create(:answer_analysis, created_at: 2.days.ago) }
+    it_behaves_like "exportable by start and end date" do
+      let(:new_record) { create(:answer_analysis, created_at: 2.days.ago) }
+      let(:old_record) { create(:answer_analysis, created_at: 4.days.ago) }
 
-    before { create(:answer_analysis, created_at: 4.days.ago) }
-
-    it "returns answer_analyses created since the last export time" do
-      last_export = 3.days.ago
-      current_time = Time.current
-
-      exportable_answer_analysis = described_class.exportable(last_export, current_time)
-
-      expect(exportable_answer_analysis).to eq([new_answer_analysis])
-    end
-
-    it "returns an empty array if there are no new answer topics" do
-      last_export = 1.day.ago
-      current_time = Time.current
-
-      exportable_answer_analysis = described_class.exportable(last_export, current_time)
-
-      expect(exportable_answer_analysis).to eq([])
+      before do
+        new_record
+        old_record
+      end
     end
   end
 

--- a/spec/models/answer_feedback_spec.rb
+++ b/spec/models/answer_feedback_spec.rb
@@ -1,28 +1,12 @@
 RSpec.describe AnswerFeedback do
   describe ".exportable" do
-    let!(:new_answer_feedback) { create(:answer_feedback, created_at: 2.days.ago) }
-    let!(:old_answer_feedback) { create(:answer_feedback, created_at: 4.days.ago - 20.seconds) }
+    it_behaves_like "exportable by start and end date" do
+      let(:new_record) { create(:answer_feedback, created_at: 2.days.ago) }
+      let(:old_record) { create(:answer_feedback, created_at: 4.days.ago) }
 
-    context "when new answer feedback has been created since the last export" do
-      it "returns answer feedback created since the last export time" do
-        last_export = 4.days.ago
-        current_time = Time.current
-
-        exportable_answer_feedback = described_class.exportable(last_export, current_time)
-
-        expect(exportable_answer_feedback).to include(new_answer_feedback)
-        expect(exportable_answer_feedback).not_to include(old_answer_feedback)
-      end
-    end
-
-    context "when no new answer feedback has been created since the last export" do
-      it "does not return any answer feedback" do
-        last_export = 1.day.ago
-        current_time = Time.current
-
-        exportable_answer_feedback = described_class.exportable(last_export, current_time)
-
-        expect(exportable_answer_feedback.size).to eq(0)
+      before do
+        new_record
+        old_record
       end
     end
   end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -54,52 +54,30 @@ RSpec.describe Question do
   end
 
   describe ".exportable" do
-    context "when new answers have been created since the last export" do
-      let(:new_question) { create(:question, created_at: 2.days.ago) }
+    it_behaves_like "exportable by start and end date" do
+      let(:new_record) { create(:question, created_at: 2.days.ago) }
+      let(:old_record) { create(:question, created_at: 4.days.ago) }
 
       before do
-        old_question = create(:question, created_at: 4.days.ago - 20.seconds)
-        new_question.answer = create(:answer, created_at: 2.days.ago)
-        old_question.answer = create(:answer, created_at: 4.days.ago - 20.seconds)
+        create(:answer, question: new_record, created_at: 2.days.ago)
+        create(:answer, question: old_record, created_at: 4.days.ago)
       end
+    end
 
-      it "returns questions with answers created since the last export time" do
-        last_export = 4.days.ago
-        current_time = Time.current
+    it "includes the conversation a question belongs to" do
+      question = create(:question, created_at: 2.days.ago)
+      create(:answer, question:, created_at: 2.days.ago)
+      last_export = 4.days.ago
+      current_time = Time.current
 
-        exportable_questions = described_class.exportable(last_export, current_time)
+      exportable_questions = described_class.exportable(last_export, current_time)
 
-        expect(exportable_questions.size).to eq(1)
-        expect(exportable_questions).to include(new_question)
-      end
-
-      it "includes the conversation a question belongs to" do
-        last_export = 4.days.ago
-        current_time = Time.current
-
-        exportable_questions = described_class.exportable(last_export, current_time)
-
-        expect(exportable_questions.first.association(:conversation).loaded?).to be(true)
-      end
+      expect(exportable_questions.first.association(:conversation).loaded?).to be(true)
     end
 
     context "when new questions without answers have been created since the last export" do
       it "does not return any questions" do
         create(:question, created_at: 2.days.ago)
-
-        last_export = 4.days.ago
-        current_time = Time.current
-
-        exportable_questions = described_class.exportable(last_export, current_time)
-
-        expect(exportable_questions.size).to eq(0)
-      end
-    end
-
-    context "when no new answers were created since the last export" do
-      it "does not return any questions" do
-        old_question = create(:question, created_at: 4.days.ago - 20.seconds)
-        old_question.answer = create(:answer, created_at: 4.days.ago - 20.seconds)
 
         last_export = 4.days.ago
         current_time = Time.current

--- a/spec/support/exportable_model_examples.rb
+++ b/spec/support/exportable_model_examples.rb
@@ -1,0 +1,21 @@
+module ExportableModelExamples
+  shared_examples "exportable by start and end date" do
+    let(:current_time) { Time.current }
+
+    it "returns records created since the last export time" do
+      last_export = new_record.created_at - 1.second
+
+      exportable_records = described_class.exportable(last_export, current_time)
+
+      expect(exportable_records).to include(new_record)
+      expect(exportable_records).not_to include(old_record)
+    end
+
+    it "returns an empty array if no records have been created since the last export" do
+      last_export = new_record.created_at + 1.second
+      exportable_records = described_class.exportable(last_export, current_time)
+
+      expect(exportable_records).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Description

We have the concept on .exportable on various models that we send to BigQuery. These largely have similar implementations. They grab records between two datetimes. This functionality can be extracted into a shared example which we can reuse.

The exception to this is the 'Question' model, which has additional logic for:

- preloading the conversation, answer and sources assoicated with it which we want to test
- it uses the answers created_at instead of the questions created_at

After thinking for a while about whether i should use the shared example for questions due to these differences I've chosen to use the shared example for shared functionality. I've left the tests that test additional functionality in the questions .exportable describe block.

I'm not wed to this though as it's a bit harder to parse what's actually going on than leaving the tests as is. So if anyone disagrees i'm happy to go with that.

## Trello card

https://trello.com/c/Lj6yUvvm/2748-add-additional-system-specs-to-check-user-interactions-are-displayed-in-admin-area