### PR TITLE
Set allowed hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require_relative "../../lib/production_host_config"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -85,11 +86,8 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = ProductionHostConfig::HOSTS
 
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # Skip DNS rebinding protection for these requests
+  config.host_authorization = ProductionHostConfig::HOST_AUTHORIZATION
 end

--- a/lib/production_host_config.rb
+++ b/lib/production_host_config.rb
@@ -1,0 +1,10 @@
+module ProductionHostConfig
+  HOSTS = [
+    /chat\.(integration\.|staging\.)?publishing\.service\.gov\.uk/,
+    /govuk-chat(.*)?\.herokuapp\.com/,
+  ].freeze
+
+  HOST_AUTHORIZATION = {
+    exclude: ->(request) { request.path.start_with?("/healthcheck") },
+  }.freeze
+end

--- a/spec/lib/production_host_config_spec.rb
+++ b/spec/lib/production_host_config_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe ProductionHostConfig do
+  describe "HOSTS" do
+    let(:hosts) { described_class::HOSTS }
+
+    it "allows the production host" do
+      host = "chat.publishing.service.gov.uk"
+      expect(hosts.any? { host.match?(it) }).to be(true)
+    end
+
+    it "allows the integration host" do
+      host = "chat.integration.publishing.service.gov.uk"
+      expect(hosts.any? { host.match?(it) }).to be(true)
+    end
+
+    it "allows the staging host" do
+      host = "chat.staging.publishing.service.gov.uk"
+      expect(hosts.any? { host.match?(it) }).to be(true)
+    end
+
+    it "allows Heroku apps" do
+      hosts = [
+        "govuk-chat.herokuapp.com",
+        "govuk-chat-claude.herokuapp.com",
+        "govuk-chat-dependabot-b-ljtboi.herokuapp.com",
+      ]
+      hosts.each do |host|
+        expect(hosts.any? { host.match?(it) }).to be(true)
+      end
+    end
+  end
+
+  describe "HOST_AUTHORIZATION" do
+    let(:excluded) { described_class::HOST_AUTHORIZATION[:exclude] }
+
+    it "excludes paths beginning with /healthcheck" do
+      env = Rack::MockRequest.env_for("http://example.com/healthcheck/live")
+      request = Rack::Request.new(env)
+      expect(excluded.call(request)).to be(true)
+    end
+
+    it "does not exclude other paths" do
+      env = Rack::MockRequest.env_for("http://example.com/chat")
+      request = Rack::Request.new(env)
+      expect(excluded.call(request)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/c5NFyBMB/2783

Restricts the allowed hosts to prevent DNS rebinding attacks.

## Testing
I tested this on both Heroku and integration.

### Heroku
Heroku uses dynamic hostnames for its apps, so there's no way we can hard-code these. We have 2 categories of apps on Heroku that need to be treated differently. 

#### "Persistent" apps
The `govuk-chat-openai` and `govuk-chat-claude` apps. The hostnames don't change here, but we don't have control over what they are.

There's a Heroku labs add-on called [Dyno Metadata](https://devcenter.heroku.com/articles/dyno-metadata). Enabling this makes Heroku set some env vars related to the dyno that the app is running on. One of these env vars is `HEROKU_APP_DEFAULT_DOMAIN_NAME` which is the current hostname. Adding this to the allowed hosts makes these apps work as expected.

#### Review apps
Created for each PR. You can configure the hostnames to follow some format:

<img width="391" height="299" alt="Screenshot 2025-10-01 at 11 07 59" src="https://github.com/user-attachments/assets/969f924d-e40d-4ef7-b4b4-54c5f4886ef0" />

So either you let Heroku choose a random hostname (`govuk-chat-xxxxxx-xxxxx`) or use the PR number (`govuk-chat-pr-xxx.herokuapp.com`). 

To allow these apps to continue working, I've added a regex to the allowed hosts (`/govuk-chat-.*\.herokuapp\.com/`). 

In theory this could allow someone to create a Heroku app called `govuk-chat-bad` which will be given the hostname of `govuk-chat-bad.herokuapp.com` and then set the x-forwarded-host header to that hostname, but I'm not sure how else we can let review apps work, as the lab add-on from above can't be automatically enabled for review apps.

### GOV.UK Infrastructure
The first two values in the allowed hosts array should allow Chat running on GOV.UK infra to continue to work. The first regex covers the standard URLs:

* chat.integration.publishing.service.gov.uk
* chat.staging.publishing.service.gov.uk
* chat.publishing.service.gov.uk

And the second value of `gov.uk` will allow requests coming from Chat when it's on https://gov.uk/chat. Given we're not using this currently though, it's debatable as to whether we need it in here.

### Healthchecks
When I deployed to integration initially, the app wouldn't boot because of the healthcheck requests being made to an IP rather than the hostname. So I've added an exception to the allowed lists for any paths starting with "/healthcheck".

### Verification
Requests with an `x-forwarded-host` that doesn't match a value in the array result in a 401 being returned.

```
> curl -I 'https://chat.integration.publishing.service.gov.uk/admin' \
  -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'cache-control: max-age=0' \
  -b 'cookies_policy={"essential":true,"settings":false,"usage":false,"campaigns":false}; _govuk_chat_session=<cookie>' \
  -H 'x-forwarded-host: foo.com'

HTTP/2 403
date: Wed, 01 Oct 2025 10:00:53 GMT
```

```
curl -I 'https://chat.integration.publishing.service.gov.uk/admin' \
  -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'cache-control: max-age=0' \
  -b 'cookies_policy={"essential":true,"settings":false,"usage":false,"campaigns":false}; _govuk_chat_session=<cookie> \
  -H 'x-forwarded-host: chat.integration.publishing.service.gov.uk'

HTTP/2 200
date: Wed, 01 Oct 2025 10:01:19 GMT
```
