### PR TITLE
Include source data in rag evaluation

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -173,6 +173,7 @@ class Answer < ApplicationRecord
       "llm_responses" => llm_responses.to_json,
     )
   end
+  alias_method :serialize_for_evaluation, :serialize_for_export
 
   def use_in_rephrasing?
     STATUSES_EXCLUDED_FROM_REPHRASING.exclude?(status)

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -105,7 +105,7 @@ namespace :evaluation do
 
     raise "Error occurred generating answer: #{answer.error_message}" if answer.status =~ /^error/
 
-    puts(answer.to_json)
+    puts(answer.serialize_for_evaluation.to_json)
   end
 
   desc "Produce the output of question routing for a user input"

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -269,10 +269,11 @@ RSpec.describe "rake evaluation tasks" do
 
     it "outputs the response as JSON to stdout" do
       ClimateControl.modify(INPUT: input) do
-        answer = build(:answer)
+        answer = build(:answer, :with_sources)
+        answer_json = answer.serialize_for_evaluation.to_json
         allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
         expect { Rake::Task[task_name].invoke("openai") }
-          .to output("#{answer.to_json}\n").to_stdout
+          .to output("#{answer_json}\n").to_stdout
       end
     end
 

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -218,6 +218,13 @@ RSpec.describe Answer do
     end
   end
 
+  describe "#serialize_for_evaluation" do
+    it "returns the same as serialize_for_export" do
+      answer = build(:answer)
+      expect(answer.serialize_for_export).to eq(answer.serialize_for_evaluation)
+    end
+  end
+
   it "ensures the question routing labels and the enum values are in sync" do
     label_config = Rails.configuration.question_routing_labels
     enum_values = described_class.question_routing_labels.values


### PR DESCRIPTION
Previously the data for RAG evaluation didn't include any source data because the to_json method doesn't include source data. As we need basically the same data as serialize_for_export I've set up a method alias for serialize_for_evaluation to indicate the different intention but same behaviour.