### PR TITLE
[DO MOT MERGE] Revert "Temporarily increase API rate limits"

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -8,13 +8,13 @@ Rails.application.config.middleware.insert_before Rack::Attack, Api::AuthMiddlew
 class Rack::Attack
   CONVERSATION_API_PATH_REGEX = /^\/api\/v\d+\/conversation/
 
-  throttle(Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME, limit: 10_800, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME, limit: 2_400, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
       signon_uid(request)
     end
   end
 
-  throttle(Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME, limit: 900, period: 1.minute) do |request|
+  throttle(Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME, limit: 200, period: 1.minute) do |request|
     if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
       signon_uid(request)
     end


### PR DESCRIPTION
Reverts alphagov/govuk-chat#1093

## Description

We're no longer expecting a significant bump in users so we can revert this. Since we're expecting some increased traffic i'll keep an eye on it and increase it if we get anywhere near out rate limits.

We've not spiked above [1% of the current rate limit on grafana](https://grafana.eks.production.govuk.digital/d/govuk-chat-technical/gov-uk-chat-technical?orgId=1&from=now-2d&to=now&timezone=browser&refresh=15m) at the moment which would be 5% with these changes.