### PR TITLE
Backfill answer source chunk data

### DIFF
--- a/db/migrate/20250917201750_backfill_source_chunks.rb
+++ b/db/migrate/20250917201750_backfill_source_chunks.rb
@@ -1,0 +1,37 @@
+class BackfillSourceChunks < ActiveRecord::Migration[8.0]
+  class AnswerSource < ApplicationRecord; end
+  class AnswerSourceChunk < ApplicationRecord; end
+
+  disable_ddl_transaction!
+
+  def up
+    AnswerSource.where(answer_source_chunk_id: nil).find_each do |answer_source|
+      content_id, locale, chunk_index = answer_source.content_chunk_id.split("_")
+      attributes = {
+        content_id:,
+        locale:,
+        chunk_index:,
+        digest: answer_source.content_chunk_digest,
+        title: answer_source.title,
+        base_path: answer_source.base_path,
+        exact_path: answer_source.exact_path,
+        # There isn't sufficient data for these fields so we're making do
+        heading_hierarchy: [answer_source.heading].compact,
+        document_type: "",
+        html_content: "",
+        plain_content: "",
+      }
+
+      unique_attributes = attributes.slice(:content_id, :locale, :chunk_index, :digest)
+      chunk = AnswerSourceChunk.find_or_create_by!(unique_attributes) do |to_insert|
+        to_insert.attributes = attributes
+      end
+
+      answer_source.update!(answer_source_chunk_id: chunk.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigratio
+  end
+end

--- a/db/migrate/20250918080510_default_for_heading_hierarchy.rb
+++ b/db/migrate/20250918080510_default_for_heading_hierarchy.rb
@@ -1,0 +1,13 @@
+class DefaultForHeadingHierarchy < ActiveRecord::Migration[8.0]
+  def up
+    change_table :answer_source_chunks, bulk: true do |t|
+      t.change :heading_hierarchy, :string, array: true, default: [], null: false
+    end
+  end
+
+  def down
+    change_table :answer_source_chunks, bulk: true do |t|
+      t.change :heading_hierarchy, :string, array: true, default: nil, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_201750) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_18_080510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_201750) do
     t.string "digest", null: false
     t.string "title", null: false
     t.string "description"
-    t.string "heading_hierarchy", array: true
+    t.string "heading_hierarchy", default: [], null: false, array: true
     t.string "base_path", null: false
     t.string "exact_path", null: false
     t.string "document_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_16_082602) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_201750) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/lib/tasks/search_spec.rb
+++ b/spec/lib/tasks/search_spec.rb
@@ -130,4 +130,57 @@ RSpec.describe "rake search tasks" do
       .to output("Adding missing content mappings\nNo mappings were added\n").to_stdout
     end
   end
+
+  describe "search:backfill_answer_source_chunks", :chunked_content_index do
+    let(:task_name) { "search:backfill_answer_source_chunks" }
+
+    before { Rake::Task[task_name].reenable }
+
+    it "updates answer_source_chunk records that have a search result with a matching digest" do
+      match_chunk, not_match_chunk = create_list(:answer_source_chunk, 2, document_type: "")
+
+      field_updates = {
+        heading_hierarchy: ["Updated Heading"],
+        html_content: "<h1>Updated HTML</h1>",
+        plain_content: "Updated plain content",
+        document_type: "updated_document_type",
+        parent_document_type: "updated_document_type",
+        description: "Updated description",
+      }
+
+      matched_result = build(
+        :chunked_content_record,
+        **field_updates.merge(match_chunk.attributes.slice(*%w[content_id locale chunk_index digest])),
+      )
+      not_matched_result = build(
+        :chunked_content_record,
+        **field_updates.merge(not_match_chunk.attributes.slice(*%w[content_id locale chunk_index])),
+      )
+
+      matched_id = [match_chunk.content_id, match_chunk.locale, match_chunk.chunk_index].join("_")
+      not_matched_id = [not_match_chunk.content_id, not_match_chunk.locale, not_match_chunk.chunk_index].join("_")
+
+      populate_chunked_content_index(matched_id => matched_result, not_matched_id => not_matched_result)
+
+      expect { Rake::Task[task_name].invoke }
+        .to output("Finished - Checked 2 records - updated 1, out of date 1, not found 0\n").to_stdout
+
+      expect(match_chunk.reload).to have_attributes(field_updates)
+      expect(not_match_chunk.reload).not_to have_attributes(field_updates)
+    end
+
+    it "doesn't update answer_source_chunk records where a search result can't be found" do
+      create(:answer_source_chunk, document_type: "")
+
+      expect { Rake::Task[task_name].invoke }
+        .to output("Finished - Checked 1 records - updated 0, out of date 0, not found 1\n").to_stdout
+    end
+
+    it "doesn't update answer_source_chunk records that have a document_type" do
+      create(:answer_source_chunk, document_type: "news_article")
+
+      expect { Rake::Task[task_name].invoke }
+        .to output("Finished - Checked 0 records - updated 0, out of date 0, not found 0\n").to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/qAuq0tcr/2782-store-used-search-results-in-the-chat-db

This adds a DB migration that populates AnswerSourceChunk records with the partial data stored in AnswerSource records, enabling a future step of using the data from AnswerSourceChunk and subsequently deleting the now duplicated records.

With this I've also added a migration to make the heading_hierarchy array column default to an empty array and not be null, this is to avoid it having two types of empty state: null and empty array.

Finally, I've added a rake task that can use the existing data we have in the search index to repopulate AnswerSourceChunk records to be complete. This will only work for content that hasn't since changed so doesn't fix all data but will resolve existing data. I intend to delete this task once it has been run in production.