### PR TITLE
Update topic tagger to return result object

### DIFF
--- a/app/jobs/answer_topics_job.rb
+++ b/app/jobs/answer_topics_job.rb
@@ -12,6 +12,13 @@ class AnswerTopicsJob < ApplicationJob
       return logger.info("Answer #{answer_id} is not eligible for topic analysis")
     end
 
-    AnswerAnalysisGeneration::TopicTagger.call(answer)
+    result = AnswerAnalysisGeneration::TopicTagger.call(answer.rephrased_question || answer.question.message)
+    analysis = answer.build_analysis(
+      primary_topic: result.primary_topic,
+      secondary_topic: result.secondary_topic,
+    )
+    analysis.assign_metrics("topic_tagger", result.metrics)
+    analysis.assign_llm_response("topic_tagger", result.llm_response)
+    analysis.save!
   end
 end

--- a/spec/lib/answer_analysis_generation/topic_tagger_spec.rb
+++ b/spec/lib/answer_analysis_generation/topic_tagger_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AnswerAnalysisGeneration::TopicTagger, :aws_credentials_stubbed d
       result = described_class.call(message)
 
       expected_content = claude_messages_tool_use_block(
-        input: { confidence: "high", primary_topic: "business", reasoning: "reason", secondary_topic: "benefits" },
+        input: { primary_topic: "business", reasoning: "reason", secondary_topic: "benefits" },
         name: "tagger_reasoning",
       )
       expected_llm_response = claude_messages_response(

--- a/spec/lib/answer_analysis_generation/topic_tagger_spec.rb
+++ b/spec/lib/answer_analysis_generation/topic_tagger_spec.rb
@@ -1,76 +1,46 @@
 RSpec.describe AnswerAnalysisGeneration::TopicTagger, :aws_credentials_stubbed do
   describe ".call" do
-    let(:answer) { create(:answer) }
-    let(:question) { answer.question }
+    let(:message) { "This is a test message." }
 
-    it "creates an analysis for the answer" do
-      stub_claude_messages_topic_tagger(question.message)
-      expect { described_class.call(answer) }.to change(AnswerAnalysis, :count).by(1)
-      expect(answer.reload.analysis)
-        .to have_attributes(
+    before { stub_claude_messages_topic_tagger(message) }
+
+    it "returns a results object with the expected topics" do
+      result = described_class.call(message)
+      expect(result)
+        .to be_a(AnswerAnalysisGeneration::TopicTagger::Result)
+        .and have_attributes(
           primary_topic: "business",
           secondary_topic: "benefits",
         )
     end
 
-    it "stores the LLM response" do
-      stub_claude_messages_topic_tagger(question.message)
+    it "returns a results object with the LLM response" do
+      result = described_class.call(message)
 
-      described_class.call(answer)
-
-      expected_llm_response = {
-        "id" => "msg-id",
-        "content" => [{ "id" => "tool-use-id", "input" => { "primary_topic" => "business", "secondary_topic" => "benefits", "confidence" => "high", "reasoning" => "reason" }, "name" => "tagger_reasoning", "type" => "tool_use" }],
-        "model" => BedrockModels.model_id(:claude_sonnet),
-        "role" => "assistant",
-        "stop_reason" => "tool_use",
-        "type" => "message",
-        "usage" => { "cache_read_input_tokens" => 20, "input_tokens" => 10, "output_tokens" => 20 },
-      }
-      expect(answer.reload.analysis.llm_responses["topic_tagger"]).to eq(expected_llm_response)
+      expected_content = claude_messages_tool_use_block(
+        input: { confidence: "high", primary_topic: "business", reasoning: "reason", secondary_topic: "benefits" },
+        name: "tagger_reasoning",
+      )
+      expected_llm_response = claude_messages_response(
+        content: [expected_content],
+        usage: { cache_read_input_tokens: 20 },
+        stop_reason: :tool_use,
+      ).to_h
+      expect(result.llm_response).to eq(expected_llm_response.to_h)
     end
 
-    it "assigns metrics to the answer" do
+    it "returns a results object with the metrics" do
       allow(Clock).to receive(:monotonic_time).and_return(100.0, 101.5)
-      stub_claude_messages_topic_tagger(question.message)
+      result = described_class.call(message)
 
-      described_class.call(answer)
-
-      expect(answer.reload.analysis.metrics["topic_tagger"])
-        .to eq(
-          "duration" => 1.5,
-          "llm_prompt_tokens" => 30,
-          "llm_completion_tokens" => 20,
-          "llm_cached_tokens" => 20,
-          "model" => BedrockModels.model_id(:claude_sonnet),
-        )
-    end
-
-    context "when the answer has a rephrased_question" do
-      let(:rephrased_question) { "This is a rephrased_question" }
-
-      it "uses the rephrased question for topic tagging" do
-        answer = create(:answer, rephrased_question:)
-        stub_claude_messages_topic_tagger(rephrased_question)
-        expect { described_class.call(answer) }.to change(AnswerAnalysis, :count).by(1)
-      end
-    end
-
-    context "when the answer isn't eligible for topic analysis" do
-      it "raises an error" do
-        answer = create(:answer, status: Answer::STATUSES_EXCLUDED_FROM_TOPIC_ANALYSIS.sample)
-
-        expect { described_class.call(answer) }
-          .to raise_error("Answer #{answer.id} is not eligible for topic analysis")
-      end
-    end
-
-    context "when the answer already has a primary topic" do
-      it "raises an error" do
-        create(:answer_analysis, answer:)
-        expect { described_class.call(answer.reload) }
-          .to raise_error("Topics already generated for answer #{answer.id}")
-      end
+      expect(result.metrics)
+        .to eq({
+          duration: 1.5,
+          llm_prompt_tokens: 30,
+          llm_completion_tokens: 20,
+          llm_cached_tokens: 20,
+          model: BedrockModels.model_id(:claude_sonnet),
+        })
     end
   end
 end

--- a/spec/requests/api/v1/conversation_flow_spec.rb
+++ b/spec/requests/api/v1/conversation_flow_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Conversation API flow" do
         status: :answered,
       )
     end
-    allow(AnswerAnalysisGeneration::TopicTagger).to receive(:call)
+    allow(AnswerTopicsJob).to receive(:perform_later)
 
     post api_v1_create_conversation_path,
          params: { user_question: "What is the capital of France?" },

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -156,7 +156,7 @@ module StubClaudeMessages
     tools = [topic_tagger_config["tool_spec"]]
     content = [
       claude_messages_tool_use_block(
-        input: { primary_topic: "business", secondary_topic: "benefits", confidence: "high", reasoning: "reason" },
+        input: { primary_topic: "business", secondary_topic: "benefits", reasoning: "reason" },
         name: tools.first["name"],
       ),
     ]


### PR DESCRIPTION
## Description 

We want to be able to run auto eval on the topics we tag questions with. Currently, the topic tagger persists the answer analysis results in the database.

This is undesirable because we don't want to persist records to the db during auto eval.

This updates the topic tagger to take a user_question and returns a results object with the primary & secondary topics, as well as the LLM response and metrics.

The job now handles persisting the analysis to the database based on the results object.

It also handles passing the question message or rephrased question to the topic tagger.

## Trello card

https://trello.com/c/jxwjoYlu/2710-auto-evaluator-for-the-topic-tagger