### PR TITLE
Add search component stylesheet

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -16,6 +16,7 @@
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/previous-and-next-navigation";
 @import "govuk_publishing_components/components/radio";
+@import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/select";
 @import "govuk_publishing_components/components/secondary-navigation";
 @import "govuk_publishing_components/components/service-navigation";


### PR DESCRIPTION
## What
This PR adds the search component stylesheet for the admin interface.

## Why
The search component was unstyled.

## Visual changes
| Before | After |
|--------|------|
| <img width="398" height="192" alt="image" src="https://github.com/user-attachments/assets/a89f8a1a-4f36-4628-8894-d213b56e0454" /> | <img width="2022" height="250" alt="image" src="https://github.com/user-attachments/assets/b41eb7f8-313e-462f-bdf2-546f0d159eed" /> |