### PR TITLE
Remove unused onboarding code

### DIFF
--- a/app/assets/javascripts/modules/chat-conversation.js
+++ b/app/assets/javascripts/modules/chat-conversation.js
@@ -14,7 +14,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     init () {
-      this.module.addEventListener('conversation-append', e => this.conversationAppend(e))
       this.formContainer.addEventListener('submit', e => this.handleFormSubmission(e))
 
       // new messages indicates we are onboarding a user
@@ -132,16 +131,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         console.error(error)
         this.redirect(this.pendingAnswerUrl)
       }
-    }
-
-    async conversationAppend (event) {
-      this.conversationFormRegion.classList.add('govuk-visually-hidden')
-      this.conversationFormRegion.classList.remove('app-conversation-layout__form-region--slide-in')
-      await this.messageLists.appendNewProgressivelyDisclosedMessages(event.detail.html)
-      this.conversationFormRegion.classList.add('app-conversation-layout__form-region--slide-in')
-      this.conversationFormRegion.classList.remove('app-conversation-layout__form-region--slide-out')
-      this.conversationFormRegion.classList.remove('govuk-visually-hidden')
-      this.messageLists.scrollToLastNewMessage()
     }
 
     redirect (url) {

--- a/app/assets/javascripts/modules/conversation-message-lists.js
+++ b/app/assets/javascripts/modules/conversation-message-lists.js
@@ -49,12 +49,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       })
     }
 
-    async appendNewProgressivelyDisclosedMessages (messagesHtml) {
-      this.newMessagesList.innerHTML = messagesHtml
-      this.newMessagesContainer.focus()
-      await this.progressivelyDiscloseMessages()
-    }
-
     scrollToLastNewMessage () {
       const message = this.newMessagesList.querySelector(`${this.MESSAGE_SELECTOR}:last-child`)
       if (message) this.scrollIntoView(message)

--- a/spec/javascripts/modules/chat-conversation-spec.js
+++ b/spec/javascripts/modules/chat-conversation-spec.js
@@ -36,15 +36,6 @@ describe('ChatConversation module', () => {
   })
 
   describe('init', () => {
-    it('executes conversationAppend on the conversation-append event', () => {
-      const conversationAppendSpy = spyOn(module, 'conversationAppend')
-
-      module.init()
-      moduleElement.dispatchEvent(new Event('conversation-append'))
-
-      expect(conversationAppendSpy).toHaveBeenCalled()
-    })
-
     it('adds an event listener for handleFormSubmission for form component submit events', () => {
       const handleFormSubmissionSpy = spyOn(module, 'handleFormSubmission')
 
@@ -423,56 +414,6 @@ describe('ChatConversation module', () => {
 
         expect(redirectSpy).toHaveBeenCalledWith(answerUrl)
       })
-    })
-  })
-
-  describe('handle conversationAppend event', () => {
-    let event
-
-    beforeEach(() => {
-      event = new CustomEvent(
-        'conversation-append',
-        {
-          detail: {
-            html: `
-              <li class="js-conversation-message">To show</li>
-              <li class="js-conversation-message">To disclose</li>
-            `
-          }
-        }
-      )
-    })
-
-    it('delegates to messageLists to append new progressively disclosed messages', () => {
-      module.init()
-
-      const appendNewProgressivelyDisclosedMessagesSpy = spyOn(
-        module.messageLists,
-        'appendNewProgressivelyDisclosedMessages'
-      )
-
-      moduleElement.dispatchEvent(event)
-
-      expect(appendNewProgressivelyDisclosedMessagesSpy).toHaveBeenCalled()
-    })
-
-    it('hides the conversationFormRegion.classList prior to disclosing messages and then shows it after', done => {
-      jasmine.clock().install()
-
-      module.init()
-
-      moduleElement.dispatchEvent(event)
-
-      expect(conversationFormRegion.classList).toContain('govuk-visually-hidden')
-
-      jasmine.clock().tick(longWaitForProgressiveDisclosure)
-      jasmine.clock().uninstall()
-
-      // timeout to ensure promise callbacks are executed
-      window.setTimeout(() => {
-        expect(conversationFormRegion.classList).not.toContain('govuk-visually-hidden')
-        done()
-      }, 0)
     })
   })
 })

--- a/spec/javascripts/modules/conversation-message-lists-spec.js
+++ b/spec/javascripts/modules/conversation-message-lists-spec.js
@@ -128,34 +128,6 @@ describe('conversationMessageLists module', () => {
     })
   })
 
-  describe('appendNewProgressivelyDisclosedMessages', () => {
-    it('sets the HTML of the new messages list', done => {
-      jasmine.clock().install()
-
-      newMessagesList.innerHTML = '<!-- expecting this to be empty -->'
-      const newHtml = '<li>A message</li>'
-      const promise = module.appendNewProgressivelyDisclosedMessages(newHtml)
-      jasmine.clock().tick(progressiveDisclosureDelay)
-      promise.then(() => {
-        expect(newMessagesList.innerHTML).toEqual(newHtml)
-        jasmine.clock().uninstall()
-        done()
-      })
-    })
-
-    it('focuses the new messages region', () => {
-      const focusSpy = spyOn(module.newMessagesContainer, 'focus')
-      module.appendNewProgressivelyDisclosedMessages('<li>Message</li>')
-      expect(focusSpy).toHaveBeenCalled()
-    })
-
-    it('delegates to progressivelyDiscloseMessages to do the progressive disclosure', () => {
-      const progressivelyDiscloseMessagesSpy = spyOn(module, 'progressivelyDiscloseMessages')
-      module.appendNewProgressivelyDisclosedMessages('<li>Message</li>')
-      expect(progressivelyDiscloseMessagesSpy).toHaveBeenCalled()
-    })
-  })
-
   describe('scrollToLastNewMessage', () => {
     describe('when there are new messages', () => {
       beforeEach(() => {


### PR DESCRIPTION

This event listener was used when we had the richer onboarding
experience. But the 'conversation-append' event isn't being dispatched
any more, so we don't need the code to listen to it.
