### PR TITLE
[CHAT-557] Switch the StructuredAnswerComposer default model to Sonnet 4.5

### DIFF
--- a/lib/answer_composition/pipeline/structured_answer_composer.rb
+++ b/lib/answer_composition/pipeline/structured_answer_composer.rb
@@ -1,7 +1,7 @@
 module AnswerComposition::Pipeline
   class StructuredAnswerComposer
-    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_6].freeze
-    DEFAULT_MODEL = :claude_sonnet_4_0
+    SUPPORTED_MODELS = %i[claude_sonnet_4_0 claude_sonnet_4_5].freeze
+    DEFAULT_MODEL = :claude_sonnet_4_5
 
     def self.call(...) = new(...).call
 

--- a/spec/lib/answer_composition/pipeline/structured_answer_composer_spec.rb
+++ b/spec/lib/answer_composition/pipeline/structured_answer_composer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe AnswerComposition::Pipeline::StructuredAnswerComposer, :aws_crede
           llm_prompt_tokens: 30,
           llm_completion_tokens: 20,
           llm_cached_tokens: 20,
-          model: BedrockModels.model_id(:claude_sonnet_4_0),
+          model: BedrockModels.model_id(described_class::DEFAULT_MODEL),
         )
       end
 
@@ -88,6 +88,7 @@ RSpec.describe AnswerComposition::Pipeline::StructuredAnswerComposer, :aws_crede
             content: [expected_content],
             usage: { cache_read_input_tokens: 20 },
             stop_reason: :tool_use,
+            bedrock_model: described_class::DEFAULT_MODEL,
           ).to_h.stringify_keys,
           "link_token_mapping" => {
             "link_1" => "https://www.test.gov.uk/vat-rates#vat-basics",
@@ -140,6 +141,7 @@ RSpec.describe AnswerComposition::Pipeline::StructuredAnswerComposer, :aws_crede
           content: [expected_content],
           usage: { cache_read_input_tokens: 20 },
           stop_reason: :tool_use,
+          bedrock_model: described_class::DEFAULT_MODEL,
         ).to_h.stringify_keys,
         "link_token_mapping" => {
           "link_1" => "https://www.test.gov.uk/vat-rates#vat-basics",
@@ -160,7 +162,7 @@ RSpec.describe AnswerComposition::Pipeline::StructuredAnswerComposer, :aws_crede
         llm_prompt_tokens: 30,
         llm_completion_tokens: 20,
         llm_cached_tokens: 20,
-        model: BedrockModels.model_id(:claude_sonnet_4_0),
+        model: BedrockModels.model_id(described_class::DEFAULT_MODEL),
       )
     end
 

--- a/spec/support/stub_claude_messages.rb
+++ b/spec/support/stub_claude_messages.rb
@@ -121,8 +121,8 @@ module StubClaudeMessages
                                     answer,
                                     sources_used: %w[link_1],
                                     answer_completeness: "complete",
-                                    chat_options: {})
-    model = chat_options[:bedrock_model] || :claude_sonnet_4_0
+                                    chat_options: { bedrock_model: :claude_sonnet_4_5 })
+    model = chat_options[:bedrock_model]
     tools = Rails.configuration
                  .govuk_chat_private
                  .llm_prompts


### PR DESCRIPTION
## Description 

This updates the StructuredAnswerComposer to set the default model to `claude_sonnet_4_5` and updates the stubs to reflect this change.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-557
