### PR TITLE
[CHAT-538] Pass less information to logs for BedrockOpenAIOssInvoke retries

### DIFF
--- a/lib/auto_evaluation/bedrock_openai_oss_invoke.rb
+++ b/lib/auto_evaluation/bedrock_openai_oss_invoke.rb
@@ -35,7 +35,6 @@ module AutoEvaluation
       client = Aws::BedrockRuntime::Client.new
 
       attempts = 0
-      last_error = nil
 
       while attempts <= MAX_ATTEMPTS
         attempts += 1
@@ -70,23 +69,17 @@ module AutoEvaluation
             metrics: build_metrics(start_time, parsed_response),
           )
         rescue *RESCUABLE_ERRORS => e
-          error_string = "#{e.class}, #{e.message}"
           full_error_message = "LLM did not return valid JSON that conformed to the schema. " \
-                          "Attempt #{attempts}/#{MAX_ATTEMPTS}. Error: #{error_string}."
-
-          if last_error.present? && error_string != last_error
-            full_error_message += " This error is different from the previous error: #{last_error}."
-          end
+                               "Attempt #{attempts}/#{MAX_ATTEMPTS}."
 
           logger.warn(full_error_message)
 
           if attempts >= MAX_ATTEMPTS
             raise InvalidLlmResponseError, "LLM did not return valid JSON that conformed to the schema " \
-                                           "after #{MAX_ATTEMPTS} attempts. Error: #{error_string}"
+                                           "after #{MAX_ATTEMPTS} attempts. Error: #{e.class}, #{e.message}"
 
           end
 
-          last_error = error_string
           next
         end
       end

--- a/spec/lib/auto_evaluation/bedrock_openai_oss_invoke_spec.rb
+++ b/spec/lib/auto_evaluation/bedrock_openai_oss_invoke_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe AutoEvaluation::BedrockOpenAIOssInvoke, :aws_credentials_stubbed 
         allow(Rails).to receive(:logger).and_return(logger)
         (1..described_class::MAX_ATTEMPTS).each do |i|
           expected_log_message = "LLM did not return valid JSON that conformed to the schema. " \
-                                 "Attempt #{i}/#{described_class::MAX_ATTEMPTS}. " \
-                                 "Error: #{error_class}, #{error_message}"
+                                 "Attempt #{i}/#{described_class::MAX_ATTEMPTS}."
           expect(logger).to receive(:warn)
             .with(/#{expected_log_message}/)
             .ordered
@@ -53,48 +52,6 @@ RSpec.describe AutoEvaluation::BedrockOpenAIOssInvoke, :aws_credentials_stubbed 
 
         expect {
           described_class.call(user_message:, tool:)
-        }.to raise_error(described_class::InvalidLlmResponseError)
-      end
-
-      it "logs additional information when the error message (or class) changes between retries" do
-        logger = instance_double(Logger)
-        allow(Rails).to receive(:logger).and_return(logger)
-        allow(logger).to receive(:warn)
-
-        call_count = 0
-        original_response_body = stub.response.body
-
-        stub_request(:post, StubBedrock::OPENAI_GPT_OSS_ENDPOINT_REGEX).to_return do |_request|
-          call_count += 1
-          if call_count == 1
-            { status: 200, headers: { "Content-Type" => "application/json" }, body: original_response_body }
-          else
-            {
-              status: 200,
-              headers: { "Content-Type" => "application/json" },
-              body: {
-                choices: [{
-                  message: {
-                    tool_calls: [{ function: { arguments: "not_json" } }],
-                  },
-                  finish_reason: "stop",
-                }],
-                usage: { prompt_tokens: 10, completion_tokens: 10 },
-              }.to_json,
-            }
-          end
-        end
-
-        error = "#{error_class}, #{error_message}"
-        expect(logger).to receive(:warn)
-          .with(/#{error}/)
-          .ordered
-        expect(logger).to receive(:warn)
-          .with(/This error is different from the previous error: #{error}/)
-          .ordered
-
-        expect {
-          described_class.call(user_message: user_message, tool: tool)
         }.to raise_error(described_class::InvalidLlmResponseError)
       end
     end


### PR DESCRIPTION
## Decription 

We added some additional logging to test if our retry strategy was working. After some analysis we've decided we're happy with the current implementation because the it works the vasty majority of the time.

This removes some of the information we log during retries. I've retained a more detailed error message for the final exception that's raised after all retries have been exhausted, so we can still get the information we need for debugging from Sentry and our db records.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-538