### PR TITLE
Add non_llm_answer to AnswerStrategy enum

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ApplicationRecord
          open_ai_rag_completion: "open_ai_rag_completion", # legacy strategy - no longer used
          openai_structured_answer: "openai_structured_answer",
          claude_structured_answer: "claude_structured_answer",
+         non_llm_answer: "non_llm_answer", # only used during load testing, but can be present on records created during testing
        },
        prefix: true
 


### PR DESCRIPTION
## Description

This strategy has been added to a branch used for load testing. When that branch is deployed and answers are generated, we persist the answer with the non_llm_answer strategy.

When we redeploy out main, it returns nil since the value isn't in our enum. This commit adds the value to the enum so that we can read those records and the question show page in the admin UI doesn't blow up when it tries to humanise nil.