### PR TITLE
[CHAT-473] Update guardrails structured response to use system prompt config

### DIFF
--- a/lib/answer_composition/multiple_guardrail/prompt.rb
+++ b/lib/answer_composition/multiple_guardrail/prompt.rb
@@ -16,13 +16,7 @@ module AnswerComposition::MultipleGuardrail
       guardrails_content = guardrails.map { |g| "#{g.key}. #{g.content}" }
                                      .join("\n")
 
-      system_prompt_key = if Checker.bedrock_model == :claude_sonnet_4_0
-                            :system_prompt
-                          else
-                            :system_prompt_structured
-                          end
-
-      prompts.fetch(system_prompt_key)
+      prompts.fetch(:system_prompt)
              .sub("{guardrails}", guardrails_content)
              .sub("{date}", Date.current.strftime("%A %d %B %Y"))
     end

--- a/spec/lib/answer_composition/multiple_guardrail/checker_spec.rb
+++ b/spec/lib/answer_composition/multiple_guardrail/checker_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Checker, :aws_credentials_s
     let(:guardrails_config) do
       {
         system_prompt: "{guardrails} {date}",
-        system_prompt_structured: "Structured system prompt: {guardrails} {date}",
         user_prompt: "{input}",
         guardrails:,
         guardrail_definitions:,

--- a/spec/lib/answer_composition/multiple_guardrail/prompt_spec.rb
+++ b/spec/lib/answer_composition/multiple_guardrail/prompt_spec.rb
@@ -11,16 +11,6 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Prompt do
       {guardrails}
     PROMPT
   end
-
-  let(:system_prompt_structured) do
-    <<~PROMPT
-      This is a structured system prompt and the date is {date}.:
-
-      The following guardrails must be followed:
-
-      {guardrails}
-    PROMPT
-  end
   let(:user_prompt) do
     <<~PROMPT
       This is the user prompt:
@@ -39,7 +29,6 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Prompt do
   let(:guardrails_config) do
     {
       system_prompt:,
-      system_prompt_structured:,
       user_prompt:,
       guardrails:,
       guardrail_definitions:,
@@ -57,38 +46,16 @@ RSpec.describe AnswerComposition::MultipleGuardrail::Prompt do
     end
 
     describe "#system_prompt" do
-      context "when the model is not claude_sonnet_4_0" do
-        it "returns the structured system prompt with guardrails and date interpolated" do
-          prompt = described_class.new(llm_prompt_name)
-          expected_guardrails_content = prompt.guardrails.map { |g| "#{g.key}. #{g.content}" }
-                                                        .join("\n")
+      it "returns the system prompt with guardrails and date interpolated" do
+        prompt = described_class.new(llm_prompt_name)
+        expected_guardrails_content = prompt.guardrails.map { |g| "#{g.key}. #{g.content}" }
+                                                      .join("\n")
 
-          expected_system_prompt = system_prompt_structured
-                                  .sub("{date}", formatted_date)
-                                  .sub("{guardrails}", expected_guardrails_content)
+        expected_system_prompt = system_prompt
+                                .sub("{date}", formatted_date)
+                                .sub("{guardrails}", expected_guardrails_content)
 
-          expect(prompt.system_prompt).to eq(expected_system_prompt)
-        end
-      end
-
-      context "when the model is claude_sonnet_4_0" do
-        let(:model) { :claude_sonnet_4_0 }
-
-        it "returns the system prompt with guardrails and date interpolated" do
-          allow(AnswerComposition::MultipleGuardrail::Checker)
-            .to receive(:bedrock_model)
-            .and_return(model)
-
-          prompt = described_class.new(llm_prompt_name)
-          expected_guardrails_content = prompt.guardrails.map { |g| "#{g.key}. #{g.content}" }
-                                                        .join("\n")
-
-          expected_system_prompt = system_prompt
-                                  .sub("{date}", formatted_date)
-                                  .sub("{guardrails}", expected_guardrails_content)
-
-          expect(prompt.system_prompt).to eq(expected_system_prompt)
-        end
+        expect(prompt.system_prompt).to eq(expected_system_prompt)
       end
     end
 


### PR DESCRIPTION
## Description

Previously, we had to have 2 separate prompts under different keys in order to support the unstructured and structured system prompts for the guardrails before porting to structured responses for guardrails.

We've now shipped this functionality and have merged a PR to remove the unstructured system prompt from the private repo[1].

As part of this PR I updated the system_prompt config key to have the strucutured system prompt as the default. This means that we can now remove logic around using the system_prompt_structured key.

A follow up PR will remove the unused system_prompt_structured key from the private repo config.

[1]: https://github.com/alphagov/govuk_chat_private/pull/124

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-473