### PR TITLE
Fix issues with daily activity Slack message

### DIFF
--- a/app/models/daily_api_activity_message.rb
+++ b/app/models/daily_api_activity_message.rb
@@ -10,7 +10,7 @@ class DailyApiActivityMessage
       status_config = Rails.configuration.answer_statuses[status]
       status_text = status_config&.label_and_description || status_config&.label
       url_text = "#{count} #{status_text}"
-      list_items << "* #{admin_url_markdown(url_text, status)}"
+      list_items << "- #{admin_url_slack_link(url_text, status)}"
     end
 
     <<~MSG.strip
@@ -36,7 +36,7 @@ private
     @total_count ||= statuses.values.sum
   end
 
-  def admin_url_markdown(text, status)
+  def admin_url_slack_link(text, status)
     start_date_params = {
       day: date.day,
       month: date.month,
@@ -56,6 +56,6 @@ private
       host: Plek.external_url_for(:chat),
     )
 
-    "[#{text}](#{url})"
+    "<#{url}|#{text}>"
   end
 end

--- a/app/models/daily_api_activity_message.rb
+++ b/app/models/daily_api_activity_message.rb
@@ -37,16 +37,21 @@ private
   end
 
   def admin_url_markdown(text, status)
-    date_params = {
+    start_date_params = {
       day: date.day,
       month: date.month,
       year: date.year,
     }
+    end_date_params = {
+      day: (date + 1).day,
+      month: (date + 1).month,
+      year: (date + 1).year,
+    }
 
     url = Rails.application.routes.url_helpers.admin_questions_url(
       source: :api,
-      start_date_params: date_params,
-      end_date_params: date_params,
+      start_date_params:,
+      end_date_params:,
       status:,
       host: Plek.external_url_for(:chat),
     )

--- a/spec/models/daily_api_activity_message_spec.rb
+++ b/spec/models/daily_api_activity_message_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DailyApiActivityMessage do
       expected_message = <<~MSG.strip
         Yesterday GOV.UK Chat API received 1 question:
 
-        * [1 Clarification - question routing requested more information](#{admin_url(:clarification)})
+        - <#{admin_url(:clarification)}|1 Clarification - question routing requested more information>
       MSG
 
       message = described_class.new(Date.yesterday).message
@@ -75,13 +75,14 @@ RSpec.describe DailyApiActivityMessage do
       expected_message = <<~MSG.strip
         Yesterday GOV.UK Chat API received 12 questions:
 
-        * [4 #{label_for_status(:error_non_specific)}](#{admin_url(:error_non_specific)})
-        * [3 #{label_for_status(:clarification)}](#{admin_url(:clarification)})
-        * [2 Answered](#{admin_url(:answered)})
-        * [2 #{label_for_status(:unanswerable_no_govuk_content)}](#{admin_url(:unanswerable_no_govuk_content)})
-        * [1 #{label_for_status(:guardrails_forbidden_terms)}](#{admin_url(:guardrails_forbidden_terms)})
+        - <#{admin_url(:error_non_specific)}|4 #{label_for_status(:error_non_specific)}>
+        - <#{admin_url(:clarification)}|3 #{label_for_status(:clarification)}>
+        - <#{admin_url(:answered)}|2 Answered>
+        - <#{admin_url(:unanswerable_no_govuk_content)}|2 #{label_for_status(:unanswerable_no_govuk_content)}>
+        - <#{admin_url(:guardrails_forbidden_terms)}|1 #{label_for_status(:guardrails_forbidden_terms)}>
       MSG
 
+      puts expected_message
       message = described_class.new(Date.yesterday).message
       expect(message).to eq(expected_message)
     end

--- a/spec/models/daily_api_activity_message_spec.rb
+++ b/spec/models/daily_api_activity_message_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe DailyApiActivityMessage do
     end
 
     def admin_url(status)
+      today = yesterday.to_date + 1
+
       url_params = {
         source: :api,
         start_date_params: { day: yesterday.day, month: yesterday.month, year: yesterday.year },
-        end_date_params: { day: yesterday.day, month: yesterday.month, year: yesterday.year },
+        end_date_params: { day: today.day, month: today.month, year: today.year },
         host: Plek.external_url_for(:chat),
       }
 
@@ -22,7 +24,7 @@ RSpec.describe DailyApiActivityMessage do
     end
 
     around do |example|
-      travel_to(Time.zone.local(2000, 1, 1, 13, 0, 0)) do
+      travel_to(Time.zone.local(2025, 1, 1, 13, 0, 0)) do
         example.run
       end
     end


### PR DESCRIPTION
This changes the end date used in parameters and the link and list syntax as per: https://docs.slack.dev/messaging/formatting-message-text/

More info in the commits.