### PR TITLE
Change absolute URL to absolute path

### DIFF
--- a/app/views/admin/search/index.html.erb
+++ b/app/views/admin/search/index.html.erb
@@ -3,7 +3,7 @@ content_for(:title, "Search RAG index")
 content_for(:active_navigation_item, admin_search_path)
 %>
 
-<%= form_with url: admin_search_url, method: :get do |f| %>
+<%= form_with url: admin_search_path, method: :get do |f| %>
     <%= render "govuk_publishing_components/components/search", {
         label_text: "Text to search for",
         inline_label: false,


### PR DESCRIPTION
Trello: https://trello.com/c/c5NFyBMB/2783-investigate-configuring-allowed-hosts-for-rails-app

This resolves an issue flagged on our ITHC where this particular form could be subject to a DNS rebinding attack because of it's use of an absolute URL. Using an absolute path resolves this issue.

We may still want to investigate having an allow list of hosts to prevent the risk of such attacks further.