### PR TITLE
Track ingestion timestamps in Prometheus gauge

### DIFF
--- a/lib/message_queue/message_processor.rb
+++ b/lib/message_queue/message_processor.rb
@@ -30,8 +30,8 @@ module MessageQueue
           base_path_version.update!(payload_version:)
           if result.content_indexed?
             PrometheusMetrics.gauge(
-              "last_document_ingested",
-              1,
+              "message_queue_last_content_indexed_timestamp_seconds",
+              Time.current.to_i,
             )
           end
         else

--- a/lib/prometheus_metrics.rb
+++ b/lib/prometheus_metrics.rb
@@ -26,8 +26,8 @@ class PrometheusMetrics
       description: "The percentage of request quota used for the API user for write requests",
     },
     {
-      name: "last_document_ingested",
-      description: "A metric triggered each time a document is successfully ingested",
+      name: "message_queue_last_content_indexed_timestamp_seconds",
+      description: "Unix timestamp of the last message queue content item indexed",
     },
   ].freeze
 

--- a/spec/lib/message_queue/message_processor_spec.rb
+++ b/spec/lib/message_queue/message_processor_spec.rb
@@ -43,9 +43,14 @@ RSpec.describe MessageQueue::MessageProcessor do
         expect(Rails.logger).to have_received(:info).with(log_message)
       end
 
-      it "calls prometheus metrics last_document_ingested gauge" do
-        expect(PrometheusMetrics).to receive(:gauge).with("last_document_ingested", 1)
-        described_class.new.process(message)
+      it "records the current timestamp in the prometheus gauge" do
+        freeze_time do
+          expect(PrometheusMetrics)
+            .to receive(:gauge)
+            .with("message_queue_last_content_indexed_timestamp_seconds", Time.current.to_i)
+
+          described_class.new.process(message)
+        end
       end
 
       it "does not call the gauge when the synchroniser indicates content was skipped" do


### PR DESCRIPTION
We want to use Grafana to track how long it has been since we actually ingested content so we can alert when ingestion stalls. The old “value 1” gauge never changed over time, so rising staleness was invisible. Emitting the current timestamp for each successful sync lets Prometheus expose the real freshness delta and underpins the planned Slack alerting when the line trends upward.