### PR TITLE
Remove deprecated columns from AnswerSource

### DIFF
--- a/db/migrate/20250924074950_drop_answer_source_deprecated_columns.rb
+++ b/db/migrate/20250924074950_drop_answer_source_deprecated_columns.rb
@@ -1,0 +1,23 @@
+class DropAnswerSourceDeprecatedColumns < ActiveRecord::Migration[8.0]
+  def up
+    change_table :answer_sources, bulk: true do |t|
+      t.remove :exact_path
+      t.remove :base_path
+      t.remove :title
+      t.remove :heading
+      t.remove :content_chunk_id
+      t.remove :content_chunk_digest
+    end
+  end
+
+  def down
+    change_table :answer_sources, bulk: true do |t|
+      t.string :exact_path, null: true
+      t.string :base_path, null: true
+      t.string :title, null: true
+      t.string :heading
+      t.string :content_chunk_id, null: true
+      t.string :content_chunk_digest, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_22_122626) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_074950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -65,15 +65,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_22_122626) do
 
   create_table "answer_sources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "answer_id", null: false
-    t.string "exact_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "relevancy", null: false
-    t.string "title"
-    t.string "content_chunk_id"
-    t.string "content_chunk_digest"
-    t.string "base_path"
-    t.string "heading"
     t.boolean "used", default: true
     t.uuid "answer_source_chunk_id", null: false
     t.float "search_score"


### PR DESCRIPTION
Trello: https://trello.com/c/qAuq0tcr/2782-store-used-search-results-in-the-chat-db

These columns are now ignored so can be safely deleted.