### PR TITLE
adding sonnet 4.5 as a supported question_router model

### DIFF
--- a/lib/answer_composition/pipeline/question_router.rb
+++ b/lib/answer_composition/pipeline/question_router.rb
@@ -1,6 +1,6 @@
 module AnswerComposition::Pipeline
   class QuestionRouter
-    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5 claude_sonnet_4_5].freeze
+    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_5].freeze
     DEFAULT_MODEL = :claude_sonnet_4_0
 
     def self.call(...) = new(...).call

--- a/lib/answer_composition/pipeline/question_router.rb
+++ b/lib/answer_composition/pipeline/question_router.rb
@@ -1,6 +1,6 @@
 module AnswerComposition::Pipeline
   class QuestionRouter
-    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5].freeze
+    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5 claude_sonnet_4_5].freeze
     DEFAULT_MODEL = :claude_sonnet_4_0
 
     def self.call(...) = new(...).call

--- a/spec/lib/answer_composition/pipeline/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_router_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
     end
 
     context "when using a model newer than Claude Sonnet 4" do
-      let(:model_name) { :claude_haiku_4_5 }
+      let(:model_name) { (described_class::SUPPORTED_MODELS - %i[claude_sonnet_4_0]).sample }
 
       let(:tools) do
         properties = classification[:properties] || {}


### PR DESCRIPTION
This adds Sonnet 4.5 to the supported models for the question_router.rb. 

This PR will be raised in tandem with adding Sonnet 4.5 to the govuk-chat-private repo where it refers directly to the config for Sonnet 4.0.