### PR TITLE
Make answer_source_chunk a required association

### DIFF
--- a/app/models/answer_source.rb
+++ b/app/models/answer_source.rb
@@ -2,7 +2,6 @@ class AnswerSource < ApplicationRecord
   belongs_to :answer
   belongs_to :chunk,
              class_name: "AnswerSourceChunk",
-             optional: true,
              foreign_key: "answer_source_chunk_id"
 
   scope :used, -> { where(used: true) }

--- a/db/migrate/20250918151214_answer_sources_answer_source_chunk_id_not_null.rb
+++ b/db/migrate/20250918151214_answer_sources_answer_source_chunk_id_not_null.rb
@@ -1,0 +1,5 @@
+class AnswerSourcesAnswerSourceChunkIdNotNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :answer_sources, :answer_source_chunk_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_080510) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_18_151214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_080510) do
     t.string "base_path", null: false
     t.string "heading"
     t.boolean "used", default: true
-    t.uuid "answer_source_chunk_id"
+    t.uuid "answer_source_chunk_id", null: false
     t.float "search_score"
     t.float "weighted_score"
     t.index ["answer_id", "relevancy"], name: "index_answer_sources_on_answer_id_and_relevancy", unique: true

--- a/spec/factories/answer_source_factory.rb
+++ b/spec/factories/answer_source_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :answer_source do
     answer
+    chunk(factory: :answer_source_chunk)
     sequence(:relevancy) { |n| n }
     sequence(:base_path) { |n| "/base_path/#{n}" }
     sequence(:exact_path) { |n| "#{base_path}/path/#{n}" }


### PR DESCRIPTION
Trello: https://trello.com/c/qAuq0tcr/2782-store-used-search-results-in-the-chat-db

Now that we have migrated data over to use this record this field can become a non-nullable entity and be a required association.