### PR TITLE
Stop using deprecated columns in AnswerSource

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -155,14 +155,6 @@ class Answer < ApplicationRecord
         chunk:,
         search_score: result.score,
         weighted_score: result.weighted_score,
-        # TODO: These fields are stored on the chunk and should be removed
-        # once we've migrated to using chunks
-        base_path: result.base_path,
-        exact_path: result.exact_path,
-        title: result.title,
-        content_chunk_id: result._id,
-        content_chunk_digest: result.digest,
-        heading: result.heading_hierarchy.last,
       )
     end
   end

--- a/app/models/answer_source.rb
+++ b/app/models/answer_source.rb
@@ -7,9 +7,12 @@ class AnswerSource < ApplicationRecord
   scope :used, -> { where(used: true) }
   scope :unused, -> { where(used: false) }
 
-  def url
-    "#{Plek.website_root}#{exact_path}"
-  end
+  self.ignored_columns = %w[base_path
+                            exact_path
+                            title
+                            heading
+                            content_chunk_id
+                            content_chunk_digest]
 
   def serialize_for_export
     as_json(except: :answer_source_chunk_id).merge(

--- a/spec/factories/answer_source_factory.rb
+++ b/spec/factories/answer_source_factory.rb
@@ -5,11 +5,5 @@ FactoryBot.define do
     sequence(:relevancy) { |n| n }
     search_score { rand(0.1..1.0) }
     weighted_score { rand(0.1..2.0) }
-    sequence(:base_path) { |n| "/base_path/#{n}" }
-    sequence(:exact_path) { |n| "#{base_path}/path/#{n}" }
-    sequence(:title) { |n| "Title #{n}" }
-    sequence(:heading) { |n| "Heading #{n}" }
-    content_chunk_id { "#{SecureRandom.uuid}_en_0" }
-    content_chunk_digest { Digest::SHA2.new(256).hexdigest(rand.to_s) }
   end
 end

--- a/spec/models/answer_source_spec.rb
+++ b/spec/models/answer_source_spec.rb
@@ -1,11 +1,4 @@
 RSpec.describe AnswerSource do
-  describe "#url" do
-    it "concatenates the website root and source path" do
-      source = build(:answer_source, exact_path: "/income-tax")
-      expect(source.url).to eq("#{Plek.website_root}/income-tax")
-    end
-  end
-
   describe ".used" do
     it "returns sources where used is 'true'" do
       used_source = create(:answer_source, used: true)

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Answer do
   describe "#sources" do
     it "implicitly orders sources by relevancy" do
       answer = create(:answer)
-      source_1 = create(:answer_source, answer:, relevancy: 1, exact_path: "/1")
-      source_2 = create(:answer_source, answer:, relevancy: 0, exact_path: "/2")
+      source_1 = create(:answer_source, answer:, relevancy: 1)
+      source_2 = create(:answer_source, answer:, relevancy: 0)
 
       expect(answer.reload.sources.strict_loading(false)).to eq([source_2, source_1])
     end
@@ -143,12 +143,6 @@ RSpec.describe Answer do
           answer_source_chunk_id: chunk_a.id,
           search_score: search_result_a.score,
           weighted_score: search_result_a.weighted_score,
-          base_path: search_result_a.base_path,
-          exact_path: search_result_a.exact_path,
-          title: search_result_a.title,
-          content_chunk_id: search_result_a._id,
-          content_chunk_digest: search_result_a.digest,
-          heading: search_result_a.heading_hierarchy.last,
         )
       expect(answer.sources.second)
         .to have_attributes(
@@ -156,12 +150,6 @@ RSpec.describe Answer do
           answer_source_chunk_id: chunk_b.id,
           search_score: search_result_b.score,
           weighted_score: search_result_b.weighted_score,
-          base_path: search_result_b.base_path,
-          exact_path: search_result_b.exact_path,
-          title: search_result_b.title,
-          content_chunk_id: search_result_b._id,
-          content_chunk_digest: search_result_b.digest,
-          heading: search_result_b.heading_hierarchy.last,
         )
     end
 
@@ -186,7 +174,7 @@ RSpec.describe Answer do
       answer.build_sources_from_search_results([search_result])
 
       expect(answer.sources.length).to be(1)
-      expect(answer.sources.first).to have_attributes(exact_path: search_result.exact_path)
+      expect(answer.sources.first.chunk).to have_attributes(exact_path: search_result.exact_path)
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/qAuq0tcr/2782-store-used-search-results-in-the-chat-db

This flags these columns as ignored, so they will no longer be written to. This then removes the references to using these columns further.

The next step will be to delete these columns.