### PR TITLE
Exclude opted out users from big query

### DIFF
--- a/app/models/answer_analysis.rb
+++ b/app/models/answer_analysis.rb
@@ -4,7 +4,9 @@ class AnswerAnalysis < ApplicationRecord
   belongs_to :answer
 
   scope :exportable, lambda { |start_date, end_date|
-    where(created_at: start_date...end_date)
+    joins(answer: { question: :conversation })
+    .where(created_at: start_date...end_date)
+    .merge(Conversation.exclude_opted_out_end_user_ids)
   }
 
   def serialize_for_export

--- a/app/models/answer_feedback.rb
+++ b/app/models/answer_feedback.rb
@@ -4,7 +4,9 @@ class AnswerFeedback < ApplicationRecord
   belongs_to :answer
 
   scope :exportable, lambda { |start_date, end_date|
-                       where(created_at: start_date...end_date)
+                       joins(answer: { question: :conversation })
+                       .where(created_at: start_date...end_date)
+                       .merge(Conversation.exclude_opted_out_end_user_ids)
                      }
 
   scope :group_useful_by_label,

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -5,6 +5,13 @@ class Conversation < ApplicationRecord
 
   scope :active, -> { where(Question.active.where("questions.conversation_id = conversations.id").arel.exists) }
 
+  scope :exclude_opted_out_end_user_ids, lambda {
+    ids = Rails.configuration.govuk_chat_private&.opted_out_end_user_ids || []
+
+    where(end_user_id: nil)
+    .or(where.not(end_user_id: ids))
+  }
+
   enum :source,
        {
          api: "api",

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -19,6 +19,16 @@ class Conversation < ApplicationRecord
        },
        prefix: true
 
+  def self.hashed_end_user_id(end_user_id)
+    return nil if end_user_id.blank?
+
+    OpenSSL::HMAC.hexdigest(
+      "SHA256",
+      Rails.application.secret_key_base,
+      end_user_id,
+    )
+  end
+
   def questions_for_showing_conversation(only_answered: false, before_id: nil, after_id: nil, limit: nil)
     scope = Question.where(conversation: self)
                   .includes(answer: %i[feedback sources])
@@ -55,10 +65,6 @@ class Conversation < ApplicationRecord
   def hashed_end_user_id
     return nil if end_user_id.blank?
 
-    OpenSSL::HMAC.hexdigest(
-      "SHA256",
-      Rails.application.secret_key_base,
-      end_user_id,
-    )
+    self.class.hashed_end_user_id(end_user_id)
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -26,6 +26,7 @@ class Question < ApplicationRecord
                        joins(:conversation, :answer)
                        .preload(:conversation, answer: %i[sources])
                        .where("answer.created_at": start_date...end_date)
+                       .merge(Conversation.exclude_opted_out_end_user_ids)
                      }
 
   scope :active, lambda {

--- a/docs/deleting-opted-out-end-user-data-in-bigquery.md
+++ b/docs/deleting-opted-out-end-user-data-in-bigquery.md
@@ -1,0 +1,21 @@
+# Deleting opted-out end user data in BigQuery
+
+When using the app, users have the ability to opt out of having us use their data for analysis. We expect this to be a relatively low number of users so for now the process is manual. If the numbers of users increase, we will revisit this and automate it.
+
+When the App team contact us to let us know a user has opted out you should do the following.
+
+## Adding the users end-user-id to the private repo
+
+Add the users `end-user-id` to the [opted out end user configuration](https://github.com/alphagov/govuk_chat_private/blob/main/config/opted_out_end_user_ids.yml) in the private repository.
+
+This will ensure that data on their conversations will be excluded from our BigQuery exports.
+
+## Deleting existing end user data
+
+After adding the `end-user-id` to the private repo you should ensure you delete any existing data for that user. You can do this by calling the [bigquery:delete_opted_out_end_user_data](https://github.com/alphagov/govuk-chat/blob/74e8f69b137f3eb658783574593995a3ae0a1ffe/lib/tasks/bigquery.rake) rake task. This rake task requires an `end-user-id` to be passed in as an argument.
+
+This rake task should be run on production. An example of this rake task being called is:
+
+```
+rake bigquery:delete_opted_out_end_user_data["real-end-users-id"]
+```

--- a/lib/tasks/bigquery.rake
+++ b/lib/tasks/bigquery.rake
@@ -60,11 +60,7 @@ namespace :bigquery do
     bigquery = Google::Cloud::Bigquery.new
     project_id = bigquery.project_id
     dataset_id = bigquery.dataset(Rails.configuration.bigquery_dataset_id).dataset_id
-    hashed_end_user_id = OpenSSL::HMAC.hexdigest(
-      "SHA256",
-      Rails.application.secret_key_base,
-      end_user_id,
-    )
+    hashed_end_user_id = Conversation.hashed_end_user_id(end_user_id)
 
     sql = <<~SQL
       DELETE FROM #{project_id}.#{dataset_id}.questions

--- a/spec/models/answer_analysis_spec.rb
+++ b/spec/models/answer_analysis_spec.rb
@@ -4,7 +4,13 @@ RSpec.describe AnswerAnalysis do
   end
 
   it_behaves_like "exportable by start and end date" do
+    let(:conversation) { create(:conversation, end_user_id: "opted-out-id") }
+    let(:question) { create(:question, conversation:) }
+    let(:answer) { create(:answer, question:) }
     let(:create_record_lambda) { ->(time) { create(:answer_analysis, created_at: time) } }
+    let(:create_excluded_record_lambda) { ->(time) { create(:answer_analysis, answer:, created_at: time) } }
+
+    before { allow(Rails.configuration.govuk_chat_private).to receive(:opted_out_end_user_ids).and_return(%w[opted-out-id]) }
   end
 
   describe "#serialize for export" do

--- a/spec/models/answer_feedback_spec.rb
+++ b/spec/models/answer_feedback_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe AnswerFeedback do
   it_behaves_like "exportable by start and end date" do
+    let(:conversation) { create(:conversation, end_user_id: "opted-out-id") }
+    let(:question) { create(:question, conversation:) }
+    let(:answer) { create(:answer, question:) }
     let(:create_record_lambda) { ->(time) { create(:answer_feedback, created_at: time) } }
+    let(:create_excluded_record_lambda) { ->(time) { create(:answer_feedback, answer:, created_at: time) } }
+
+    before { allow(Rails.configuration.govuk_chat_private).to receive(:opted_out_end_user_ids).and_return(%w[opted-out-id]) }
   end
 
   describe ".group_useful_by_label" do

--- a/spec/models/conversations_spec.rb
+++ b/spec/models/conversations_spec.rb
@@ -213,6 +213,23 @@ RSpec.describe Conversation do
     end
   end
 
+  describe ".hashed_end_user_id" do
+    it "returns nil if end_user_id is blank" do
+      expect(described_class.hashed_end_user_id(nil)).to be_nil
+      expect(described_class.hashed_end_user_id("")).to be_nil
+    end
+
+    it "returns the hashed end_user_id" do
+      hashed_id = OpenSSL::HMAC.hexdigest(
+        "SHA256",
+        Rails.application.secret_key_base,
+        "12345",
+      )
+
+      expect(described_class.hashed_end_user_id("12345")).to eq(hashed_id)
+    end
+  end
+
   describe "#hashed_end_user_id" do
     it "returns nil if end_user_id is blank" do
       conversation = create(:conversation, end_user_id: nil)

--- a/spec/models/conversations_spec.rb
+++ b/spec/models/conversations_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Conversation do
     end
   end
 
+  describe ".exclude_opted_out_end_user_ids" do
+    it "excludes conversations with opted-out end users" do
+      opted_out_end_user_id = "opted-out-id"
+      allow(Rails.configuration.govuk_chat_private)
+        .to receive(:opted_out_end_user_ids)
+        .and_return([opted_out_end_user_id])
+
+      create(:conversation, end_user_id: opted_out_end_user_id)
+      conversation = create(:conversation, end_user_id: "included-id")
+      conversation_with_no_end_user = create(:conversation, end_user_id: nil)
+
+      result = described_class.exclude_opted_out_end_user_ids
+      expect(result).to eq([conversation, conversation_with_no_end_user])
+    end
+  end
+
   describe ".questions_for_showing_conversation" do
     let(:conversation) { create(:conversation) }
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -64,14 +64,27 @@ RSpec.describe Question do
           )
         }
       end
+
+      let(:create_excluded_record_lambda) do
+        lambda { |time|
+          create(
+            :question,
+            created_at: time,
+            answer: create(:answer, created_at: time),
+            conversation: create(:conversation, end_user_id: "opted-out-id"),
+          )
+        }
+      end
+
+      before { allow(Rails.configuration.govuk_chat_private).to receive(:opted_out_end_user_ids).and_return(%w[opted-out-id]) }
     end
 
     it "includes the conversation a question belongs to" do
       question = create(:question, created_at: 2.days.ago)
       create(:answer, question:, created_at: 2.days.ago)
       last_export = 4.days.ago
-      current_time = Time.current
 
+      current_time = Time.current
       exportable_questions = described_class.exportable(last_export, current_time)
 
       expect(exportable_questions.first.association(:conversation).loaded?).to be(true)

--- a/spec/support/exportable_model_examples.rb
+++ b/spec/support/exportable_model_examples.rb
@@ -11,6 +11,15 @@ module ExportableModelExamples
       expect(exportable_records).to eq([new_record])
     end
 
+    it "excludes records with opted-out end users" do
+      new_record = create_record_lambda.call(last_export + 1.day)
+      create_excluded_record_lambda.call(last_export + 1.day)
+
+      exportable_records = described_class.exportable(last_export, Time.current)
+
+      expect(exportable_records).to eq([new_record])
+    end
+
     it "returns an empty array if no records have been created since the last export" do
       exportable_records = described_class.exportable(last_export, Time.current)
 


### PR DESCRIPTION
## Description

App users may want their data excluded from analysis. I've opened a draft PR to add some config to our private repo which will contain an array of user ids to exclude https://github.com/alphagov/govuk_chat_private/pull/41 

This PR does the following

- ensures we exclude data for opted-out users from Biguery by updating the various `.exportable` scopes to filter out records associated with end users that have opted out
- add a rake task to delete records from BigQuery associated with an end user id

## Trello card

https://trello.com/c/ixnHciM4/2767-process-to-delete-data-from-big-query-if-someone-has-opted-out