### PR TITLE
Create error_timeout answers when appropriate in the GET answer API endpoint

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -70,7 +70,7 @@ class Api::V1::ConversationsController < Api::BaseController
 
   def answer
     question = @conversation.questions.find(params[:question_id])
-    answer = question.answer
+    answer = question.check_or_create_timeout_answer
 
     if answer.present?
       render json: AnswerBlueprint.render(answer), status: :ok


### PR DESCRIPTION
## Description 

We have the concept of an answer timing out in the Chat UI. When an answer takes longer than 2 minutes to generate, we create an "error_timeout" answer so that the user is able to ask another question.

We didn't add this to the API endpoint, so this commit adds that functionality.

## Trello card

https://trello.com/c/QG0VO4sA/2812-update-api-to-create-timed-out-answer-after-2-minutes