### PR TITLE
Switch the QuestionRouter default model to Sonnet 4.5

### DIFF
--- a/lib/answer_composition/pipeline/question_router.rb
+++ b/lib/answer_composition/pipeline/question_router.rb
@@ -1,7 +1,7 @@
 module AnswerComposition::Pipeline
   class QuestionRouter
     SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_5].freeze
-    DEFAULT_MODEL = :claude_sonnet_4_0
+    DEFAULT_MODEL = :claude_sonnet_4_5
 
     def self.call(...) = new(...).call
 

--- a/spec/lib/answer_composition/pipeline/question_router_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_router_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stubbed do
   let(:question) { build :question }
   let(:context) { build(:answer_pipeline_context, question:) }
-  let(:model_name) { :claude_sonnet_4_0 }
+  let(:model_name) { described_class::DEFAULT_MODEL }
 
   it_behaves_like "a claude answer composition component with a configurable model", "BEDROCK_CLAUDE_QUESTION_ROUTER_MODEL" do
     let(:pipeline_step) { described_class.new(context) }
@@ -44,6 +44,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         {
           name: "greetings",
           description: "A classification description",
+          strict: model_name != :claude_sonnet_4_0 ? true : nil,
           input_schema: {
             type: "object",
             properties: properties.merge({
@@ -52,7 +53,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
             required: %w[confidence] + properties.keys.map(&:to_s),
             additionalProperties: false,
           },
-        },
+        }.compact,
       ]
     end
 
@@ -61,15 +62,18 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
     end
 
     before do
-      allow(AnswerComposition::Pipeline::Prompts).to receive(:config).with(:question_routing, model_name).and_return(
-        classifications: [classification],
-        system_prompt: "The system prompt",
-        confidence_property: {
-          title: "Confidence",
-          type: "number",
-          description: "The confidence that you have correctly identified the user's request",
-        },
-      )
+      allow(AnswerComposition::Pipeline::Prompts)
+        .to receive(:config)
+        .with(:question_routing, model_name)
+        .and_return(
+          classifications: [classification],
+          system_prompt: "The system prompt",
+          confidence_property: {
+            title: "Confidence",
+            type: "number",
+            description: "The confidence that you have correctly identified the user's request",
+          },
+        )
     end
 
     it "calls Bedrock with with the right prompt and tool config" do
@@ -102,6 +106,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         content: [expected_content],
         usage: { cache_read_input_tokens: 20 },
         stop_reason: :tool_use,
+        bedrock_model: model_name,
       ).to_h
       expect(context.answer.llm_responses["question_routing"])
         .to match(expected_llm_response)
@@ -124,7 +129,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
         llm_prompt_tokens: 30,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
-        model: BedrockModels.model_id(:claude_sonnet_4_0),
+        model: BedrockModels.model_id(model_name),
       })
     end
 
@@ -266,6 +271,49 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRouter, :aws_credentials_stu
       end
 
       it "sets `strict: true` in the tool config" do
+        ClimateControl.modify(BEDROCK_CLAUDE_QUESTION_ROUTER_MODEL: model_name.to_s) do
+          request = stub_claude_question_routing(
+            question.message,
+            tools:,
+            tool_name: "greetings",
+            tool_input: classification_response,
+            chat_options: {
+              bedrock_model: model_name,
+            },
+          )
+
+          described_class.call(context)
+          expect(request).to have_been_made
+        end
+      end
+    end
+
+    context "when using Claude Sonnet 4" do
+      let(:model_name) { :claude_sonnet_4_0 }
+
+      let(:tools) do
+        properties = classification[:properties] || {}
+        confidence_property = AnswerComposition::Pipeline::Prompts.config(
+          :question_routing, model_name
+        )[:confidence_property]
+
+        [
+          {
+            name: "greetings",
+            description: "A classification description",
+            input_schema: {
+              type: "object",
+              properties: properties.merge({
+                confidence: confidence_property,
+              }),
+              required: %w[confidence] + properties.keys.map(&:to_s),
+              additionalProperties: false,
+            },
+          },
+        ]
+      end
+
+      it "doesn't set `strict: true` in the tool config" do
         ClimateControl.modify(BEDROCK_CLAUDE_QUESTION_ROUTER_MODEL: model_name.to_s) do
           request = stub_claude_question_routing(
             question.message,

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -95,7 +95,7 @@ module StubClaudeMessages
                                    tool_name: "genuine_rag",
                                    tool_input: { "answer": "This is RAG.", confidence: 1.0 },
                                    stop_reason: :tool_use,
-                                   chat_options: {})
+                                   chat_options: { bedrock_model: :claude_sonnet_4_5 })
     chat_options = {
       tools:,
       tool_choice: { type: "any", disable_parallel_tool_use: true },


### PR DESCRIPTION
**Do not merge until 27/04/2026**

## Description
 
This updates the QuestionRouter to set the default model to `:claude_sonnet_4_5` and updates the stubs to default to using `:claude_sonnet_4_5` as the bedrock model.

I've had to update the tests slightly to account for the fact that newer models are expected to have strict set to true for the tool call.

Also, i've added an explicit test that Sonnnet 4.0 doesn't set strict to true since the behaviour won't be covered post migration.

I've not worried about duplication or verbosity since we're stripping it out soon anyway.

## Migration plan 

https://gdsgovukagents.atlassian.net/wiki/spaces/GUC/pages/116293635/Staggered+Migration+Plan+for+LLM+Components+from+Sonnet+4+to+Haiku+4.5+and+Sonnet+4.5

## Jira ticket 

to be created.