### PR TITLE
Add completeness graph to metrics & reorder them

### DIFF
--- a/app/controllers/admin/metrics_controller.rb
+++ b/app/controllers/admin/metrics_controller.rb
@@ -18,12 +18,6 @@ class Admin::MetricsController < Admin::BaseController
     render json: count_by_period(scope, :created_at).chart_json
   end
 
-  def answer_feedback
-    scope = AnswerFeedback.where(created_at: start_time..)
-                          .group_useful_by_label
-    render json: count_by_period(scope, :created_at).chart_json
-  end
-
   def answer_unanswerable_statuses
     scope = Answer.where(created_at: start_time..)
                   .aggregate_status("unanswerable")

--- a/app/controllers/admin/metrics_controller.rb
+++ b/app/controllers/admin/metrics_controller.rb
@@ -125,6 +125,18 @@ class Admin::MetricsController < Admin::BaseController
     render json: combined_counts.chart_json
   end
 
+  def answer_completeness
+    scope = Answer.where(created_at: start_time..)
+                  .where.not(completeness: nil)
+                  .group(:completeness)
+
+    if @period == :last_7_days
+      render json: count_by_period(scope, :created_at).chart_json
+    else
+      render json: scope.count.chart_json
+    end
+  end
+
 private
 
   def set_period

--- a/app/views/admin/metrics/index.html.erb
+++ b/app/views/admin/metrics/index.html.erb
@@ -127,3 +127,19 @@ common_chart_options = { refresh: 30 }
     <% end %>
   </div>
 </div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
+  <div class="<%= column_class %>" id="answer-completeness">
+    <h2 class="govuk-heading-l">Answer completeness</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
+
+  </div>
+
+<% if @period == :last_7_days %>
+</div>
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
+<% end %>

--- a/app/views/admin/metrics/index.html.erb
+++ b/app/views/admin/metrics/index.html.erb
@@ -36,9 +36,13 @@ common_chart_options = { refresh: 30 }
 <% column_class = @period == :last_7_days ? "govuk-grid-column-full" : "govuk-grid-column-one-half" %>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
-  <div class="<%= column_class %>" id="answer-feedback">
-    <h2 class="govuk-heading-l">Answer feedback</h2>
-    <%= column_chart admin_metrics_answer_feedback_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+  <div class="<%= column_class %>" id="topics">
+    <h2 class="govuk-heading-l">Topics</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_topics_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_topics_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
   </div>
 
 <% if @period == :last_7_days %>
@@ -46,12 +50,37 @@ common_chart_options = { refresh: 30 }
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
 <% end %>
 
+  <div class="<%= column_class %>" id="answers-with-error-status">
+    <h2 class="govuk-heading-l">Answers with error status</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_answer_error_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_answer_error_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="<%= column_class %>" id="answers-with-unanswerable-status">
     <h2 class="govuk-heading-l">Unanswerable questions</h2>
     <% if @period == :last_7_days %>
       <%= column_chart admin_metrics_answer_unanswerable_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
     <% else %>
       <%= pie_chart admin_metrics_answer_unanswerable_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
+  </div>
+
+  <% if @period == :last_7_days %>
+  </div>
+  <div class="govuk-grid-row govuk-!-margin-bottom-8">
+  <% end %>
+
+  <div class="<%= column_class %>" id="answer-completeness">
+    <h2 class="govuk-heading-l">Answer completeness</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
     <% end %>
   </div>
 </div>
@@ -70,32 +99,6 @@ common_chart_options = { refresh: 30 }
 </div>
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
 <% end %>
-
-  <div class="<%= column_class %>" id="answers-with-error-status">
-    <h2 class="govuk-heading-l">Answers with error status</h2>
-    <% if @period == :last_7_days %>
-      <%= column_chart admin_metrics_answer_error_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% else %>
-      <%= pie_chart admin_metrics_answer_error_statuses_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% end %>
-  </div>
-</div>
-
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
-  <div class="<%= column_class %>" id="question-routing-labels">
-    <h2 class="govuk-heading-l">Question routing labels</h2>
-    <% if @period == :last_7_days %>
-      <%= column_chart admin_metrics_question_routing_labels_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% else %>
-      <%= pie_chart admin_metrics_question_routing_labels_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% end %>
-  </div>
-
-<% if @period == :last_7_days %>
-</div>
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
-<% end %>
-
   <div class="<%= column_class %>" id="answer-guardrails-failures">
     <h2 class="govuk-heading-l">Answer guardrails failures</h2>
     <% if @period == :last_7_days %>
@@ -115,31 +118,25 @@ common_chart_options = { refresh: 30 }
       <%= pie_chart admin_metrics_question_routing_guardrails_failures_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
     <% end %>
   </div>
-</div>
-
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
-  <div class="<%= column_class %>" id="topics">
-    <h2 class="govuk-heading-l">Topics</h2>
-    <% if @period == :last_7_days %>
-      <%= column_chart admin_metrics_topics_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% else %>
-      <%= pie_chart admin_metrics_topics_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% end %>
-  </div>
-</div>
-
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
-  <div class="<%= column_class %>" id="answer-completeness">
-    <h2 class="govuk-heading-l">Answer completeness</h2>
-    <% if @period == :last_7_days %>
-      <%= column_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% else %>
-      <%= pie_chart admin_metrics_answer_completeness_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-    <% end %>
-
-  </div>
 
 <% if @period == :last_7_days %>
 </div>
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
 <% end %>
+
+  <div class="<%= column_class %>" id="question-routing-labels">
+    <h2 class="govuk-heading-l">Question routing labels</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_question_routing_labels_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_question_routing_labels_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
+  <div class="<%= column_class %>" id="answer-feedback">
+    <h2 class="govuk-heading-l">Answer feedback</h2>
+    <%= column_chart admin_metrics_answer_feedback_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+  </div>
+</div>

--- a/app/views/admin/metrics/index.html.erb
+++ b/app/views/admin/metrics/index.html.erb
@@ -133,10 +133,3 @@ common_chart_options = { refresh: 30 }
     <% end %>
   </div>
 </div>
-
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
-  <div class="<%= column_class %>" id="answer-feedback">
-    <h2 class="govuk-heading-l">Answer feedback</h2>
-    <%= column_chart admin_metrics_answer_feedback_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
-  </div>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
         get "question-routing-guardrails-failures", to: "metrics#question_routing_guardrails_failures",
                                                     as: :metrics_question_routing_guardrails_failures
         get "topics", to: "metrics#topics", as: :metrics_topics
+        get "answer-completeness", to: "metrics#answer_completeness", as: :metrics_answer_completeness
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,6 @@ Rails.application.routes.draw do
       scope defaults: { format: "json" }, constraints: html_json_constraint do
         get "conversations", to: "metrics#conversations", as: :metrics_conversations
         get "questions", to: "metrics#questions", as: :metrics_questions
-        get "answer-feedback", to: "metrics#answer_feedback", as: :metrics_answer_feedback
         get "answer-unanswerable-statuses", to: "metrics#answer_unanswerable_statuses", as: :metrics_answer_unanswerable_statuses
         get "answer-guardrails-statuses", to: "metrics#answer_guardrails_statuses", as: :metrics_answer_guardrails_statuses
         get "answer-error-statuses", to: "metrics#answer_error_statuses", as: :metrics_answer_error_statuses

--- a/spec/requests/admin/metrics_spec.rb
+++ b/spec/requests/admin/metrics_spec.rb
@@ -97,42 +97,6 @@ RSpec.describe "Admin::MetricsController" do
     end
   end
 
-  describe "GET :answer_feedback" do
-    it "renders a successful JSON response" do
-      get admin_metrics_answer_feedback_path
-      expect(response).to have_http_status(:ok)
-      expect(response.headers["Content-Type"]).to match("application/json")
-      expect(JSON.parse(response.body)).to eq([])
-    end
-
-    it "returns data of answer feedback grouped by useful and hour" do
-      create_list(:answer_feedback, 3, created_at: 3.hours.ago, useful: true)
-      create_list(:answer_feedback, 2, created_at: 5.hours.ago, useful: false)
-      create(:answer_feedback, created_at: 26.hours.ago)
-
-      get admin_metrics_answer_feedback_path
-
-      expect(JSON.parse(response.body)).to contain_exactly(
-        { "name" => "useful", "data" => counts_for_last_24_hours(hours_ago_3: 3) },
-        { "name" => "not useful", "data" => counts_for_last_24_hours(hours_ago_5: 2) },
-      )
-    end
-
-    context "when period is last_7_days" do
-      it "returns data of answer feedback grouped by useful label by day" do
-        create_list(:answer_feedback, 3, created_at: 3.days.ago, useful: true)
-        create_list(:answer_feedback, 2, created_at: 3.days.ago, useful: false)
-
-        get admin_metrics_answer_feedback_path(period: "last_7_days")
-
-        expect(JSON.parse(response.body)).to contain_exactly(
-          { "name" => "useful", "data" => counts_for_last_7_days(days_ago_3: 3) },
-          { "name" => "not useful", "data" => counts_for_last_7_days(days_ago_3: 2) },
-        )
-      end
-    end
-  end
-
   describe "GET :answer_unanswerable_statuses" do
     it "renders a successful JSON response" do
       get admin_metrics_answer_unanswerable_statuses_path

--- a/spec/system/admin/user_views_metrics_spec.rb
+++ b/spec/system/admin/user_views_metrics_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Admin user views metrics", :js do
     expect(page).to have_selector("#answer-guardrails-failures canvas")
     expect(page).to have_selector("#question-routing-guardrails-failures canvas")
     expect(page).to have_selector("#topics canvas")
+    expect(page).to have_selector("#answer-completeness canvas")
   end
 
   def and_i_can_see_its_for_last_24_hours

--- a/spec/system/admin/user_views_metrics_spec.rb
+++ b/spec/system/admin/user_views_metrics_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "Admin user views metrics", :js do
     # element, unclear how to assert correct chart
     expect(page).to have_selector("#conversations canvas")
     expect(page).to have_selector("#questions canvas")
-    expect(page).to have_selector("#answer-feedback canvas")
     expect(page).to have_selector("#answers-with-unanswerable-status canvas")
     expect(page).to have_selector("#answers-with-error-status canvas")
     expect(page).to have_selector("#question-routing-labels canvas")


### PR DESCRIPTION
## Description

This adds an answer completeness graph to the admin metrics. I've utilised the same logic as the answer feedback graph. So grouped by hour for 24hrs and grouped by day for 7 days. Happy to just have a simple pie chat for per day if that's preferable.

I've also reordered the metrics. The reasoning for the new ordering is in the commit. Again v happy to discuss/tweak based on peoples feedback.


## Screenshots 
### Last 24 hours 

<img width="219" height="158" alt="image" src="https://github.com/user-attachments/assets/6415b684-bf56-41f6-b1da-05e92d9eac21" />

### Last 7 days

<img width="460" height="172" alt="image" src="https://github.com/user-attachments/assets/98d3a90c-af82-4420-b577-f766349dcf79" />

### New ordering 

<img width="473" height="906" alt="image" src="https://github.com/user-attachments/assets/6ce6e07c-2abd-462c-aafc-717062b658ed" />

## Trello card

https://trello.com/c/UsyXUPCd/2805-add-answer-completeness-graph-to-the-admin-area-metrics