### PR TITLE
[CHAT-645] Ensure Faithfulness evaluation sends all retrieved sources in the correct format

### DIFF
--- a/lib/auto_evaluation/faithfulness.rb
+++ b/lib/auto_evaluation/faithfulness.rb
@@ -49,16 +49,12 @@ private
   end
 
   def retrieval_context
-    used_sources.map(&:plain_content).join("\n\n")
+    answer.sources.map(&:plain_content).join("\n\n")
   end
 
   def calculate_score(verdicts)
     faithful_count = verdicts.count { |verdict| verdict["verdict"].strip.downcase != "no" }
     faithful_count.to_d / verdicts.count
-  end
-
-  def used_sources
-    answer.sources.select(&:used)
   end
 
   def build_error_result(error_message)

--- a/lib/auto_evaluation/faithfulness.rb
+++ b/lib/auto_evaluation/faithfulness.rb
@@ -49,7 +49,7 @@ private
   end
 
   def retrieval_context
-    answer.sources.map(&:plain_content).join("\n\n")
+    answer.sources.map { |source| format_chunk_for_evaluation(source.chunk) }.join("\n")
   end
 
   def calculate_score(verdicts)
@@ -74,5 +74,14 @@ private
       llm_responses:,
       metrics:,
     )
+  end
+
+  def format_chunk_for_evaluation(chunk)
+    <<~STRING
+      #{chunk.title}
+      #{chunk.heading_hierarchy.join(' > ')}
+      #{chunk.description}
+      #{chunk.html_content}
+    STRING
   end
 end

--- a/spec/lib/auto_evaluation/faithfulness_spec.rb
+++ b/spec/lib/auto_evaluation/faithfulness_spec.rb
@@ -1,12 +1,14 @@
 RSpec.describe AutoEvaluation::Faithfulness, :aws_credentials_stubbed do
   describe ".call" do
     let(:answer_message) { "Einstein won the Nobel Prize in 1968 for the photoelectric effect." }
-    let(:retrieval_context) { "Einstein won the Nobel Prize in 1921 for the photoelectric effect." }
+    let(:used_chunk_conext) { "Einstein won the Nobel Prize in 1921 for the photoelectric effect." }
     let(:question) { build(:question, message: "When did Einstein win the Nobel Prize?") }
-    let(:chunk) { build(:answer_source_chunk, plain_content: retrieval_context) }
-    let(:used_source) { build(:answer_source, used: true, chunk:) }
-    let(:answer) { build(:answer, question:, message: answer_message, sources: [used_source]) }
-
+    let(:used_chunk) { build(:answer_source_chunk, plain_content: used_chunk_conext) }
+    let(:unused_chunk) { build(:answer_source_chunk, plain_content: "Some other context.") }
+    let(:used_source) { build(:answer_source, used: true, chunk: used_chunk) }
+    let(:unused_source) { build(:answer_source, used: false, chunk: unused_chunk) }
+    let(:answer) { build(:answer, question:, message: answer_message, sources: [used_source, unused_source]) }
+    let(:retrieval_context) { "#{used_chunk_conext}\n\n#{unused_chunk.plain_content}" }
     let(:truths) { ["Einstein won the Nobel Prize in 1921.", "Einstein won the Nobel Prize for the photoelectric effect."] }
     let(:claims) { ["Einstein won the Nobel Prize in 1968.", "Einstein won the Nobel Prize for the photoelectric effect."] }
     let(:verdicts) do

--- a/spec/lib/auto_evaluation/faithfulness_spec.rb
+++ b/spec/lib/auto_evaluation/faithfulness_spec.rb
@@ -8,7 +8,19 @@ RSpec.describe AutoEvaluation::Faithfulness, :aws_credentials_stubbed do
     let(:used_source) { build(:answer_source, used: true, chunk: used_chunk) }
     let(:unused_source) { build(:answer_source, used: false, chunk: unused_chunk) }
     let(:answer) { build(:answer, question:, message: answer_message, sources: [used_source, unused_source]) }
-    let(:retrieval_context) { "#{used_chunk_conext}\n\n#{unused_chunk.plain_content}" }
+    let(:retrieval_context) do
+      <<~STRING
+        #{used_chunk.title}
+        #{used_chunk.heading_hierarchy.join(' > ')}
+        #{used_chunk.description}
+        #{used_chunk.html_content}
+
+        #{unused_chunk.title}
+        #{unused_chunk.heading_hierarchy.join(' > ')}
+        #{unused_chunk.description}
+        #{unused_chunk.html_content}
+      STRING
+    end
     let(:truths) { ["Einstein won the Nobel Prize in 1921.", "Einstein won the Nobel Prize for the photoelectric effect."] }
     let(:claims) { ["Einstein won the Nobel Prize in 1968.", "Einstein won the Nobel Prize for the photoelectric effect."] }
     let(:verdicts) do

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -60,8 +60,16 @@ module SystemSpecHelpers
       question_message: question,
       answer_message: answer,
     )
+
+    retrieval_context = <<~STRING
+      Title
+      Heading 1 > Heading 2
+      Description
+      <p>Some content</p>
+    STRING
+
     stub_bedrock_invoke_model_openai_oss_faithfulness(
-      retrieval_context: "Some content",
+      retrieval_context: retrieval_context,
       answer_message: answer,
     )
     stub_bedrock_invoke_model_openai_oss_coherence(


### PR DESCRIPTION
## Description

There are a couple of issues Nick identified in our Faithfulness evaluation:

1. We're not sending all the chunks that we sent to the LLM to generate an answer. Currently, we're only sending the chunks from used sources.
2. We're not sending the chunks to the LLM in the correct format. We're using the `#plain_content` method. This strips out the html from the content, including the inline links.

I've updated the evaluation to send all the sources that we send to the structured answer comp llm call and updated the chunk content to [mirror the implementation in the evaluation repo](https://github.com/alphagov/govuk-chat-evaluation/blob/08894080765b0b4c21451adc3c13d3370359977c/govuk_chat_evaluation/rag_answers/data_models/input.py#L15-L22).

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-645