### PR TITLE
[CHAT-472] Update rake tasks to not take a provider argument

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -18,12 +18,11 @@ namespace :evaluation do
   end
 
   desc "Produce the output of the jailbreak response for a user input"
-  task :generate_jailbreak_guardrail_response, %i[provider] => :environment do |_, args|
+  task generate_jailbreak_guardrail_response: :environment do
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
-    raise "Requires a provider" if args[:provider].blank?
 
     begin
-      response = Guardrails::JailbreakChecker.call(ENV["INPUT"], args[:provider].to_sym)
+      response = Guardrails::JailbreakChecker.call(ENV["INPUT"], :claude)
 
       puts({ success: response }.to_json)
     rescue Guardrails::JailbreakChecker::ResponseError => e
@@ -32,37 +31,25 @@ namespace :evaluation do
   end
 
   desc "Produce the output guardrails response for a user input"
-  task :generate_output_guardrail_response, %i[provider guardrail_type] => :environment do |_, args|
+  task :generate_output_guardrail_response, %i[guardrail_type] => :environment do |_, args|
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
-    raise "Requires a provider" if args[:provider].blank?
     raise "Requires a guardrail type" if args[:guardrail_type].blank?
 
-    response = Guardrails::MultipleChecker.call(ENV["INPUT"], args[:guardrail_type].to_sym, args[:provider].to_sym)
+    response = Guardrails::MultipleChecker.call(ENV["INPUT"], args[:guardrail_type].to_sym, :claude)
 
     puts(response.to_json)
   end
 
   desc "Produce the output of a RAG response for a user input"
-  task :generate_rag_structured_answer_response, %i[llm_provider] => :environment do |_, args|
+  task generate_rag_structured_answer_response: :environment do
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
-    raise "Requires an llm provider" if args[:llm_provider].blank?
 
     question = Question.new(message: ENV["INPUT"], conversation: Conversation.new)
 
-    answer = case args[:llm_provider]
-             when "openai"
-               AnswerComposition::PipelineRunner.call(question:, pipeline: [
-                 AnswerComposition::Pipeline::SearchResultFetcher,
-                 AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer,
-               ])
-             when "claude"
-               AnswerComposition::PipelineRunner.call(question:, pipeline: [
-                 AnswerComposition::Pipeline::SearchResultFetcher,
-                 AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
-               ])
-             else
-               raise "Unexpected llm provider #{args[:llm_provider]}"
-             end
+    answer = AnswerComposition::PipelineRunner.call(question:, pipeline: [
+      AnswerComposition::Pipeline::SearchResultFetcher,
+      AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
+    ])
 
     raise "Error occurred generating answer: #{answer.error_message}" if answer.status =~ /^error/
 
@@ -71,21 +58,11 @@ namespace :evaluation do
   end
 
   desc "Produce the output of question routing for a user input"
-  task :generate_question_routing_response, %i[provider] => :environment do |_, args|
+  task generate_question_routing_response: :environment do
     raise "Requires an INPUT env var" if ENV["INPUT"].blank?
-    raise "Requires a provider" if args[:provider].blank?
-
-    klass = case args[:provider]
-            when "openai"
-              AnswerComposition::Pipeline::OpenAI::QuestionRouter
-            when "claude"
-              AnswerComposition::Pipeline::Claude::QuestionRouter
-            else
-              raise "Unexpected provider #{args[:provider]}"
-            end
 
     question = Question.new(message: ENV["INPUT"], conversation: Conversation.new)
-    answer = AnswerComposition::PipelineRunner.call(question:, pipeline: [klass])
+    answer = AnswerComposition::PipelineRunner.call(question:, pipeline: [AnswerComposition::Pipeline::Claude::QuestionRouter])
 
     raise "Error occurred generating answer: #{answer.error_message}" if answer.status =~ /^error/
 

--- a/lib/tasks/guardrails.rake
+++ b/lib/tasks/guardrails.rake
@@ -1,19 +1,13 @@
 namespace "guardrails" do
   desc "Print prompts for a guardrail type"
-  task :print_prompts, %i[guardrail_type llm_provider] => :environment do |_, args|
+  task :print_prompts, %i[guardrail_type] => :environment do |_, args|
     guardrail_type = args[:guardrail_type].to_sym
     valid_guardrail_types = %i[answer_guardrails question_routing_guardrails]
     if guardrail_type.blank? || valid_guardrail_types.exclude?(guardrail_type)
       abort("Invalid guardrail type. Valid guardrail types are #{valid_guardrail_types.to_sentence}")
     end
 
-    llm_provider = (args[:llm_provider] || :openai).to_sym
-    valid_providers = %i[openai claude]
-    if valid_providers.exclude?(llm_provider)
-      abort("Invalid LLM provider. Valid providers are #{valid_providers.to_sentence}")
-    end
-
-    prompt = Guardrails::MultipleChecker.collated_prompts(guardrail_type, llm_provider)
+    prompt = Guardrails::MultipleChecker.collated_prompts(guardrail_type, :claude)
     puts prompt
   end
 end

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -1,27 +1,4 @@
 RSpec.describe "rake evaluation tasks" do
-  shared_examples "a task requiring input and provider" do
-    it "requires an INPUT env var" do
-      expect { Rake::Task[task_name].invoke("openai") }
-        .to raise_error("Requires an INPUT env var")
-    end
-
-    it "requires a provider" do
-      ClimateControl.modify(INPUT: input) do
-        expect { Rake::Task[task_name].invoke }
-          .to raise_error("Requires a provider")
-      end
-    end
-  end
-
-  shared_examples "a task requiring a known provider" do
-    it "raises an error when given an unknown provider" do
-      ClimateControl.modify(INPUT: input) do
-        expect { Rake::Task[task_name].invoke("super-duper-ai") }
-          .to raise_error("Unexpected provider super-duper-ai")
-      end
-    end
-  end
-
   shared_examples "a task requiring an input" do
     it "requires an INPUT env var" do
       expect { Rake::Task[task_name].invoke }
@@ -160,8 +137,7 @@ RSpec.describe "rake evaluation tasks" do
 
     before { Rake::Task[task_name].reenable }
 
-    it_behaves_like "a task requiring input and provider"
-    it_behaves_like "a task requiring a known provider"
+    it_behaves_like "a task requiring an input"
 
     context "when a successful check occurs" do
       it "outputs the response as JSON to stdout with a success key" do
@@ -172,11 +148,11 @@ RSpec.describe "rake evaluation tasks" do
             llm_prompt_tokens: 100,
             llm_completion_tokens: 100,
             llm_cached_tokens: 0,
-            model: Guardrails::OpenAI::JailbreakChecker::OPENAI_MODEL,
+            model: Guardrails::Claude::MultipleChecker.bedrock_model,
           )
-          allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :openai).and_return(result)
+          allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :claude).and_return(result)
           expected = { success: result }.to_json
-          expect { Rake::Task[task_name].invoke("openai") }
+          expect { Rake::Task[task_name].invoke }
             .to output("#{expected}\n").to_stdout
         end
       end
@@ -192,12 +168,12 @@ RSpec.describe "rake evaluation tasks" do
             llm_prompt_tokens: 100,
             llm_completion_tokens: 100,
             llm_cached_tokens: 0,
-            model: Guardrails::OpenAI::JailbreakChecker::OPENAI_MODEL,
+            model: Guardrails::Claude::MultipleChecker.bedrock_model,
           )
-          allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :openai).and_raise(error)
+          allow(Guardrails::JailbreakChecker).to receive(:call).with(input, :claude).and_raise(error)
 
           expected = { response_error: error }.to_json
-          expect { Rake::Task[task_name].invoke("openai") }
+          expect { Rake::Task[task_name].invoke }
             .to output("#{expected}\n").to_stdout
         end
       end
@@ -210,11 +186,11 @@ RSpec.describe "rake evaluation tasks" do
 
     before { Rake::Task[task_name].reenable }
 
-    it_behaves_like "a task requiring input and provider"
+    it_behaves_like "a task requiring an input"
 
     it "requires a guardrail type" do
       ClimateControl.modify(INPUT: input) do
-        expect { Rake::Task[task_name].invoke("openai") }
+        expect { Rake::Task[task_name].invoke }
           .to raise_error("Requires a guardrail type")
       end
     end
@@ -222,8 +198,8 @@ RSpec.describe "rake evaluation tasks" do
     it "outputs the response as JSON to stdout" do
       ClimateControl.modify(INPUT: input) do
         result = build(:guardrails_multiple_checker_result, :pass)
-        allow(Guardrails::MultipleChecker).to receive(:call).with(input, :answer_guardrails, :openai).and_return(result)
-        expect { Rake::Task[task_name].invoke("openai", "answer_guardrails") }
+        allow(Guardrails::MultipleChecker).to receive(:call).with(input, :answer_guardrails, :claude).and_return(result)
+        expect { Rake::Task[task_name].invoke("answer_guardrails") }
           .to output("#{result.to_json}\n").to_stdout
       end
     end
@@ -237,17 +213,20 @@ RSpec.describe "rake evaluation tasks" do
 
     it_behaves_like "a task requiring an input"
 
-    it "requires an llm_provider" do
+    it "calls the pipeline runner with the tasks to generate a structured answer" do
       ClimateControl.modify(INPUT: input) do
-        expect { Rake::Task[task_name].invoke }
-          .to raise_error("Requires an llm provider")
-      end
-    end
+        answer = build(:answer)
+        allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
 
-    it "raises if given an unknown llm provider" do
-      ClimateControl.modify(INPUT: input) do
-        expect { Rake::Task[task_name].invoke("super-ai") }
-          .to raise_error("Unexpected llm provider super-ai")
+        expect { Rake::Task[task_name].invoke }
+          .to output.to_stdout
+
+        expect(AnswerComposition::PipelineRunner)
+          .to have_received(:call)
+          .with(question: instance_of(Question), pipeline: [
+            AnswerComposition::Pipeline::SearchResultFetcher,
+            AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
+          ])
       end
     end
 
@@ -258,46 +237,8 @@ RSpec.describe "rake evaluation tasks" do
                               .merge("opensearch_index" => Search::ChunkedContentRepository.new.index)
                               .to_json
         allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-        expect { Rake::Task[task_name].invoke("openai") }
+        expect { Rake::Task[task_name].invoke }
           .to output("#{expected_json}\n").to_stdout
-      end
-    end
-
-    context "when provider is openai" do
-      it "calls the pipeline runner with the tasks to generate an OpenAI structured answer" do
-        ClimateControl.modify(INPUT: input) do
-          answer = build(:answer)
-          allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-
-          expect { Rake::Task[task_name].invoke("openai") }
-            .to output.to_stdout
-
-          expect(AnswerComposition::PipelineRunner)
-            .to have_received(:call)
-            .with(question: instance_of(Question), pipeline: [
-              AnswerComposition::Pipeline::SearchResultFetcher,
-              AnswerComposition::Pipeline::OpenAI::StructuredAnswerComposer,
-            ])
-        end
-      end
-    end
-
-    context "when provider is claude" do
-      it "calls the pipeline runner with the tasks to generate a Claude structured answer" do
-        ClimateControl.modify(INPUT: input) do
-          answer = build(:answer)
-          allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-
-          expect { Rake::Task[task_name].invoke("claude") }
-            .to output.to_stdout
-
-          expect(AnswerComposition::PipelineRunner)
-            .to have_received(:call)
-            .with(question: instance_of(Question), pipeline: [
-              AnswerComposition::Pipeline::SearchResultFetcher,
-              AnswerComposition::Pipeline::Claude::StructuredAnswerComposer,
-            ])
-        end
       end
     end
   end
@@ -308,8 +249,23 @@ RSpec.describe "rake evaluation tasks" do
 
     before { Rake::Task[task_name].reenable }
 
-    it_behaves_like "a task requiring input and provider"
-    it_behaves_like "a task requiring a known provider"
+    it_behaves_like "a task requiring an input"
+
+    it "calls the pipeline runner with the tasks to generate a question routing response" do
+      ClimateControl.modify(INPUT: input) do
+        answer = build(:answer)
+        allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
+
+        expect { Rake::Task[task_name].invoke }
+          .to output.to_stdout
+
+        expect(AnswerComposition::PipelineRunner)
+          .to have_received(:call)
+          .with(question: instance_of(Question), pipeline: [
+            AnswerComposition::Pipeline::Claude::QuestionRouter,
+          ])
+      end
+    end
 
     it "outputs the response as JSON to stdout" do
       ClimateControl.modify(INPUT: input) do
@@ -319,7 +275,7 @@ RSpec.describe "rake evaluation tasks" do
                        message: "Sorry, can you say that again?")
         answer_json = answer.serialize_for_evaluation.to_json
         allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-        expect { Rake::Task[task_name].invoke("openai") }
+        expect { Rake::Task[task_name].invoke }
           .to output("#{answer_json}\n").to_stdout
       end
     end
@@ -329,44 +285,8 @@ RSpec.describe "rake evaluation tasks" do
         error_message = "Oh no!"
         answer = build(:answer, status: :error_answer_service_error, error_message:)
         allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-        expect { Rake::Task[task_name].invoke("openai") }
+        expect { Rake::Task[task_name].invoke }
           .to raise_error("Error occurred generating answer: Oh no!")
-      end
-    end
-
-    context "when provider is openai" do
-      it "calls the pipeline runner with the tasks to generate an OpenAI question routing response" do
-        ClimateControl.modify(INPUT: input) do
-          answer = build(:answer)
-          allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-
-          expect { Rake::Task[task_name].invoke("openai") }
-            .to output.to_stdout
-
-          expect(AnswerComposition::PipelineRunner)
-            .to have_received(:call)
-            .with(question: instance_of(Question), pipeline: [
-              AnswerComposition::Pipeline::OpenAI::QuestionRouter,
-            ])
-        end
-      end
-    end
-
-    context "when provider is claude" do
-      it "calls the pipeline runner with the tasks to generate a Claude question routing response" do
-        ClimateControl.modify(INPUT: input) do
-          answer = build(:answer)
-          allow(AnswerComposition::PipelineRunner).to receive(:call).and_return(answer)
-
-          expect { Rake::Task[task_name].invoke("claude") }
-            .to output.to_stdout
-
-          expect(AnswerComposition::PipelineRunner)
-            .to have_received(:call)
-            .with(question: instance_of(Question), pipeline: [
-              AnswerComposition::Pipeline::Claude::QuestionRouter,
-            ])
-        end
       end
     end
   end

--- a/spec/lib/tasks/guardrails_spec.rb
+++ b/spec/lib/tasks/guardrails_spec.rb
@@ -13,22 +13,9 @@ RSpec.describe "rake guardrails tasks" do
         .and raise_error(SystemExit)
     end
 
-    it "aborts if an invalid llm_provider is provided" do
-      expect { Rake::Task[task_name].invoke("answer_guardrails", "invalid_provider") }
-        .to output(/Invalid LLM provider/).to_stderr
-        .and raise_error(SystemExit)
+    it "calls MultipleChecker.collated_prompts with the correct args and outputs to stdout" do
+      expect { Rake::Task[task_name].invoke("answer_guardrails") }.to output(/# System prompt/).to_stdout
+      expect(Guardrails::MultipleChecker).to have_received(:collated_prompts).with(:answer_guardrails, :claude)
     end
-
-    shared_examples "prints prompts" do |provider|
-      it "calls MultipleChecker.collated_prompts with the correct args and outputs to stdout" do
-        expect { Rake::Task[task_name].invoke("answer_guardrails", provider) }.to output(/# System prompt/).to_stdout
-        expected_provider = provider&.to_sym || :openai
-        expect(Guardrails::MultipleChecker).to have_received(:collated_prompts).with(:answer_guardrails, expected_provider)
-      end
-    end
-
-    it_behaves_like "prints prompts", nil # Test default OpenAI provider
-    it_behaves_like "prints prompts", "openai"
-    it_behaves_like "prints prompts", "claude"
   end
 end


### PR DESCRIPTION
## Description

This is one of many PRs that will remove our OpenAI integration. Since we're only going to be supporting Claude going forward we can remove the provider argument from the evaluation rake tasks and call the Claude pipeline directly.

I've also opened a [PR](https://github.com/alphagov/govuk-chat-evaluation/pull/278) on the evaluation repo which removes the provider configuration. That PR should be merged shortly after this one.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472