### PR TITLE
Make deprecated answer_sources field nullable

### DIFF
--- a/db/migrate/20250922122626_make_answer_source_deprecated_columns_nullable.rb
+++ b/db/migrate/20250922122626_make_answer_source_deprecated_columns_nullable.rb
@@ -1,0 +1,21 @@
+class MakeAnswerSourceDeprecatedColumnsNullable < ActiveRecord::Migration[8.0]
+  def up
+    change_table :answer_sources, bulk: true do |t|
+      t.change :exact_path, :string, null: true
+      t.change :base_path, :string, null: true
+      t.change :title, :string, null: true
+      t.change :content_chunk_id, :string, null: true
+      t.change :content_chunk_digest, :string, null: true
+    end
+  end
+
+  def down
+    change_table :answer_sources, bulk: true do |t|
+      t.change :exact_path, :string, null: false
+      t.change :base_path, :string, null: false
+      t.change :title, :string, null: false
+      t.change :content_chunk_id, :string, null: false
+      t.change :content_chunk_digest, :string, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_151214) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_122626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -65,14 +65,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_151214) do
 
   create_table "answer_sources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "answer_id", null: false
-    t.string "exact_path", null: false
+    t.string "exact_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "relevancy", null: false
-    t.string "title", null: false
-    t.string "content_chunk_id", null: false
-    t.string "content_chunk_digest", null: false
-    t.string "base_path", null: false
+    t.string "title"
+    t.string "content_chunk_id"
+    t.string "content_chunk_digest"
+    t.string "base_path"
     t.string "heading"
     t.boolean "used", default: true
     t.uuid "answer_source_chunk_id", null: false


### PR DESCRIPTION
This is a pre-cursor to removing these fields. This makes these fields be nullable so that we can set them as ignored_columns for Rails prior to their dropping from the database.