### PR TITLE
API: Require end user ID header

### DIFF
--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -440,7 +440,7 @@ components:
     EndUserIdHeader:
       name: Govuk-Chat-End-User-Id
       in: header
-      required: false
+      required: true
       description: |
         An identifier for an individual end-user client to be used to provide
         individual end-user rate limiting to ensure that no one client can

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -451,6 +451,7 @@ components:
         header, it's up to the client to ensure that the value is unique.
       schema:
         type: string
+        pattern: '\S'
   headers:
     GovukApiUserReadRateLimitLimit:
       description: The request limit for the API user in the current period.

--- a/spec/requests/api/v1/conversation_flow_spec.rb
+++ b/spec/requests/api/v1/conversation_flow_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Conversation API flow" do
   describe "API user conducts a conversation" do
     it "allows user to interact with the conversation API E2E" do
       given_i_am_a_signed_in_api_user
+      and_i_have_the_required_headers_set
       when_i_create_a_conversation
       and_i_poll_for_an_answer
       then_i_see_the_question_has_been_accepted
@@ -35,6 +36,7 @@ RSpec.describe "Conversation API flow" do
   describe "API user paginates through a long conversation" do
     it "allows user to paginate through the conversation" do
       given_i_am_a_signed_in_api_user
+      and_i_have_the_required_headers_set
       and_i_have_a_conversation_with_many_questions
       when_i_make_a_request_for_the_conversation
       then_i_receive_a_successful_response
@@ -60,6 +62,10 @@ RSpec.describe "Conversation API flow" do
     login_as(@api_user)
   end
 
+  def and_i_have_the_required_headers_set
+    @headers = { "HTTP_GOVUK_CHAT_END_USER_ID" => "end-user-123" }
+  end
+
   def when_i_create_a_conversation
     allow(AnswerComposition::Composer).to receive(:call) do |question|
       question.build_answer(
@@ -71,13 +77,14 @@ RSpec.describe "Conversation API flow" do
 
     post api_v1_create_conversation_path,
          params: { user_question: "What is the capital of France?" },
+         headers: @headers,
          as: :json
     @conversation_id = JSON.parse(response.body)["conversation_id"]
     @answer_url = JSON.parse(response.body)["answer_url"]
   end
 
   def and_i_poll_for_an_answer
-    get @answer_url
+    get(@answer_url, headers: @headers)
   end
 
   def then_i_see_the_question_has_been_accepted
@@ -96,6 +103,7 @@ RSpec.describe "Conversation API flow" do
   def when_i_add_another_question_to_the_conversation
     put api_v1_update_conversation_path(@conversation_id),
         params: { user_question: "What is the capital of Spain?" },
+        headers: @headers,
         as: :json
     @answer_url = JSON.parse(response.body)["answer_url"]
   end
@@ -103,6 +111,7 @@ RSpec.describe "Conversation API flow" do
   def when_i_attempt_to_submit_another_question_again
     put api_v1_update_conversation_path(@conversation_id),
         params: { user_question: "What is the capital of Spain?" },
+        headers: @headers,
         as: :json
   end
 
@@ -111,17 +120,22 @@ RSpec.describe "Conversation API flow" do
   end
 
   def and_i_have_a_conversation_with_many_questions
-    @conversation = create(:conversation, :api, signon_user: @api_user)
+    @conversation = create(
+      :conversation,
+      :api,
+      signon_user: @api_user,
+      end_user_id: "end-user-123",
+    )
     5.times { create(:question, :with_answer, conversation: @conversation) }
   end
 
   def when_i_make_a_request_for_the_conversation
     allow(Rails.configuration.conversations).to receive(:api_questions_per_page).and_return(2)
-    get api_v1_show_conversation_path(@conversation)
+    get(api_v1_show_conversation_path(@conversation), headers: @headers)
   end
 
   def when_i_request_the_earlier_page_of_questions
-    get JSON.parse(response.body)["earlier_questions_url"]
+    get(JSON.parse(response.body)["earlier_questions_url"], headers: @headers)
   end
   alias_method :when_i_request_the_earliest_page_of_questions, :when_i_request_the_earlier_page_of_questions
 
@@ -130,7 +144,7 @@ RSpec.describe "Conversation API flow" do
   end
 
   def when_i_request_the_later_page_of_questions
-    get JSON.parse(response.body)["later_questions_url"]
+    get(JSON.parse(response.body)["later_questions_url"], headers: @headers)
   end
 
   def and_there_is_no_later_questions_url

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -66,8 +66,22 @@ RSpec.describe "Api::V1::ConversationsController" do
       end
     end
 
+    [nil, "", "    "].each do |invalid_value|
+      it "responds with bad request if the end user ID header is '#{invalid_value.inspect}'" do
+        headers = { "HTTP_GOVUK_CHAT_END_USER_ID" => invalid_value }
+        process(method, url, params:, headers:, as: :json)
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
     it "responds with bad request if the end user ID header is missing" do
       process(method, url, params:, headers: {}, as: :json)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "responds with bad request if the end user ID header is empty" do
+      headers = { "HTTP_GOVUK_CHAT_END_USER_ID" => "     " }
+      process(method, url, params:, headers:, as: :json)
       expect(response).to have_http_status(:bad_request)
     end
   end

--- a/spec/requests/api/v1/downtime_spec.rb
+++ b/spec/requests/api/v1/downtime_spec.rb
@@ -1,19 +1,27 @@
 RSpec.describe "toggling downtime with Settings.instance.api_access_enabled" do
   let(:api_user) { create(:signon_user, :conversation_api) }
-  let(:conversation) { create(:conversation, :api, :with_history, signon_user: api_user) }
+  let(:conversation) do
+    create(:conversation, :api, :with_history, signon_user: api_user, end_user_id: "end-user-123")
+  end
 
   before { login_as(api_user) }
 
   it "returns the right status when api_access_enabled is false" do
     create(:settings, api_access_enabled: false)
-    get api_v1_show_conversation_path(conversation)
+    get(
+      api_v1_show_conversation_path(conversation),
+      headers: { "HTTP_GOVUK_CHAT_END_USER_ID" => "end-user-123" },
+    )
     expect(response).to have_http_status(:service_unavailable)
     expect(JSON.parse(response.body)["message"]).to eq("Service unavailable")
   end
 
   it "doesn't impact routes when api_access_enabled is true" do
     create(:settings, api_access_enabled: true)
-    get api_v1_show_conversation_path(conversation)
+    get(
+      api_v1_show_conversation_path(conversation),
+      headers: { "HTTP_GOVUK_CHAT_END_USER_ID" => "end-user-123" },
+    )
     expect(response).to have_http_status(:ok)
   end
 end


### PR DESCRIPTION

https://trello.com/c/LUgo03zy/2733

This header value is currently optional. If it's set then it'll
associate a conversation with the user ID specified. If it's not, then
the conversation is just associated with the signon user.

One DPIA requirement for Chat is that a user can request deletion of
their data. Without requiring this header value we wouldn't be able to
find the conversations for a given user. So we need to require it.
