### PR TITLE
Add config for sidekiq high and low priority processes

### DIFF
--- a/config/sidekiq_answer.yml
+++ b/config/sidekiq_answer.yml
@@ -1,0 +1,6 @@
+---
+:verbose: false
+:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 10).to_i %>
+:max_retries: 0
+:queues:
+  - answer

--- a/config/sidekiq_default.yml
+++ b/config/sidekiq_default.yml
@@ -1,0 +1,6 @@
+---
+:verbose: false
+:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 10).to_i %>
+:max_retries: 0
+:queues:
+  - default


### PR DESCRIPTION
## Description 

This adds config for separate Sidekiq processes for high and low priority jobs. I've chosen to implement these in separate configuration files rather than combining them and using env vars to set the queue names for simplicity.

This way we can simply use the separate configuration files for each process and not have to worry setting extra en vars in helm.

I've left the env vars for configuring concurrency in place. It looks like we're not using these env vars in helm at the moment, but i'm assuming it's been left in place for a reason. I can see we also have the option to configure the db pool. I can remove them if we decide we don't need them anymore.

The plan is to leave the current sidekiq config file in place until it's not being used anymore in helm.

## Trello card

https://trello.com/c/ZvE5LPnA/2747-investigate-moving-post-answer-composition-jobs-into-separate-process