### PR TITLE
Update stub to use new prompt structure

### DIFF
--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -126,7 +126,7 @@ module StubClaudeMessages
     tools = Rails.configuration
                  .govuk_chat_private
                  .llm_prompts
-                 .claude[:structured_answer][model][:tool_spec]
+                 .answer_composition[:structured_answer][model][:tool_spec]
 
     allow(Rails.configuration.govuk_chat_private.llm_prompts.answer_composition.structured_answer)
       .to receive(:fetch)


### PR DESCRIPTION
This was missed as part of the port to using the answer composition prompts.