### PR TITLE
[Do not merge] Add temporary "non_llm_answer" strategy

### DIFF
--- a/app/jobs/answer_topics_job.rb
+++ b/app/jobs/answer_topics_job.rb
@@ -12,6 +12,15 @@ class AnswerTopicsJob < ApplicationJob
       return logger.info("Answer #{answer_id} is not eligible for topic analysis")
     end
 
-    AnswerAnalysisGeneration::TopicTagger.call(answer)
+    if Rails.configuration.answer_strategy == "non_llm_answer"
+      # Temporary strategy for SREs to load test without incurring LLM costs
+      sleep 10
+      analysis = answer.build_analysis
+      analysis.primary_topic = "non_llm_primary_topic"
+      analysis.secondary_topic = "non_llm_secondary_topic"
+      analysis.save!
+    else
+      AnswerAnalysisGeneration::TopicTagger.call(answer)
+    end
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ApplicationRecord
          open_ai_rag_completion: "open_ai_rag_completion", # legacy strategy - no longer used
          openai_structured_answer: "openai_structured_answer",
          claude_structured_answer: "claude_structured_answer",
+         non_llm_answer: "non_llm_answer",
        },
        prefix: true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,7 +83,7 @@ module GovukChat
 
     config.bigquery_dataset_id = ENV["BIGQUERY_DATASET"]
 
-    config.answer_strategy = ENV.fetch("ANSWER_STRATEGY", "claude_structured_answer")
+    config.answer_strategy = "non_llm_answer"
 
     config.question_topics = GovukChatPrivate.config
                                              .llm_prompts.claude

--- a/lib/answer_composition/composer.rb
+++ b/lib/answer_composition/composer.rb
@@ -55,6 +55,14 @@ module AnswerComposition
           Pipeline::Claude::StructuredAnswerComposer,
           Pipeline::AnswerGuardrails.new(llm_provider: :claude),
         ])
+      when "non_llm_answer"
+        # Temporary strategy for SREs to load test without incurring LLM costs
+        sleep 20
+        context = Pipeline::Context.new(question)
+        context.abort_pipeline(
+          message: Answer::CannedResponses::LLM_CANNOT_ANSWER_MESSAGE,
+          status: "answered",
+        )
       else
         raise "Answer strategy #{answer_strategy} not configured"
       end


### PR DESCRIPTION
This strategy (which is configured as the default for this branch) will generate an answer without making any LLM calls.

It's for the SREs to be able to do load testing without incurring costs from any LLM providers.