### PR TITLE
Use separate process for post answer comp workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 release: bin/rails db:prepare
 web: bin/rails server -p ${PORT:-5000}
-worker: bundle exec sidekiq -C ./config/sidekiq.yml
+answer-worker: bundle exec sidekiq -C ./config/sidekiq_answer.yml
+default-worker: bundle exec sidekiq -C ./config/sidekiq_default.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,5 @@
 web: bin/rails server -p 3000
 css: bin/rails dartsass:watch
-worker: bundle exec sidekiq -C ./config/sidekiq.yml
+answer-worker: bundle exec sidekiq -C ./config/sidekiq_answer.yml
+default-worker: bundle exec sidekiq -C ./config/sidekiq_default.yml
 queue_consumer: bundle exec rake message_queue:published_documents_consumer

--- a/app/jobs/answer_topics_job.rb
+++ b/app/jobs/answer_topics_job.rb
@@ -1,6 +1,5 @@
 class AnswerTopicsJob < ApplicationJob
   MAX_RETRIES = 5
-  queue_as :default
   retry_on Anthropic::Errors::APIError, wait: 1.minute, attempts: MAX_RETRIES
 
   def perform(answer_id)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  queue_as :default
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 

--- a/app/jobs/compose_answer_job.rb
+++ b/app/jobs/compose_answer_job.rb
@@ -1,5 +1,5 @@
 class ComposeAnswerJob < ApplicationJob
-  queue_as :default
+  queue_as :answer
 
   def perform(question_id)
     question = Question.includes(:answer, :conversation).find_by(id: question_id)

--- a/app/jobs/generate_text_embedding_job.rb
+++ b/app/jobs/generate_text_embedding_job.rb
@@ -1,6 +1,4 @@
 class GenerateTextEmbeddingJob < ApplicationJob
-  queue_as :default
-
   def perform(document_id)
     repository = Search::ChunkedContentRepository.new
 

--- a/app/jobs/notify_slack_api_user_rate_limit_warning_job.rb
+++ b/app/jobs/notify_slack_api_user_rate_limit_warning_job.rb
@@ -1,6 +1,4 @@
 class NotifySlackApiUserRateLimitWarningJob < ApplicationJob
-  queue_as :default
-
   def perform(signon_name, percentage_used, request_type)
     SlackPoster.api_user_rate_limit_warning(signon_name:, percentage_used:, request_type:)
   end

--- a/bin/setup
+++ b/bin/setup
@@ -35,7 +35,7 @@ FileUtils.chdir APP_ROOT do
     # under normal circumstances
     if govuk_docker
       # avoid bin/dev in docker to avoid a single docker process managing multiple processes
-      exec "govuk-docker up govuk-chat-app govuk-chat-css govuk-chat-worker"
+      exec "govuk-docker up govuk-chat-app govuk-chat-css govuk-chat-answer-worker govuk-chat-default-worker"
     else
       exec "bin/dev -m all=1,queue_consumer=0"
     end

--- a/spec/jobs/answer_topics_job_spec.rb
+++ b/spec/jobs/answer_topics_job_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe AnswerTopicsJob do
 
   before { allow(AnswerAnalysisGeneration::TopicTagger).to receive(:call) }
 
+  it_behaves_like "a job in queue", "default"
+
   describe "#perform" do
     it "calls the AnswerAnalysisGeneration::TopicTagger with the answer" do
       described_class.new.perform(answer.id)

--- a/spec/jobs/compose_answer_job_spec.rb
+++ b/spec/jobs/compose_answer_job_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ComposeAnswerJob do
     allow(AnswerTopicsJob).to receive(:perform_later)
   end
 
+  it_behaves_like "a job in queue", "answer"
+
   describe "#perform" do
     it "saves the answer and sources" do
       expect { described_class.new.perform(question.id) }

--- a/spec/jobs/generate_text_embedding_job_spec.rb
+++ b/spec/jobs/generate_text_embedding_job_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe GenerateTextEmbeddingJob, :chunked_content_index do
+  it_behaves_like "a job in queue", "default"
+
   describe "#perform" do
     it "logs an error if the document is not found" do
       expect(Rails.logger).to receive(:info).with("Document non_existent_id not found in the index.")

--- a/spec/jobs/notify_slack_api_user_rate_limit_warning_job_spec.rb
+++ b/spec/jobs/notify_slack_api_user_rate_limit_warning_job_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe NotifySlackApiUserRateLimitWarningJob do
+  it_behaves_like "a job in queue", "default"
+
   describe "#perform" do
     it "triggers a Slack notification" do
       expect(SlackPoster).to receive(:api_user_rate_limit_warning).with(

--- a/spec/support/job_examples.rb
+++ b/spec/support/job_examples.rb
@@ -1,0 +1,7 @@
+module JobExamples
+  shared_examples "a job in queue" do |expected_queue|
+    it "is enqueued to the #{expected_queue} queue" do
+      expect(described_class.queue_name).to eq(expected_queue)
+    end
+  end
+end


### PR DESCRIPTION
## Description 

This follows on from #500 which added the config for the new sidekiq processes. This:

- updates the jobs to use the new high priority and low priority queues (run in different processes)
- adds a test to each worker to make sure it's in the right queue
- updates the procfiles
- updates bin/setup 

The plan is 

1. merge #500 which adds the the sidekiq config
2. merge https://github.com/alphagov/govuk-helm-charts/pull/3471 which adds the new processes
3. merge the [PR](https://github.com/alphagov/govuk-docker/pull/881) on GOV.UK Docker that adds the new Sidekiq processes
4. merge this PR 
5. create a PR to remove the unused worker process on helm 
6. remove unused config on GOV.UK Chat

## Trello card

https://trello.com/c/ZvE5LPnA/2747-investigate-moving-post-answer-composition-jobs-into-separate-process