### PR TITLE
Rescue from URI::InvalidComponentError in LinkTokenMapper

### DIFF
--- a/lib/answer_composition/link_token_mapper.rb
+++ b/lib/answer_composition/link_token_mapper.rb
@@ -25,7 +25,7 @@ module AnswerComposition
         else
           ensure_absolute_url(link)
         end
-      rescue URI::InvalidURIError
+      rescue URI::InvalidURIError, URI::InvalidComponentError
         link
       end
 

--- a/spec/lib/answer_composition/link_token_mapper_spec.rb
+++ b/spec/lib/answer_composition/link_token_mapper_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe AnswerComposition::LinkTokenMapper do
 
       expect(mapper.link_for_token(token)).to eq("#{Plek.website_root}/tax-returns")
     end
+
+    it "handles URIs with invalid components" do
+      mapper = described_class.new
+      token = mapper.map_link_to_token("mailto://user@example.com")
+      expect(mapper.link_for_token(token)).to eq("mailto://user@example.com")
+    end
   end
 
   describe "#replace_tokens_with_links" do


### PR DESCRIPTION
https://trello.com/c/EP78CpM7/2827

We had an issue recently where some GOV.UK content contained a malformed
mailto URI. This caused an exception to be raised in the
LinkTokenMapper.

We should rescue these exceptions just like we do for
`URI::InvalidURIError` and store the malformed URI in the mapper as it
is.

There's not much we can do for URLs that are incorrect in the GOV.UK
content itself. We could try to fix this specific issue - the link that
triggered this exception was "mailto://consular.uae@fco.gov.uk" - but we
run the risk of changing content that we're not the owners of. It's best
to just keep the content as it is.

Deployed to integration:

* [Before](https://chat.integration.publishing.service.gov.uk/admin/questions/94b063b6-a423-4ab7-b5fd-aa1851e1dd86) (exception raised)
* [After](https://chat.integration.publishing.service.gov.uk/admin/questions/d9e685cf-c393-4b1a-820b-91eebc01a097) (answered successfully)