### PR TITLE
Move mock answer stubbing to system helper & remove unused helpers

### DIFF
--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -10,12 +10,6 @@ module SystemSpecHelpers
       .and_return("claude_structured_answer")
   end
 
-  def given_i_am_using_the_openai_structured_answer_strategy
-    allow(Rails.configuration)
-      .to receive(:answer_strategy)
-      .and_return("openai_structured_answer")
-  end
-
   def given_i_have_dismissed_the_cookie_banner
     visit homepage_path
 
@@ -37,10 +31,6 @@ module SystemSpecHelpers
 
   def given_i_am_an_admin_with_the_settings_permission
     login_as(create(:signon_user, :admin_area_settings))
-  end
-
-  def ur_question_first_option_text(question_label)
-    Rails.configuration.pilot_user_research_questions.dig(question_label, :options, 0, :text)
   end
 
   def stubs_for_mock_answer(question,

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -42,4 +42,49 @@ module SystemSpecHelpers
   def ur_question_first_option_text(question_label)
     Rails.configuration.pilot_user_research_questions.dig(question_label, :options, 0, :text)
   end
+
+  def stubs_for_mock_answer(question,
+                            answer,
+                            rephrase_question: false,
+                            sources_used: [],
+                            create_content_chunk: true)
+    stub_claude_jailbreak_guardrails(question)
+
+    if rephrase_question
+      rephrased_question = "Rephrased #{question}"
+
+      stub_claude_question_rephrasing(question, rephrased_question)
+
+      question = rephrased_question
+    end
+
+    stub_bedrock_titan_embedding(question)
+
+    if create_content_chunk
+      populate_chunked_content_index([
+        build(:chunked_content_record, titan_embedding: mock_titan_embedding(question)),
+      ])
+    end
+
+    stub_claude_question_routing(question)
+    stub_claude_structured_answer(question, answer, sources_used:)
+
+    stub_claude_output_guardrails(answer)
+    stub_bedrock_invoke_model_openai_oss_topic_tagger(question)
+    stub_bedrock_invoke_model_openai_oss_answer_relevancy(
+      question_message: question,
+      answer_message: answer,
+    )
+    stub_bedrock_invoke_model_openai_oss_faithfulness(
+      retrieval_context: "Some content",
+      answer_message: answer,
+    )
+    stub_bedrock_invoke_model_openai_oss_coherence(
+      question_message: question,
+      answer_message: answer,
+    )
+    stub_bedrock_invoke_model_openai_oss_context_relevancy(
+      question_message: question,
+    )
+  end
 end

--- a/spec/system/conversation_js_features_spec.rb
+++ b/spec/system/conversation_js_features_spec.rb
@@ -234,51 +234,6 @@ RSpec.describe "Conversation JavaScript features", :aws_credentials_stubbed, :ch
     expect(page).to have_content("You have 10 characters too many")
   end
 
-  def stubs_for_mock_answer(question,
-                            answer,
-                            rephrase_question: false,
-                            sources_used: [],
-                            create_content_chunk: true)
-    stub_claude_jailbreak_guardrails(question)
-
-    if rephrase_question
-      rephrased_question = "Rephrased #{question}"
-
-      stub_claude_question_rephrasing(question, rephrased_question)
-
-      question = rephrased_question
-    end
-
-    stub_bedrock_titan_embedding(question)
-
-    if create_content_chunk
-      populate_chunked_content_index([
-        build(:chunked_content_record, titan_embedding: mock_titan_embedding(question)),
-      ])
-    end
-
-    stub_claude_question_routing(question)
-    stub_claude_structured_answer(question, answer, sources_used:)
-
-    stub_claude_output_guardrails(answer)
-    stub_bedrock_invoke_model_openai_oss_topic_tagger(question)
-    stub_bedrock_invoke_model_openai_oss_answer_relevancy(
-      question_message: question,
-      answer_message: answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_faithfulness(
-      retrieval_context: "Some content",
-      answer_message: answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_coherence(
-      question_message: question,
-      answer_message: answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_context_relevancy(
-      question_message: question,
-    )
-  end
-
   def then_i_cant_see_the_clear_chat_link
     within(".app-c-header") do
       # This is link is visually hidden but doesn't register as visible: :hidden

--- a/spec/system/conversation_with_claude_structured_answer_spec.rb
+++ b/spec/system/conversation_with_claude_structured_answer_spec.rb
@@ -35,37 +35,10 @@ RSpec.describe "Conversation with Claude with a structured answer", :aws_credent
   end
 
   def when_the_first_answer_is_generated
-    titan_embedding = mock_titan_embedding(@first_question)
-    allow(Search::TextToEmbedding)
-      .to receive(:call)
-      .and_return(titan_embedding)
-
-    populate_chunked_content_index([
-      build(:chunked_content_record, titan_embedding:, exact_path: "/pay-more-tax#yes-really"),
-    ])
-
-    @first_answer = "Lots of tax."
-
-    stub_claude_jailbreak_guardrails(@first_question)
-    stub_claude_question_routing(@first_question)
-    stub_claude_structured_answer(@first_question, @first_answer)
-    stub_claude_output_guardrails(@first_answer)
-    stub_bedrock_invoke_model_openai_oss_topic_tagger(@first_question)
-    stub_bedrock_invoke_model_openai_oss_answer_relevancy(
-      question_message: @first_question,
-      answer_message: @first_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_faithfulness(
-      retrieval_context: "Some content",
-      answer_message: @first_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_coherence(
-      question_message: @first_question,
-      answer_message: @first_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_context_relevancy(
-      question_message: @first_question,
-    )
+    @first_answer = "You can use a simple service on GOV.UK"
+    stubs_for_mock_answer(@first_question,
+                          @first_answer,
+                          sources_used: %w[link_1])
 
     execute_queued_sidekiq_jobs
   end
@@ -89,30 +62,13 @@ RSpec.describe "Conversation with Claude with a structured answer", :aws_credent
   end
 
   def when_the_second_answer_is_generated
-    rephrased_question = "Rephrased #{@second_question}"
     @second_answer = "Even more tax."
 
-    stub_claude_jailbreak_guardrails(@second_question)
-    stub_claude_question_rephrasing(@second_question, rephrased_question)
-    stub_claude_question_routing(rephrased_question)
-    stub_claude_structured_answer(rephrased_question, @second_answer)
-    stub_claude_output_guardrails(@second_answer)
-    stub_bedrock_invoke_model_openai_oss_topic_tagger(rephrased_question)
-    stub_bedrock_invoke_model_openai_oss_answer_relevancy(
-      question_message: rephrased_question,
-      answer_message: @second_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_faithfulness(
-      retrieval_context: "Some content",
-      answer_message: @second_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_coherence(
-      question_message: rephrased_question,
-      answer_message: @second_answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_context_relevancy(
-      question_message: rephrased_question,
-    )
+    stubs_for_mock_answer(@second_question,
+                          @second_answer,
+                          rephrase_question: true,
+                          sources_used: %w[link_1],
+                          create_content_chunk: false)
 
     execute_queued_sidekiq_jobs
   end

--- a/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
+++ b/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
@@ -34,37 +34,10 @@ RSpec.describe "Users interactions with chat are shown in admin area", :aws_cred
   end
 
   def and_the_answer_is_generated
-    titan_embedding = mock_titan_embedding(@question)
-    allow(Search::TextToEmbedding)
-      .to receive(:call)
-      .and_return(titan_embedding)
-
-    populate_chunked_content_index([
-      build(:chunked_content_record, titan_embedding:, exact_path: "/pay-more-tax#yes-really"),
-    ])
-
     @answer = "Maybe. You could get some benefits."
-
-    stub_claude_jailbreak_guardrails(@question)
-    stub_claude_question_routing(@question)
-    stub_claude_structured_answer(@question, @answer)
-    stub_claude_output_guardrails(@answer)
-    stub_bedrock_invoke_model_openai_oss_topic_tagger(@question)
-    stub_bedrock_invoke_model_openai_oss_answer_relevancy(
-      question_message: @question,
-      answer_message: @answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_faithfulness(
-      retrieval_context: "Some content",
-      answer_message: @answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_coherence(
-      question_message: @question,
-      answer_message: @answer,
-    )
-    stub_bedrock_invoke_model_openai_oss_context_relevancy(
-      question_message: @question,
-    )
+    stubs_for_mock_answer(@question,
+                          @answer,
+                          sources_used: %w[link_1])
 
     execute_queued_sidekiq_jobs
   end


### PR DESCRIPTION
## Description 

While spiking out rephrasing every question i noticed that there's some opportunities to move shared logic for stubbing mock answers into a helper.

Also we've got some unused helpers o i've removed those.

