### PR TITLE
Switch default models for Guardrails to Haiku 4.5

### DIFF
--- a/lib/answer_composition/multiple_guardrail/checker.rb
+++ b/lib/answer_composition/multiple_guardrail/checker.rb
@@ -11,7 +11,7 @@ module AnswerComposition::MultipleGuardrail
 
     MAX_TOKENS = 100
     SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5].freeze
-    DEFAULT_MODEL = :claude_sonnet_4_0
+    DEFAULT_MODEL = :claude_haiku_4_5
 
     attr_reader :input, :llm_provider, :llm_prompt_name
 

--- a/lib/answer_composition/pipeline/jailbreak_guardrails.rb
+++ b/lib/answer_composition/pipeline/jailbreak_guardrails.rb
@@ -2,7 +2,7 @@ module AnswerComposition
   module Pipeline
     class JailbreakGuardrails
       SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_haiku_4_5].freeze
-      DEFAULT_MODEL = :claude_sonnet_4_0
+      DEFAULT_MODEL = :claude_haiku_4_5
 
       def self.call(...) = new(...).call
 

--- a/spec/lib/answer_composition/multiple_guardrail/checker_spec.rb
+++ b/spec/lib/answer_composition/multiple_guardrail/checker_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Checker, :aws_credentials_s
         expected_llm_response = claude_messages_response(
           content: [claude_messages_text_block('True | "1, 2"')],
           usage: { cache_read_input_tokens: 20 },
+          bedrock_model: described_class::DEFAULT_MODEL,
         ).to_h
         expect(result.llm_response).to eq(expected_llm_response)
       end
@@ -148,6 +149,7 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Checker, :aws_credentials_s
         expected_llm_response = claude_messages_response(
           content: [claude_messages_text_block(llm_guardrail_result)],
           usage: { cache_read_input_tokens: 20 },
+          bedrock_model: described_class::DEFAULT_MODEL,
         ).to_h
         expect { described_class.call(input, llm_prompt_name) }
           .to raise_error(
@@ -168,6 +170,7 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Checker, :aws_credentials_s
         expected_llm_response = claude_messages_response(
           content: [claude_messages_text_block(llm_guardrail_result)],
           usage: { cache_read_input_tokens: 20 },
+          bedrock_model: described_class::DEFAULT_MODEL,
         ).to_h
         expect { described_class.call(input, llm_prompt_name) }
           .to raise_error(

--- a/spec/lib/answer_composition/pipeline/jailbreak_guardrails_spec.rb
+++ b/spec/lib/answer_composition/pipeline/jailbreak_guardrails_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails, :aws_credential
 
       expected_llm_response = claude_messages_response(
         content: [claude_messages_text_block(pass_value)],
+        bedrock_model: described_class::DEFAULT_MODEL,
       ).to_h
       expect(context.answer.llm_responses["jailbreak_guardrails"]).to eq(expected_llm_response)
     end
@@ -83,6 +84,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails, :aws_credential
       expect { described_class.call(context) }.to throw_symbol(:abort)
       expected_llm_response = claude_messages_response(
         content: [claude_messages_text_block(fail_value)],
+        bedrock_model: described_class::DEFAULT_MODEL,
       ).to_h
       expect(context.answer.llm_responses["jailbreak_guardrails"]).to eq(expected_llm_response)
     end
@@ -122,6 +124,7 @@ RSpec.describe AnswerComposition::Pipeline::JailbreakGuardrails, :aws_credential
       expect { described_class.call(context) }.to throw_symbol(:abort)
       expected_llm_response = claude_messages_response(
         content: [claude_messages_text_block(response)],
+        bedrock_model: described_class::DEFAULT_MODEL,
       ).to_h
       expect(context.answer.llm_responses["jailbreak_guardrails"]).to eq(expected_llm_response)
     end

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -39,6 +39,7 @@ module StubClaudeMessages
       content:,
       usage:,
       stop_reason:,
+      bedrock_model:,
     )
 
     endpoint_regex = case bedrock_model
@@ -61,15 +62,14 @@ module StubClaudeMessages
       )
   end
 
-  def stub_claude_jailbreak_guardrails(input, response = "PassValue", chat_options: {})
+  def stub_claude_jailbreak_guardrails(input, response = "PassValue", chat_options: { bedrock_model: :claude_haiku_4_5 })
     jailbreak_guardrails_config = Rails.configuration
                                        .govuk_chat_private
                                        .llm_prompts
                                        .answer_composition
                                        .jailbreak_guardrails
 
-    model = chat_options[:bedrock_model] || :claude_sonnet_4_0
-    model_config = jailbreak_guardrails_config[model]
+    model_config = jailbreak_guardrails_config[chat_options[:bedrock_model]]
 
     allow(model_config).to receive(:fetch).and_call_original
     allow(model_config).to receive(:fetch).with(:pass_value).and_return("PassValue")
@@ -162,7 +162,9 @@ module StubClaudeMessages
     )
   end
 
-  def stub_claude_output_guardrails(to_check, response = "False | None", chat_options: {})
+  def stub_claude_output_guardrails(to_check,
+                                    response = "False | None",
+                                    chat_options: { bedrock_model: :claude_haiku_4_5 })
     system = array_including(a_hash_including("cache_control" => { "type" => "ephemeral" }))
 
     stub_claude_messages_response(
@@ -201,10 +203,10 @@ module StubClaudeMessages
     )
   end
 
-  def claude_messages_response(content:, usage: {}, stop_reason: :end_turn)
+  def claude_messages_response(content:, usage: {}, stop_reason: :end_turn, bedrock_model: :claude_sonnet_4_0)
     Anthropic::Models::Message.new(
       id: "msg-id",
-      model: BedrockModels.model_id(:claude_sonnet_4_0),
+      model: BedrockModels.model_id(bedrock_model),
       role: :assistant,
       content:,
       stop_reason:,


### PR DESCRIPTION
This flips the switch of which models we'll be using in the codebase for these guardrail tasks and represents the first stage in a multi-step journey to change the models.

Following the adoption of this model as the default we will later remove the Sonnet 4.0 configuration - once we're content we don't need to migrate back.

In order to get the tests passing, some changes were required to the `StubClaudeMessages` helpers. The `claude_messages_response` hardcoded the Sonnet 4.0 model in the response. I've updated the helper to allow an optional `bedrock_model` to be passed in and used to populate it instead.
