### PR TITLE
Run onboarding animation only once

### DIFF
--- a/app/assets/javascripts/modules/chat-conversation.js
+++ b/app/assets/javascripts/modules/chat-conversation.js
@@ -17,12 +17,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.formContainer.addEventListener('submit', e => this.handleFormSubmission(e))
 
       // new messages indicates we are onboarding a user
-      if (this.messageLists.hasNewMessages()) {
+      if (this.messageLists.hasNewMessages() && !window.GOVUK.cookie('govuk_chat_onboarding_complete')) {
         this.conversationFormRegion.classList.add('govuk-visually-hidden')
         this.messageLists.progressivelyDiscloseMessages().then(() => {
           this.conversationFormRegion.classList.add('app-conversation-layout__form-region--slide-in')
           this.conversationFormRegion.classList.remove('govuk-visually-hidden')
           this.messageLists.scrollToLastNewMessage()
+          window.GOVUK.cookie('govuk_chat_onboarding_complete', 'true')
         })
       } else {
         this.messageLists.scrollToLastMessageInHistory()

--- a/spec/javascripts/modules/chat-conversation-spec.js
+++ b/spec/javascripts/modules/chat-conversation-spec.js
@@ -45,8 +45,10 @@ describe('ChatConversation module', () => {
       expect(handleFormSubmissionSpy).toHaveBeenCalled()
     })
 
-    describe('when initialised with existing new messages', () => {
+    describe('when initialised with existing new messages for the first time', () => {
       beforeEach(() => {
+        window.GOVUK.deleteCookie('govuk_chat_onboarding_complete')
+
         const newMessagesList = moduleElement.querySelector('.js-new-conversation-messages-list')
         newMessagesList.innerHTML = `
           <li class="js-conversation-message">Message 1</li>
@@ -79,6 +81,36 @@ describe('ChatConversation module', () => {
           expect(conversationFormRegion.classList).toContain('app-conversation-layout__form-region--slide-in')
           done()
         }, 0)
+      })
+    })
+
+    describe('when initialised with existing new messages after the govuk_onboarding_complete cookie has been set', () => {
+      beforeEach(() => {
+        window.GOVUK.cookie('govuk_chat_onboarding_complete', 'true')
+
+        const newMessagesList = moduleElement.querySelector('.js-new-conversation-messages-list')
+        newMessagesList.innerHTML = `
+          <li class="js-conversation-message">Message 1</li>
+          <li class="js-conversation-message">Message 2</li>
+        `
+      })
+
+      afterEach(() => {
+        window.GOVUK.deleteCookie('govuk_chat_onboarding_complete')
+      })
+
+      it('does not progressively disclose messages', () => {
+        const progressivelyDiscloseMessagesSpy = spyOn(module.messageLists, 'progressivelyDiscloseMessages').and.resolveTo()
+
+        module.init()
+
+        expect(progressivelyDiscloseMessagesSpy).not.toHaveBeenCalled()
+      })
+
+      it('does not hide the form component', () => {
+        module.init()
+
+        expect(conversationFormRegion.classList).not.toContain('govuk-visually-hidden')
       })
     })
 


### PR DESCRIPTION
## What
This PR prevents the onboarding animation from running again if the user clears their chat or refreshes the page without having started a conversation. This has been achieved by adding a new `govuk_chat_onboarding_complete` cookie to detect whether the onboarding animation has completed. Happy to discuss.

If we're happy with this approach, we'll need to merge a corresponding PR in the components gem before merging this to accept the `govuk_chat_onboarding_complete` cookie in order for this to work as we're using `GOVUK.cookie()` (hence the failing test).

## Why
Requested by design.

## Visual changes
N/A - no changes have been made to the animation itself, only when it is run.