### PR TITLE
Use secure cookies in hosted envs

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -137,6 +137,7 @@ private
     cookies[:conversation_id] = {
       value: conversation.id,
       expires: Rails.configuration.conversations.max_question_age_days.days.from_now,
+      secure: Rails.env.production?,
     }
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,7 +77,7 @@ module GovukChat
     config.available_without_signon_authentication = ENV.key?("AVAILABLE_WITHOUT_SIGNON_AUTHENTICATION")
 
     # Make session length predictable to reduce confusion of when session data is lost.
-    config.session_store :cookie_store, key: "_govuk_chat_session", expire_after: 30.days
+    config.session_store :cookie_store, key: "_govuk_chat_session", expire_after: 30.days, secure: Rails.env.production?
 
     config.conversation_js_progressive_disclosure_delay = nil
 


### PR DESCRIPTION
## Description 

One of the outcomes of the ITHC report was that we could improve the security of our cookies by making them secure (only sent over HTTPS).

This commit updates the session cookie and the conversation_id cookie to be secure when in hosted environments (prod, staging, int and on Heroku).

The reason i'm doing all hosted envs is that Rails.env.production? returns true on staging and int. If we want to only have it in prod. I can:

- add an env var to helm for staging and int
- add an env var to the various heroku environments to toggle it off 

I don't see a massive downside to using secure cookies in all of the above though.

## Testing

I had a go at testing this, but everything that i came up with felt so contrived that it seemed pointless. I've decided to leave this untested, but it anyone has got any ideas then please do let me know.

## Screenshots 

<img width="947" height="105" alt="image" src="https://github.com/user-attachments/assets/adc1c9d0-a6b9-45a7-aac0-2d2cb23de78b" />


## Trello card

https://trello.com/c/36EeIbas/2784-use-secure-cookies-for-govuk-chat