### PR TITLE
Temporarily increase API rate limits

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -8,13 +8,13 @@ Rails.application.config.middleware.insert_before Rack::Attack, Api::AuthMiddlew
 class Rack::Attack
   CONVERSATION_API_PATH_REGEX = /^\/api\/v\d+\/conversation/
 
-  throttle(Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME, limit: 2_400, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME, limit: 10_800, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
       signon_uid(request)
     end
   end
 
-  throttle(Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME, limit: 200, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME, limit: 900, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
       signon_uid(request)
     end


### PR DESCRIPTION
## Description

We expect there to be a surge of users next week. We want to make sure that the API rate limits are not too restrictive and become a point of failure.

Based on our load testing document we have tested up to ~197 requests per second. If we do 4.5x bumps to the current limits we get:

10,800 rpm for read requests
900 rpm for write requests

Which is 195 requests per second (11,700 * 60 = 195).

Roch has confirmed that these limits are fine on our end. We're currently engaging AWS to up our model rate limits. Until that's done then we would hit model rate limits far before hitting this rate limit anyway.

DoW attacks were discussed etc. and SLT have signed this off too.

## Load testing document with thresholds

https://docs.google.com/document/d/1dsjxNSC9fv83YocebWYlAAq3MvdCuWdrrLwhn51AEgs/edit?tab=t.0

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269/backlog?selectedIssue=CHAT-607