### PR TITLE
Remove ignored columns and delegate chunk methods

### DIFF
--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -170,11 +170,11 @@ module Admin
 
       if answer&.sources.present?
         used_source_links = answer.sources.used.map do |source|
-          tag.a(source.chunk.title, href: source.chunk.govuk_url, class: "govuk-link")
+          tag.a(source.title, href: source.govuk_url, class: "govuk-link")
         end
 
         unused_source_links = answer.sources.unused.map do |source|
-          tag.a(source.chunk.title, href: source.chunk.govuk_url, class: "govuk-link")
+          tag.a(source.title, href: source.govuk_url, class: "govuk-link")
         end
 
         rows << {

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -180,10 +180,10 @@ class Answer < ApplicationRecord
   end
 
   def group_used_answer_sources_by_base_path
-    sources_by_base_path = sources.used.group_by { |source| source.chunk.base_path }
+    sources_by_base_path = sources.used.group_by(&:base_path)
 
     sources_by_base_path.map do |base_path, group|
-      result = group.first.chunk
+      result = group.first
       path = group.count == 1 ? result.exact_path : base_path
 
       title = result.title

--- a/app/models/answer_source.rb
+++ b/app/models/answer_source.rb
@@ -7,13 +7,6 @@ class AnswerSource < ApplicationRecord
   scope :used, -> { where(used: true) }
   scope :unused, -> { where(used: false) }
 
-  self.ignored_columns = %w[base_path
-                            exact_path
-                            title
-                            heading
-                            content_chunk_id
-                            content_chunk_digest]
-
   def serialize_for_export
     as_json(except: :answer_source_chunk_id).merge(
       "chunk" => chunk.serialize_for_export,

--- a/app/models/answer_source.rb
+++ b/app/models/answer_source.rb
@@ -7,6 +7,23 @@ class AnswerSource < ApplicationRecord
   scope :used, -> { where(used: true) }
   scope :unused, -> { where(used: false) }
 
+  delegate :content_id,
+           :locale,
+           :chunk_index,
+           :digest,
+           :title,
+           :description,
+           :heading_hierarchy,
+           :base_path,
+           :exact_path,
+           :document_type,
+           :parent_document_type,
+           :html_content,
+           :plain_content,
+           :govuk_url,
+           :heading,
+           to: :chunk
+
   def serialize_for_export
     as_json(except: :answer_source_chunk_id).merge(
       "chunk" => chunk.serialize_for_export,

--- a/lib/answer_composition/pipeline/context.rb
+++ b/lib/answer_composition/pipeline/context.rb
@@ -46,7 +46,7 @@ module AnswerComposition::Pipeline
 
     def update_sources_from_exact_urls_used(exact_urls)
       used_sources = exact_urls.filter_map do |exact_url|
-        answer.sources.find { |source| source.chunk.govuk_url == exact_url }
+        answer.sources.find { |source| source.govuk_url == exact_url }
       end
 
       if used_sources.empty?

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Admin::QuestionsHelper do
 
       expect(returned_keys(result)).to include("Used sources")
       expect(returned_value(result, "Used sources"))
-        .to have_link(source.chunk.title, href: source.chunk.govuk_url)
+        .to have_link(source.title, href: source.govuk_url)
     end
 
     it "returns an unused sources row when the answer has unused sources" do
@@ -130,7 +130,7 @@ RSpec.describe Admin::QuestionsHelper do
 
       expect(returned_keys(result)).to include("Unused sources")
       expect(returned_value(result, "Unused sources"))
-        .to have_link(source.chunk.title, href: source.chunk.govuk_url)
+        .to have_link(source.title, href: source.govuk_url)
     end
 
     it "returns feedback rows when the answer has feedback" do

--- a/spec/lib/answer_composition/pipeline/context_spec.rb
+++ b/spec/lib/answer_composition/pipeline/context_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe AnswerComposition::Pipeline::Context do
 
       instance.update_sources_from_exact_urls_used(
         [
-          first_used_source.chunk.govuk_url,
-          second_used_source.chunk.govuk_url,
+          first_used_source.govuk_url,
+          second_used_source.govuk_url,
         ],
       )
 
@@ -220,7 +220,7 @@ RSpec.describe AnswerComposition::Pipeline::Context do
 
       answer.sources = [unused_source, used_source]
 
-      instance.update_sources_from_exact_urls_used([used_source.chunk.govuk_url])
+      instance.update_sources_from_exact_urls_used([used_source.govuk_url])
 
       expect(answer.sources).to contain_exactly(used_source, unused_source)
       expect(used_source.relevancy).to eq(0)

--- a/spec/requests/admin/questions_spec.rb
+++ b/spec/requests/admin/questions_spec.rb
@@ -221,9 +221,9 @@ RSpec.describe "Admin::QuestionsController" do
 
       expect(response.body)
         .to have_content("Used sources")
-        .and have_link(used_source.chunk.title, href: used_source.chunk.govuk_url)
+        .and have_link(used_source.title, href: used_source.govuk_url)
         .and have_content("Unused sources")
-        .and have_link(unused_source.chunk.title, href: unused_source.chunk.govuk_url)
+        .and have_link(unused_source.title, href: unused_source.govuk_url)
     end
 
     it "renders the feedback for an answer when present" do


### PR DESCRIPTION
Trello: https://trello.com/c/qAuq0tcr/2782-store-used-search-results-in-the-chat-db

This removes the ignored columns from the codebase and, given the old columns are gone, then adds some method delegation to remove the need to always reference a chunk when calling a method for it.