### PR TITLE
Use ’ instead of '

### DIFF
--- a/app/views/components/_chat_introduction.html.erb
+++ b/app/views/components/_chat_introduction.html.erb
@@ -5,7 +5,7 @@
 <%= content_tag :div, class: "app-c-chat-introduction" do %>
   <%= render "components/chat_introduction_title", {
     title: "Get quick answers from GOV.UK Chat",
-    standfirst_paragraphs: ["Use GOV.UK's experimental AI tool to easily find out more about topics, services and information on GOV.UK."],
+    standfirst_paragraphs: ["Use GOV.UK’s experimental AI tool to easily find out more about topics, services and information on GOV.UK."],
   } %>
 
   <%= render "components/blue_button", {

--- a/spec/views/components/_chat_introduction.html.erb_spec.rb
+++ b/spec/views/components/_chat_introduction.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "components/_chat_introduction.html.erb" do
       .to have_selector(".app-c-chat-introduction")
       .and have_selector(".app-c-chat-introduction-title__svg-container")
       .and have_selector(".app-c-chat-introduction-title__title", text: "Get quick answers from GOV.UK Chat")
-      .and have_selector(".app-c-chat-introduction-title__lead-paragraph", text: "Use GOV.UK's experimental AI tool to easily find out more about topics, services and information on GOV.UK.")
+      .and have_selector(".app-c-chat-introduction-title__lead-paragraph", text: "Use GOV.UK’s experimental AI tool to easily find out more about topics, services and information on GOV.UK.")
       .and have_link("Ask a question")
   end
 end


### PR DESCRIPTION
## What
This PR is a small update to the copy on the homepage to switch out the usage of `'` to `’`.

## Why
Requested by design.

## Visual changes
As described above.