### PR TITLE
Remove unused sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,0 @@
----
-:verbose: false
-:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 10).to_i %>
-:max_retries: 0
-:queues:


### PR DESCRIPTION
## Description

We've not rolled out the workers that use the sidekiq answer and sidekiq default configuration files, so we can remove the unused config/sidekiq.yml config.

## Trello card

https://trello.com/c/ZvE5LPnA/2747-investigate-using-sidekiq-in-separate-process-for-post-answer-composition-jobs