### PR TITLE
Update QuestionRephraser supported models

### DIFF
--- a/lib/answer_composition/pipeline/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/question_rephraser.rb
@@ -3,7 +3,7 @@ module AnswerComposition
     class QuestionRephraser
       Result = Data.define(:llm_response, :rephrased_question, :metrics)
 
-      SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5].freeze
+      SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_5].freeze
       DEFAULT_MODEL = :claude_sonnet_4_0
 
       def self.call(...) = new(...).call

--- a/lib/bedrock_models.rb
+++ b/lib/bedrock_models.rb
@@ -1,6 +1,7 @@
 module BedrockModels
   MODEL_IDS = {
     claude_sonnet_4_0: "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+    claude_sonnet_4_5: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
     claude_sonnet_4_6: "eu.anthropic.claude-sonnet-4-6",
     claude_haiku_4_5: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
     titan_embed_v2: "amazon.titan-embed-text-v2:0",

--- a/spec/lib/bedrock_models_spec.rb
+++ b/spec/lib/bedrock_models_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe BedrockModels do
     it "returns the expected foundation models without the 'eu.' prefix" do
       allow(described_class).to receive(:MODEL_IDS).and_return({
         claude_sonnet_4_0: "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+        claude_sonnet_4_5: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
         claude_sonnet_4_6: "eu.anthropic.claude-sonnet-4-6",
         claude_haiku_4_5: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
         titan_embed_v2: "amazon.titan-embed-text-v2:0",
@@ -74,6 +75,7 @@ RSpec.describe BedrockModels do
       expect(described_class.expected_foundation_models).to contain_exactly(
         "amazon.titan-embed-text-v2:0",
         "anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "anthropic.claude-sonnet-4-6",
         "anthropic.claude-haiku-4-5-20251001-v1:0",
         "openai.gpt-oss-120b-1:0",

--- a/spec/lib/healthcheck/bedrock_spec.rb
+++ b/spec/lib/healthcheck/bedrock_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Healthcheck::Bedrock do
 
       allow(BedrockModels).to receive(:MODEL_IDS).and_return({
         claude_sonnet_4_0: "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+        claude_sonnet_4_5: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
         claude_sonnet_4_6: "eu.anthropic.claude-sonnet-4-6",
         claude_haiku_4_5: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
         titan_embed_v2: "amazon.titan-embed-text-v2:0",
@@ -31,6 +32,10 @@ RSpec.describe Healthcheck::Bedrock do
             Aws::Bedrock::Types::FoundationModelSummary.new(
               model_id: "anthropic.claude-sonnet-4-20250514-v1:0",
               model_arn: "arn:claude-sonnet-4",
+            ),
+            Aws::Bedrock::Types::FoundationModelSummary.new(
+              model_id: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+              model_arn: "arn:claude-sonnet-4-5",
             ),
             Aws::Bedrock::Types::FoundationModelSummary.new(
               model_id: "anthropic.claude-sonnet-4-6",
@@ -68,10 +73,7 @@ RSpec.describe Healthcheck::Bedrock do
 
       it "sets the message attribute to show the name of the missing models" do
         healthcheck.status
-        expect(healthcheck.message).to eq(
-          "Bedrock model(s) not available: amazon.titan-embed-text-v2:0, anthropic.claude-haiku-4-5-20251001-v1:0, " \
-          "anthropic.claude-sonnet-4-20250514-v1:0, anthropic.claude-sonnet-4-6, openai.gpt-oss-120b-1:0",
-        )
+        expect(healthcheck.message).to match(/Bedrock model\(s\) not available:.*amazon\.titan-embed-text-v2:0/)
       end
     end
 

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -1,5 +1,6 @@
 module StubClaudeMessages
   CLAUDE_SONNET_4_0_ENDPOINT_REGEX = %r{https://bedrock-runtime\..*\.amazonaws\.com/model/.*anthropic\.claude-sonnet-4-20250514-v1:0.*?/invoke}
+  CLAUDE_SONNET_4_5_ENDPOINT_REGEX = %r{https://bedrock-runtime\..*\.amazonaws\.com/model/.*eu.anthropic.claude-sonnet-4-5-20250929-v1:0.*?/invoke}
   CLAUDE_SONNET_4_6_ENDPOINT_REGEX = %r{https://bedrock-runtime\..*\.amazonaws\.com/model/.*anthropic\.claude-sonnet-4-6.*?/invoke}
   CLAUDE_HAIKU_4_5_ENDPOINT_REGEX = %r{https://bedrock-runtime\..*\.amazonaws\.com/model/.*anthropic\.claude-haiku-4-5-20251001-v1:0.*?/invoke}
 
@@ -43,6 +44,8 @@ module StubClaudeMessages
     endpoint_regex = case bedrock_model
                      when :claude_sonnet_4_0
                        CLAUDE_SONNET_4_0_ENDPOINT_REGEX
+                     when :claude_sonnet_4_5
+                       CLAUDE_SONNET_4_5_ENDPOINT_REGEX
                      when :claude_sonnet_4_6
                        CLAUDE_SONNET_4_6_ENDPOINT_REGEX
                      when :claude_haiku_4_5


### PR DESCRIPTION
## Description

We're actually going to be using Sonnet 4.5, not Haiku 4.5 for the question rephraser.

The prompt for Sonnet 4.5 was added in this [PR](https://github.com/alphagov/govuk_chat_private/pull/106):

This adds Sonnet 4.5 to`BedrockModels` and updates the `QuestionRephraser::SUPPORTED_MODELS` to include Sonnet 4.5 instead of Haiku 4.5.