### PR TITLE
Add cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,25 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - gds-sso
+        - govuk_*
+        - rubocop-govuk
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
 registries:
   github:
     type: git


### PR DESCRIPTION
The GOV.UK programme is now suggesting the use of dependabot cooldowns to help mitigate against supply chain attacks see: https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#configuring-dependabot-for-your-repository

This excludes the govuk dependencies so they can stay current.