### PR TITLE
[CHAT-472] Remove unused question routing labels

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -100,13 +100,10 @@ class Answer < ApplicationRecord
          greetings: "greetings",
          harmful_vulgar_controversy: "harmful_vulgar_controversy",
          mental_health_crisis_signposting: "mental_health_crisis_signposting",
-         multi_questions: "multi_questions",
          negative_acknowledgement: "negative_acknowledgement",
          non_english: "non_english",
-         personal_info: "personal_info",
          positive_acknowledgement: "positive_acknowledgement",
          requires_account_data: "requires_account_data",
-         vague_acronym_grammar: "vague_acronym_grammar",
          unclear_intent: "unclear_intent",
        },
        prefix: true

--- a/config/question_routing_labels.yml
+++ b/config/question_routing_labels.yml
@@ -11,8 +11,8 @@ about_mps:
   answer_status: unanswerable_question_routing
   canned_responses:
     - |
-      Sorry, I cannot answer that question. You may be able to find your answer on [the UK Parliament website](https://www.parliament.uk/). 
-    
+      Sorry, I cannot answer that question. You may be able to find your answer on [the UK Parliament website](https://www.parliament.uk/).
+
       If you have questions that can be answered using GOV.UK guidance, I'd be happy to help.
 
 advice_opinions_predictions:
@@ -38,9 +38,9 @@ gov_transparency:
   use_answer: false
   answer_status: unanswerable_question_routing
   canned_responses:
-    - | 
+    - |
       Sorry, I cannot answer your question. You may be able to find the information by [searching on GOV.UK](https://www.gov.uk/).
-      
+
       If not, check [Freedom of Information (FOI) responses](https://www.gov.uk/search/transparency-and-freedom-of-information-releases?content_store_document_type=foi_release) to find out if your question has already been answered. You can also [make your own FOI request](https://www.gov.uk/make-a-freedom-of-information-request).
 
 greetings:
@@ -61,13 +61,6 @@ harmful_vulgar_controversy:
   canned_responses:
     - I can only provide information based on GOV.UK guidance, so I cannot answer that. If you have a different question, I’d be happy to help.
 
-multi_questions:
-  label: "Multi-questions"
-  use_answer: true
-  answer_status: clarification
-  canned_responses:
-    - "Sorry, I experienced a technical error while trying to answer your question. Please try again."
-
 negative_acknowledgement:
   label: "Negative acknowledgement"
   use_answer: false
@@ -86,13 +79,6 @@ non_english:
   canned_responses:
     - Sorry, I cannot answer that. Please translate your question into English and try again.
 
-personal_info:
-  label: "Personal information"
-  use_answer: false
-  answer_status: unanswerable_question_routing
-  canned_responses:
-    - I do not have access to any personal or confidential information. You can try searching for the [service you need on GOV.UK](https://www.gov.uk/search/services). Or ask me another question, if you need more help.
-
 requires_account_data:
   label: "Requires account data"
   use_answer: true
@@ -110,13 +96,6 @@ positive_acknowledgement:
     - If you’ve got more questions, I’m here to help.
     - If you’ve got any follow-up questions or would like to ask about something else, I’m happy to keep chatting.
     - Feel free to ask me another question.
-
-vague_acronym_grammar:
-  label: "Vague, acronym, grammar"
-  use_answer: true
-  answer_status: clarification
-  canned_responses:
-    - "Sorry, I experienced a technical error while trying to answer your question. Please try again."
 
 unclear_intent:
   label: "Unclear intent"

--- a/db/migrate/20260417081153_remove_legacy_question_routing_labels.rb
+++ b/db/migrate/20260417081153_remove_legacy_question_routing_labels.rb
@@ -1,0 +1,40 @@
+class RemoveLegacyQuestionRoutingLabels < ActiveRecord::Migration[8.1]
+  class Answer < ApplicationRecord; end
+  class AnswerAnalysisAnswerRelevancyRun < ApplicationRecord; end
+
+  def up
+    Question.joins(:answer)
+            .where(answer: { question_routing_label: %w[multi_questions personal_info vague_acronym_grammar] })
+            .delete_all
+
+    Conversation.where.missing(:questions).delete_all
+
+    execute <<-SQL
+    ALTER TYPE question_routing_label RENAME TO question_routing_label_old;
+
+    CREATE TYPE question_routing_label AS ENUM(
+                                          'about_chat',
+                                          'about_mps',
+                                          'advice_opinions_predictions',
+                                          'character_fun',
+                                          'genuine_rag',
+                                          'gov_transparency',
+                                          'greetings',
+                                          'harmful_vulgar_controversy',
+                                          'mental_health_crisis_signposting',
+                                          'negative_acknowledgement',
+                                          'non_english',
+                                          'positive_acknowledgement',
+                                          'requires_account_data',
+                                          'unclear_intent');
+
+    ALTER TABLE answers ALTER COLUMN question_routing_label TYPE question_routing_label USING question_routing_label::text::question_routing_label;
+
+    DROP TYPE question_routing_label_old;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_26_123210) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_081153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_123210) do
   create_enum "answer_status", ["answered", "clarification", "error_answer_guardrails", "error_answer_service_error", "error_jailbreak_guardrails", "error_non_specific", "error_question_routing_guardrails", "error_timeout", "guardrails_answer", "guardrails_forbidden_terms", "guardrails_jailbreak", "guardrails_question_routing", "unanswerable_llm_cannot_answer", "unanswerable_no_govuk_content", "unanswerable_question_routing"]
   create_enum "conversation_source", ["web", "api"]
   create_enum "guardrails_status", ["pass", "fail", "error"]
-  create_enum "question_routing_label", ["about_mps", "advice_opinions_predictions", "character_fun", "genuine_rag", "gov_transparency", "greetings", "harmful_vulgar_controversy", "multi_questions", "negative_acknowledgement", "non_english", "personal_info", "positive_acknowledgement", "vague_acronym_grammar", "unclear_intent", "requires_account_data", "about_chat", "mental_health_crisis_signposting"]
+  create_enum "question_routing_label", ["about_chat", "about_mps", "advice_opinions_predictions", "character_fun", "genuine_rag", "gov_transparency", "greetings", "harmful_vulgar_controversy", "mental_health_crisis_signposting", "negative_acknowledgement", "non_english", "positive_acknowledgement", "requires_account_data", "unclear_intent"]
 
   create_table "answer_analysis_answer_relevancy_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "answer_id", null: false

--- a/spec/lib/answer_composition/pipeline/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_router_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         stub_claude_question_routing(
           question.message,
           tools:,
-          tool_name: "vague_acronym_grammar",
+          tool_name: "unclear_intent",
           tool_input: classification_response,
           stop_reason: :max_tokens,
         )
@@ -192,7 +192,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
 
         allow(Answer::CannedResponses)
           .to receive(:response_for_question_routing_label)
-          .with("vague_acronym_grammar")
+          .with("unclear_intent")
           .and_return(canned_response)
 
         described_class.call(context)
@@ -200,7 +200,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         expect(context.answer).to have_attributes(
           message: canned_response,
           status: "clarification",
-          question_routing_label: "vague_acronym_grammar",
+          question_routing_label: "unclear_intent",
         )
       end
 
@@ -217,7 +217,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         stub_claude_question_routing(
           question.message,
           tools:,
-          tool_name: "multi_questions",
+          tool_name: "unclear_intent",
           tool_input: { "answer" => answer_message, "confidence" => 0.9 },
         )
       end
@@ -228,7 +228,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         expect(context.answer).to have_attributes(
           message: answer_message,
           status: "clarification",
-          question_routing_label: "multi_questions",
+          question_routing_label: "unclear_intent",
           question_routing_confidence_score: 0.9,
         )
       end

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
         :answer,
         :with_feedback,
         question:,
-        question_routing_label: "vague_acronym_grammar",
+        question_routing_label: Answer.question_routing_labels.keys.first,
         completeness: "complete",
       )
       create(:answer_analysis_topics, answer:, primary_topic: "business", secondary_topic: "tax")
@@ -432,7 +432,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       conversation_id: conversation.id,
       signon_user_id: signon_user.id,
       end_user_id: "end-user-id",
-      question_routing_label: "vague_acronym_grammar",
+      question_routing_label: Answer.question_routing_labels.keys.first,
       primary_topic: "business",
       secondary_topic: "tax",
       completeness: "complete",


### PR DESCRIPTION
## Description 

The `multi_questions`, `personal_info` and `vague_acronym_grammar` are legacy question routing labels that I believe were only used in our OpenAI integration. 

This PR:

- removes them from the `Answer.question_routing_label enum`
- removes them from the `question_routing_label.yml` config
- removes references to them in tests
- runs a migration to recreate the`question_routing_label` enum in the db

Regarding the migration. I've not worried about deleting old records because from memory these values haven't been used in our Claude answer strategy.

### How i confirmed they are unused by our Claude implementation

```
claude_supported_models = AnswerComposition::Pipeline::QuestionRouter::SUPPORTED_MODELS.map(&:to_s)
classifications = Rails.configuration
                         .govuk_chat_private
                         .llm_prompts
                         .answer_composition
                         .question_routing
                         .select { |key, _| key.in?(claude_supported_models) }
                         .values
                         .map { |config| config[:classifications].pluck(:name) }
                         .flatten
                         .uniq
=> ["about_mps",
 "character_fun",
 "gov_transparency",
 "greetings",
 "harmful_vulgar_controversy",
 "negative_acknowledgement",
 "non_english",
 "requires_account_data",
 "positive_acknowledgement",
 "advice_opinions_predictions",
 "genuine_rag",
 "unclear_intent",
 "about_chat",
 "mental_health_crisis_signposting"]

enum_values = Answer.question_routing_labels.values
=> ["about_chat",
 "about_mps",
 "advice_opinions_predictions",
 "character_fun",
 "genuine_rag",
 "gov_transparency",
 "greetings",
 "harmful_vulgar_controversy",
 "mental_health_crisis_signposting",
 "multi_questions",
 "negative_acknowledgement",
 "non_english",
 "personal_info",
 "positive_acknowledgement",
 "requires_account_data",
 "vague_acronym_grammar",
 "unclear_intent"]
enum_values - classifications
=> ["multi_questions", "personal_info", "vague_acronym_grammar"]

```

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-472