### PR TITLE
Use auto-evaluation topic tagger prompt config for question topics

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -90,11 +90,11 @@ module GovukChat
     config.answer_strategy = ENV.fetch("ANSWER_STRATEGY", "claude_structured_answer")
 
     config.question_topics = GovukChatPrivate.config
-                                             .llm_prompts.claude
+                                             .llm_prompts
+                                             .auto_evaluation
                                              .topic_tagger
-                                             .dig("tool_spec", "input_schema", "$defs", "govuk_topic_tags", "enum")
+                                             .dig("tool_spec", "function", "parameters", "properties", "primary_topic", "enum")
                                              .sort
-
     config.max_auto_evaluations_per_hour = 300
 
     config.titan_aws_region = ENV["TITAN_AWS_REGION"] || ENV.fetch("AWS_REGION", "eu-west-1")


### PR DESCRIPTION
This was still using the Claude topic tagger config. Alessia realised the prompts hadn't been deleted and that this was still reliant on them despite us switching to the GPT OSS 120b model for topic tagging.