### PR TITLE
[CHAT-558] Switch the QuestionRephraser default model to Sonnet 4.5

### DIFF
--- a/lib/answer_composition/pipeline/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/question_rephraser.rb
@@ -4,7 +4,7 @@ module AnswerComposition
       Result = Data.define(:llm_response, :rephrased_question, :metrics)
 
       SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_5].freeze
-      DEFAULT_MODEL = :claude_sonnet_4_0
+      DEFAULT_MODEL = :claude_sonnet_4_5
 
       def self.call(...) = new(...).call
 

--- a/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser, :aws_credentials_
           llm_prompt_tokens: 10,
           llm_completion_tokens: 20,
           llm_cached_tokens: nil,
-          model: BedrockModels.model_id(:claude_sonnet_4_0),
+          model: BedrockModels.model_id(described_class::DEFAULT_MODEL),
         })
     end
 
@@ -115,6 +115,7 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser, :aws_credentials_
       expected_llm_response = claude_messages_response(
         content: [claude_messages_text_block(rephrased)],
         usage: claude_messages_usage_block(input_tokens: 10, output_tokens: 20),
+        bedrock_model: described_class::DEFAULT_MODEL,
       ).to_h
 
       expect(context.answer.llm_responses["question_rephrasing"])

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -82,7 +82,9 @@ module StubClaudeMessages
     )
   end
 
-  def stub_claude_question_rephrasing(original_question, rephrased_question, chat_options: {})
+  def stub_claude_question_rephrasing(original_question,
+                                      rephrased_question,
+                                      chat_options: { bedrock_model: :claude_sonnet_4_5 })
     stub_claude_messages_response(
       array_including({ "role" => "user", "content" => a_string_including(original_question) }),
       content: [claude_messages_text_block(rephrased_question)],

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -62,7 +62,9 @@ module StubClaudeMessages
       )
   end
 
-  def stub_claude_jailbreak_guardrails(input, response = "PassValue", chat_options: { bedrock_model: :claude_haiku_4_5 })
+  def stub_claude_jailbreak_guardrails(input,
+                                       response = "PassValue",
+                                       chat_options: { bedrock_model: AnswerComposition::Pipeline::JailbreakGuardrails::DEFAULT_MODEL })
     jailbreak_guardrails_config = Rails.configuration
                                        .govuk_chat_private
                                        .llm_prompts
@@ -84,7 +86,7 @@ module StubClaudeMessages
 
   def stub_claude_question_rephrasing(original_question,
                                       rephrased_question,
-                                      chat_options: { bedrock_model: :claude_sonnet_4_5 })
+                                      chat_options: { bedrock_model: AnswerComposition::Pipeline::QuestionRephraser::DEFAULT_MODEL })
     stub_claude_messages_response(
       array_including({ "role" => "user", "content" => a_string_including(original_question) }),
       content: [claude_messages_text_block(rephrased_question)],
@@ -97,7 +99,7 @@ module StubClaudeMessages
                                    tool_name: "genuine_rag",
                                    tool_input: { "answer": "This is RAG.", confidence: 1.0 },
                                    stop_reason: :tool_use,
-                                   chat_options: { bedrock_model: :claude_sonnet_4_5 })
+                                   chat_options: { bedrock_model: AnswerComposition::Pipeline::QuestionRouter::DEFAULT_MODEL })
     chat_options = {
       tools:,
       tool_choice: { type: "any", disable_parallel_tool_use: true },
@@ -123,7 +125,7 @@ module StubClaudeMessages
                                     answer,
                                     sources_used: %w[link_1],
                                     answer_completeness: "complete",
-                                    chat_options: { bedrock_model: :claude_sonnet_4_5 })
+                                    chat_options: { bedrock_model: AnswerComposition::Pipeline::StructuredAnswerComposer::DEFAULT_MODEL })
     model = chat_options[:bedrock_model]
     tools = Rails.configuration
                  .govuk_chat_private
@@ -166,7 +168,7 @@ module StubClaudeMessages
 
   def stub_claude_output_guardrails(to_check,
                                     response = [].to_json,
-                                    chat_options: { bedrock_model: :claude_haiku_4_5 })
+                                    chat_options: { bedrock_model: AnswerComposition::MultipleGuardrail::Checker::DEFAULT_MODEL })
     system = array_including(a_hash_including("cache_control" => { "type" => "ephemeral" }))
 
     if chat_options[:bedrock_model] != :claude_sonnet_4_0


### PR DESCRIPTION
## Description

This updates the `QuestionRephraser` to set the default model to `:claude_sonnet_4_5` and updates the stubs to reflect this change.

## Migration plan 

https://gdsgovukagents.atlassian.net/wiki/spaces/GUC/pages/116293635/Staggered+Migration+Plan+for+LLM+Components+from+Sonnet+4+to+Haiku+4.5+and+Sonnet+4.5

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-558