### PR TITLE
[CHAT-472] Update Chat to use newer private repo prompt configuration

### DIFF
--- a/lib/answer_composition/pipeline/jailbreak_guardrails.rb
+++ b/lib/answer_composition/pipeline/jailbreak_guardrails.rb
@@ -64,7 +64,7 @@ module AnswerComposition
       end
 
       def guardrails_llm_prompts
-        AnswerComposition::Pipeline::Claude.prompt_config(:jailbreak_guardrails, model_name)
+        AnswerComposition::Pipeline::Prompts.config(:jailbreak_guardrails, model_name)
       end
 
       # TODO: Move the common prompts into the claude config and use one set of prompts here.

--- a/lib/answer_composition/pipeline/jailbreak_guardrails.rb
+++ b/lib/answer_composition/pipeline/jailbreak_guardrails.rb
@@ -67,17 +67,12 @@ module AnswerComposition
         AnswerComposition::Pipeline::Prompts.config(:jailbreak_guardrails, model_name)
       end
 
-      # TODO: Move the common prompts into the claude config and use one set of prompts here.
-      def common_guardrails_llm_prompts
-        Rails.configuration.govuk_chat_private.llm_prompts.common.jailbreak_guardrails
-      end
-
       def pass_value
-        common_guardrails_llm_prompts.fetch(:pass_value)
+        guardrails_llm_prompts.fetch(:pass_value)
       end
 
       def fail_value
-        common_guardrails_llm_prompts.fetch(:fail_value)
+        guardrails_llm_prompts.fetch(:fail_value)
       end
 
       def max_tokens

--- a/lib/answer_composition/pipeline/prompts.rb
+++ b/lib/answer_composition/pipeline/prompts.rb
@@ -1,6 +1,6 @@
-module AnswerComposition::Pipeline::Claude
-  def self.prompt_config(component_name, bedrock_model)
-    prompts = Rails.configuration.govuk_chat_private.llm_prompts.claude.fetch(component_name.to_sym) do
+module AnswerComposition::Pipeline::Prompts
+  def self.config(component_name, bedrock_model)
+    prompts = Rails.configuration.govuk_chat_private.llm_prompts.answer_composition.fetch(component_name.to_sym) do
       raise "No LLM prompts found for #{component_name}"
     end
 

--- a/lib/answer_composition/pipeline/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/question_rephraser.rb
@@ -68,7 +68,7 @@ module AnswerComposition
       end
 
       def config
-        Claude.prompt_config(:question_rephraser, model_name)
+        Prompts.config(:question_rephraser, model_name)
       end
 
       def inference_config

--- a/lib/answer_composition/pipeline/question_router.rb
+++ b/lib/answer_composition/pipeline/question_router.rb
@@ -113,7 +113,7 @@ module AnswerComposition::Pipeline
     end
 
     def prompt_config
-      Claude.prompt_config(:question_routing, model_name)
+      Prompts.config(:question_routing, model_name)
     end
 
     def tool_config

--- a/lib/answer_composition/pipeline/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/structured_answer_composer.rb
@@ -84,7 +84,7 @@ module AnswerComposition::Pipeline
     end
 
     def prompt_config
-      Claude.prompt_config(:structured_answer, model_name)
+      Prompts.config(:structured_answer, model_name)
     end
 
     def anthropic_bedrock_client

--- a/lib/chunking/content_item_parsing/travel_guide_parser.rb
+++ b/lib/chunking/content_item_parsing/travel_guide_parser.rb
@@ -68,7 +68,7 @@ module Chunking
         return nil if alert_status.empty?
 
         prefix = GovukChatPrivate.config.llm_prompts.dig(
-          :common, :chunking_parser_instructions, :travel_guide_parser
+          :chunking, :parser_instructions, :travel_guide_parser
         )
 
         "#{prefix} #{alert_status_warnings.join(' ')}"

--- a/lib/guardrails/multiple_checker.rb
+++ b/lib/guardrails/multiple_checker.rb
@@ -37,7 +37,7 @@ module Guardrails
 
       def initialize(prompt_name, llm_provider = :claude)
         prompts = if llm_provider == :claude
-                    AnswerComposition::Pipeline::Claude.prompt_config(prompt_name, Claude::MultipleChecker.bedrock_model)
+                    AnswerComposition::Pipeline::Prompts.config(prompt_name, Claude::MultipleChecker.bedrock_model)
                   else
                     Rails.configuration.govuk_chat_private.llm_prompts[llm_provider][prompt_name]
                   end

--- a/spec/config/question_routing_labels_spec.rb
+++ b/spec/config/question_routing_labels_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Question routing labels" do
     question_routing_prompt_configs = Rails.configuration
                                            .govuk_chat_private
                                            .llm_prompts
-                                           .claude
+                                           .answer_composition
                                            .question_routing
                                            .select { |key, _| key.in?(supported_models) }
                                            .values

--- a/spec/lib/answer_composition/pipeline/prompts_spec.rb
+++ b/spec/lib/answer_composition/pipeline/prompts_spec.rb
@@ -1,26 +1,26 @@
-RSpec.describe AnswerComposition::Pipeline::Claude do
-  describe ".prompt_config" do
+RSpec.describe AnswerComposition::Pipeline::Prompts do
+  describe ".config" do
     it "fetches the prompt configuration for the given component name and model" do
       config = {
         system_prompt: "The system prompt",
         user_prompt: "The user prompt ",
       }
-      allow(Rails.configuration.govuk_chat_private.llm_prompts.claude).to receive(:fetch).with(:test_prompt).and_return({ claude_sonnet_4_0: config })
+      allow(Rails.configuration.govuk_chat_private.llm_prompts.answer_composition).to receive(:fetch).with(:test_prompt).and_return({ claude_sonnet_4_0: config })
 
-      result = described_class.prompt_config(:test_prompt, :claude_sonnet_4_0)
+      result = described_class.config(:test_prompt, :claude_sonnet_4_0)
 
       expect(result).to eq(config)
     end
 
     it "raises an error if no prompt configuration is found for the given component name" do
-      expect { described_class.prompt_config(:non_existent_component, :claude_sonnet_4_0) }
+      expect { described_class.config(:non_existent_component, :claude_sonnet_4_0) }
         .to raise_error("No LLM prompts found for non_existent_component")
     end
 
     it "raises an error if no prompt configuration is found for the given model" do
-      allow(Rails.configuration.govuk_chat_private.llm_prompts.claude).to receive(:fetch).with(:test_prompt).and_return({ claude_sonnet_4_0: {} })
+      allow(Rails.configuration.govuk_chat_private.llm_prompts.answer_composition).to receive(:fetch).with(:test_prompt).and_return({ claude_sonnet_4_0: {} })
 
-      expect { described_class.prompt_config(:test_prompt, :non_existent_model) }
+      expect { described_class.config(:test_prompt, :non_existent_model) }
       .to raise_error("No LLM prompts found for the non_existent_model model in the test_prompt prompt configuration")
     end
   end

--- a/spec/lib/answer_composition/pipeline/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_router_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         )
       }
     end
-    before { allow(AnswerComposition::Pipeline::Claude).to receive(:prompt_config).and_call_original }
+    before { allow(AnswerComposition::Pipeline::Prompts).to receive(:config).and_call_original }
   end
 
   describe ".call" do
@@ -36,7 +36,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
 
     let(:tools) do
       properties = classification[:properties] || {}
-      confidence_property = AnswerComposition::Pipeline::Claude.prompt_config(
+      confidence_property = AnswerComposition::Pipeline::Prompts.config(
         :question_routing, model_name
       )[:confidence_property]
 
@@ -61,7 +61,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
     end
 
     before do
-      allow(AnswerComposition::Pipeline::Claude).to receive(:prompt_config).with(:question_routing, model_name).and_return(
+      allow(AnswerComposition::Pipeline::Prompts).to receive(:config).with(:question_routing, model_name).and_return(
         classifications: [classification],
         system_prompt: "The system prompt",
         confidence_property: {
@@ -244,7 +244,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
 
       let(:tools) do
         properties = classification[:properties] || {}
-        confidence_property = AnswerComposition::Pipeline::Claude.prompt_config(
+        confidence_property = AnswerComposition::Pipeline::Prompts.config(
           :question_routing, model_name
         )[:confidence_property]
 

--- a/spec/lib/chunking/content_item_parsing/travel_guide_parser_spec.rb
+++ b/spec/lib/chunking/content_item_parsing/travel_guide_parser_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Chunking::ContentItemParsing::TravelGuideParser do
         chunks = described_class.call(content_item)
 
         prefix = GovukChatPrivate.config.llm_prompts.dig(
-          :common, :chunking_parser_instructions, :travel_guide_parser
+          :chunking, :parser_instructions, :travel_guide_parser
         )
         instructions = "#{prefix} FCDO advises against all but essential travel to Thailand. FCDO advises against all travel to parts of Thailand."
 

--- a/spec/lib/guardrails/claude/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/claude/multiple_checker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Guardrails::Claude::MultipleChecker, :aws_credentials_stubbed do
   describe ".call" do
     context "when the request is successful" do
       let(:llm_prompt_name) { :answer_guardrails }
-      let(:guardrails_config) { Rails.configuration.govuk_chat_private.llm_prompts.claude }
+      let(:guardrails_config) { Rails.configuration.govuk_chat_private.llm_prompts.answer_composition }
       let(:guardrail_definitions) do
         {
           "costs" => "This is a costs guardrail",

--- a/spec/lib/guardrails/multiple_checker_spec.rb
+++ b/spec/lib/guardrails/multiple_checker_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Guardrails::MultipleChecker do
           },
         }.with_indifferent_access
 
-        allow(AnswerComposition::Pipeline::Claude).to receive(:prompt_config)
-                                                  .with(llm_prompt_name, Guardrails::Claude::MultipleChecker.bedrock_model)
-                                                  .and_return(guardrails_config)
+        allow(AnswerComposition::Pipeline::Prompts).to receive(:config)
+                                                   .with(llm_prompt_name, Guardrails::Claude::MultipleChecker.bedrock_model)
+                                                   .and_return(guardrails_config)
         allow(Guardrails::Claude::MultipleChecker).to receive(:call).and_return(guardrail_response_hash)
       end
 
@@ -108,9 +108,9 @@ RSpec.describe Guardrails::MultipleChecker do
 
     before do
       guardrails_config = { system_prompt:, user_prompt:, guardrails:, guardrail_definitions: }.with_indifferent_access
-      allow(AnswerComposition::Pipeline::Claude).to receive(:prompt_config)
-                                          .with(llm_prompt_name, Guardrails::Claude::MultipleChecker.bedrock_model)
-                                          .and_return(guardrails_config)
+      allow(AnswerComposition::Pipeline::Prompts).to receive(:config)
+                                                 .with(llm_prompt_name, Guardrails::Claude::MultipleChecker.bedrock_model)
+                                                 .and_return(guardrails_config)
     end
 
     context "when the llm_prompt_name is :answer_guardrails" do

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -122,7 +122,7 @@ module StubClaudeMessages
                  .llm_prompts
                  .claude[:structured_answer][model][:tool_spec]
 
-    allow(Rails.configuration.govuk_chat_private.llm_prompts.claude.structured_answer)
+    allow(Rails.configuration.govuk_chat_private.llm_prompts.answer_composition.structured_answer)
       .to receive(:fetch)
       .with(model)
       .and_return(

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -62,17 +62,23 @@ module StubClaudeMessages
   end
 
   def stub_claude_jailbreak_guardrails(input, response = "PassValue", chat_options: {})
-    llm_prompts_config = Rails.configuration.govuk_chat_private.llm_prompts
-    allow(llm_prompts_config.common).to receive(:jailbreak_guardrails)
-                                     .and_return(pass_value: "PassValue", fail_value: "FailValue")
+    jailbreak_guardrails_config = Rails.configuration
+                                       .govuk_chat_private
+                                       .llm_prompts
+                                       .answer_composition
+                                       .jailbreak_guardrails
 
     model = chat_options[:bedrock_model] || :claude_sonnet_4_0
-    jailbreak_guardrails_config = llm_prompts_config.claude.jailbreak_guardrails[model]
+    model_config = jailbreak_guardrails_config[model]
+
+    allow(model_config).to receive(:fetch).and_call_original
+    allow(model_config).to receive(:fetch).with(:pass_value).and_return("PassValue")
+    allow(model_config).to receive(:fetch).with(:fail_value).and_return("FailValue")
 
     stub_claude_messages_response(
       input,
       content: [claude_messages_text_block(response)],
-      chat_options: { max_tokens: jailbreak_guardrails_config.fetch(:max_tokens) }.merge(chat_options),
+      chat_options: { max_tokens: model_config.fetch(:max_tokens) }.merge(chat_options),
     )
   end
 


### PR DESCRIPTION
We've recently pulled out our OpenAI integration from Chat. This means we only have one provider available for answer composition.

I've duplicated the existing prompts to the answer_composition directory. I also merged the common prompt config into the relevant prompts. This PR:

- Updates the codebase to use the duplicated answer composition prompts.
- Renames the Claude module to Prompts to reflect that it now accesses the answer composition prompts.
- Updates code that previously used the common prompts to use the newer prompt config.

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472