### PR TITLE
[CHAT-472] Move missed prompt config to answer composition

### DIFF
--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Answer do
     question_routing_prompt_configs = Rails.configuration
                                            .govuk_chat_private
                                            .llm_prompts
-                                           .claude
+                                           .answer_composition
                                            .question_routing
                                            .select { |key, _| key.in?(claude_supported_models) }
                                            .values


### PR DESCRIPTION
## Description 

This was missed in the previous PR which ported the application over to using the new answer composition prompt config.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472