### PR TITLE
Fix pagination bugs on questions index page 

### DIFF
--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -69,11 +69,18 @@ private
     filters = {}
     filters[:status] = status if status.present?
     filters[:search] = search if search.present?
+    filters[:source] = source if source.present?
     filters[:start_date_params] = start_date_params if start_date_params.values.any?(&:present?)
     filters[:end_date_params] = end_date_params if end_date_params.values.any?(&:present?)
     filters[:sort] = sort if sort != self.class.default_sort
     filters[:answer_feedback_useful] = answer_feedback_useful unless answer_feedback_useful.nil?
     filters[:conversation_id] = conversation.id if conversation.present?
+    filters[:signon_user_id] = signon_user_id if signon_user_id.present?
+    filters[:end_user_id] = end_user_id if end_user_id.present?
+    filters[:question_routing_label] = question_routing_label if question_routing_label.present?
+    filters[:primary_topic] = primary_topic if primary_topic.present?
+    filters[:secondary_topic] = secondary_topic if secondary_topic.present?
+    filters[:completeness] = completeness if completeness.present?
 
     filters
   end
@@ -127,13 +134,13 @@ private
   def signon_user_scope(scope)
     return scope if signon_user_id.blank?
 
-    scope.joins(:conversation).where(conversation: { signon_user_id: signon_user_id })
+    scope.joins(:conversation).where("signon_user_id = ?", signon_user_id)
   end
 
   def end_user_id_scope(scope)
     return scope if end_user_id.blank?
 
-    scope.joins(:conversation).where(conversation: { end_user_id: end_user_id, source: :api })
+    scope.joins(:conversation).where("end_user_id = ? AND conversations.source = ?", end_user_id, "api")
   end
 
   def question_routing_label_scope(scope)

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -367,90 +367,69 @@ RSpec.describe Admin::Filters::QuestionsFilter do
 
   describe "#previous_page_params" do
     it "retains all other query params when constructing the params" do
-      signon_user = create(:signon_user)
-      conversation = create(:conversation, signon_user_id: signon_user.id, end_user_id: "end-user-id", source: :api)
-      26.times do
-        question = create(:question, conversation:)
-        answer = create(
-          :answer,
-          :with_feedback,
-          question:,
-          question_routing_label: "vague_acronym_grammar",
-          completeness: "complete",
-        )
-        create(:answer_analysis, answer:, primary_topic: "business", secondary_topic: "tax")
-      end
-      today = Date.current
-      start_date_params = { day: today.day, month: today.month, year: today.year - 1 }
-      end_date_params = { day: today.day, month: today.month, year: today.year + 1 }
+      filter = create_paginatable_filter({ page: 2 })
 
-      filter_params = {
-        status: "answered",
-        search: "message",
-        source: "api",
-        page: 2,
-        start_date_params:,
-        end_date_params:,
-        answer_feedback_useful: "true",
-        conversation_id: conversation.id,
-        signon_user_id: signon_user.id,
-        end_user_id: "end-user-id",
-        question_routing_label: "vague_acronym_grammar",
-        primary_topic: "business",
-        secondary_topic: "tax",
-        completeness: "complete",
-      }
-
-      filter = described_class.new(**filter_params)
-
-      expected_params = filter_params.except(:page, :answer_feedback_useful)
-                                     .merge(answer_feedback_useful: true)
+      expected_params = filter.attributes
+                              .symbolize_keys
+                              .except(:page, :answer_feedback_useful)
+                              .merge(answer_feedback_useful: true)
       expect(filter.previous_page_params).to eq(expected_params)
     end
   end
 
   describe "#next_page_params" do
     it "retains all other query params when constructing the params" do
-      signon_user = create(:signon_user)
-      conversation = create(:conversation, signon_user_id: signon_user.id, end_user_id: "end-user-id", source: :api)
-      26.times do
-        question = create(:question, conversation:)
-        answer = create(
-          :answer,
-          :with_feedback,
-          question:,
-          question_routing_label: "vague_acronym_grammar",
-          completeness: "complete",
-        )
-        create(:answer_analysis, answer:, primary_topic: "business", secondary_topic: "tax")
-      end
-
       today = Date.current
       start_date_params = { day: today.day, month: today.month, year: today.year - 1 }
       end_date_params = { day: today.day, month: today.month, year: today.year + 1 }
 
-      filter_params = {
-        status: "answered",
-        search: "message",
-        source: "api",
-        start_date_params:,
-        end_date_params:,
-        answer_feedback_useful: "true",
-        conversation_id: conversation.id,
-        signon_user_id: signon_user.id,
-        end_user_id: "end-user-id",
-        question_routing_label: "vague_acronym_grammar",
-        primary_topic: "business",
-        secondary_topic: "tax",
-        completeness: "complete",
-      }
+      filter = create_paginatable_filter({ start_date_params:, end_date_params: })
 
-      filter = described_class.new(**filter_params)
-      expected_params = filter_params.except(:answer_feedback_useful)
-                                     .merge(answer_feedback_useful: true, page: 2)
-
+      expected_params = filter.attributes
+                              .symbolize_keys
+                              .except(:answer_feedback_useful)
+                              .merge(answer_feedback_useful: true, page: 2)
       expect(filter.next_page_params).to eq(expected_params)
     end
+  end
+
+  def create_paginatable_filter(attrs = {})
+    signon_user = create(:signon_user)
+    conversation = create(:conversation, signon_user_id: signon_user.id, end_user_id: "end-user-id", source: :api)
+    26.times do
+      question = create(:question, conversation:)
+      answer = create(
+        :answer,
+        :with_feedback,
+        question:,
+        question_routing_label: "vague_acronym_grammar",
+        completeness: "complete",
+      )
+      create(:answer_analysis, answer:, primary_topic: "business", secondary_topic: "tax")
+    end
+
+    today = Date.current
+    start_date_params = { day: today.day, month: today.month, year: today.year - 1 }
+    end_date_params = { day: today.day, month: today.month, year: today.year + 1 }
+
+    filter_params = {
+      status: "answered",
+      search: "message",
+      sort: "created_at",
+      source: "api",
+      start_date_params:,
+      end_date_params:,
+      answer_feedback_useful: "true",
+      conversation_id: conversation.id,
+      signon_user_id: signon_user.id,
+      end_user_id: "end-user-id",
+      question_routing_label: "vague_acronym_grammar",
+      primary_topic: "business",
+      secondary_topic: "tax",
+      completeness: "complete",
+    }.merge(attrs)
+
+    described_class.new(**filter_params)
   end
 
   it_behaves_like "a sortable filter", "created_at"

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -367,71 +367,89 @@ RSpec.describe Admin::Filters::QuestionsFilter do
 
   describe "#previous_page_params" do
     it "retains all other query params when constructing the params" do
-      conversation = create(:conversation)
+      signon_user = create(:signon_user)
+      conversation = create(:conversation, signon_user_id: signon_user.id, end_user_id: "end-user-id", source: :api)
       26.times do
         question = create(:question, conversation:)
-        create(:answer, :with_feedback, question:)
+        answer = create(
+          :answer,
+          :with_feedback,
+          question:,
+          question_routing_label: "vague_acronym_grammar",
+          completeness: "complete",
+        )
+        create(:answer_analysis, answer:, primary_topic: "business", secondary_topic: "tax")
       end
       today = Date.current
       start_date_params = { day: today.day, month: today.month, year: today.year - 1 }
       end_date_params = { day: today.day, month: today.month, year: today.year + 1 }
 
-      filter = described_class.new(
+      filter_params = {
         status: "answered",
         search: "message",
+        source: "api",
         page: 2,
         start_date_params:,
         end_date_params:,
         answer_feedback_useful: "true",
         conversation_id: conversation.id,
-      )
+        signon_user_id: signon_user.id,
+        end_user_id: "end-user-id",
+        question_routing_label: "vague_acronym_grammar",
+        primary_topic: "business",
+        secondary_topic: "tax",
+        completeness: "complete",
+      }
 
-      expect(filter.previous_page_params)
-        .to eq(
-          {
-            status: "answered",
-            search: "message",
-            answer_feedback_useful: true,
-            start_date_params:,
-            end_date_params:,
-            conversation_id: conversation.id,
-          },
-        )
+      filter = described_class.new(**filter_params)
+
+      expected_params = filter_params.except(:page, :answer_feedback_useful)
+                                     .merge(answer_feedback_useful: true)
+      expect(filter.previous_page_params).to eq(expected_params)
     end
   end
 
   describe "#next_page_params" do
     it "retains all other query params when constructing the params" do
-      conversation = create(:conversation)
+      signon_user = create(:signon_user)
+      conversation = create(:conversation, signon_user_id: signon_user.id, end_user_id: "end-user-id", source: :api)
       26.times do
         question = create(:question, conversation:)
-        create(:answer, :with_feedback, question:)
+        answer = create(
+          :answer,
+          :with_feedback,
+          question:,
+          question_routing_label: "vague_acronym_grammar",
+          completeness: "complete",
+        )
+        create(:answer_analysis, answer:, primary_topic: "business", secondary_topic: "tax")
       end
+
       today = Date.current
       start_date_params = { day: today.day, month: today.month, year: today.year - 1 }
       end_date_params = { day: today.day, month: today.month, year: today.year + 1 }
 
-      filter = described_class.new(
+      filter_params = {
         status: "answered",
         search: "message",
+        source: "api",
         start_date_params:,
         end_date_params:,
         answer_feedback_useful: "true",
         conversation_id: conversation.id,
-      )
+        signon_user_id: signon_user.id,
+        end_user_id: "end-user-id",
+        question_routing_label: "vague_acronym_grammar",
+        primary_topic: "business",
+        secondary_topic: "tax",
+        completeness: "complete",
+      }
 
-      expect(filter.next_page_params)
-        .to eq(
-          {
-            status: "answered",
-            search: "message",
-            answer_feedback_useful: true,
-            page: 2,
-            start_date_params:,
-            end_date_params:,
-            conversation_id: conversation.id,
-          },
-        )
+      filter = described_class.new(**filter_params)
+      expected_params = filter_params.except(:answer_feedback_useful)
+                                     .merge(answer_feedback_useful: true, page: 2)
+
+      expect(filter.next_page_params).to eq(expected_params)
     end
   end
 


### PR DESCRIPTION
## Description 

When we added a bunch of new filters, we missed adding them to the pagination logic, which means that the query params aren't retained in the pagination links.

This adds them to the pagination_query_params method in the QuestionsFilter class.

I've also done a bit of work to pull out some shared creation logic to it's own method and updated the test to build the expected_params from the filter attrs.

Hopefully this way it'll mean that if any new filters are added via attrs and not added to the filter params logic, the filter param retention tests will fail.

## Trello card

https://trello.com/c/EH4JTpYO/2825-fix-admin-area-user-pagination-bug