### PR TITLE
Update rate limit documentation

### DIFF
--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -20,7 +20,7 @@ info:
 
     | User type | Write request limit | Read request limit |
     |-----------|---------------------|--------------------|
-    | API User  | 200 RPM             | 2,400 RPM          |
+    | API User  | 900 RPM             | 10,800 RPM          |
     | End User  | 15 RPM              | 180 RPM            |
 
   version: "0.5.0"


### PR DESCRIPTION
This updates the rate limits to match what we have configured in: https://github.com/alphagov/govuk-chat/blob/main/config/initializers/rack_attack.rb

We did initially think we were going to revert the rate limit increases as a temporary thing https://github.com/alphagov/govuk-chat/pull/1093 however there is increased comfort at a leadership level with having more leeway with rate limits.