### PR TITLE
Revert "[CHAT-523] Always rephrase question for Sonnet 4.5"

### DIFF
--- a/lib/answer_composition/pipeline/question_rephraser.rb
+++ b/lib/answer_composition/pipeline/question_rephraser.rb
@@ -18,11 +18,11 @@ module AnswerComposition
       end
 
       def call
-        return if message_records.blank? && model_name == :claude_sonnet_4_0
+        return if message_records.blank?
 
         start_time = Clock.monotonic_time
         response = anthropic_bedrock_client.messages.create(
-          system: [{ type: "text", text: system_prompt }],
+          system: [{ type: "text", text: config[:system_prompt] }],
           model: model_id,
           messages:,
           **inference_config,
@@ -78,25 +78,10 @@ module AnswerComposition
         }
       end
 
-      def system_prompt
-        return config[:system_prompt] if model_name == :claude_sonnet_4_0
-
-        config[:system_prompt_always_rephrase]
-      end
-
       def user_prompt
-        if model_name == :claude_sonnet_4_0
-          return config[:user_prompt].sub("{question}", question_message)
-                                     .sub("{message_history}", message_history)
-
-        end
-
-        if message_records.present?
-          config[:user_prompt_with_history].sub("{question}", question_message)
-                                           .sub("{message_history}", message_history)
-        else
-          config[:user_prompt_without_history].sub("{question}", question_message)
-        end
+        config[:user_prompt]
+          .sub("{question}", question_message)
+          .sub("{message_history}", message_history)
       end
 
       def messages

--- a/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
+++ b/spec/lib/answer_composition/pipeline/question_rephraser_spec.rb
@@ -30,100 +30,96 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser, :aws_credentials_
     end
   end
 
-  it "includes the current question in the user prompt" do
-    described_class.call(context)
-    expect(stub).to have_been_requested
+  context "when the question is the beginning of the conversation" do
+    let(:context) { build(:answer_pipeline_context) }
+
+    it "returns nil" do
+      expect(described_class.call(context)).to be_nil
+    end
   end
 
-  it "includes the message_history in the user prompt" do
-    message_history = <<~HISTORY.strip
-      user:
-      """
-      How do I pay my tax
-      """
-      assistant:
-      """
-      What type of tax
-      """
-      user:
-      """
-      What types are there
-      """
-      assistant:
-      """
-      Self-assessment, PAYE, Corporation tax
-      """
-    HISTORY
+  context "when all other recent answers have statuses in Answer::STATUSES_EXCLUDED_FROM_REPHRASING" do
+    it "returns nil" do
+      conversation = create(:conversation)
+      create(:question, conversation:)
+      Answer::STATUSES_EXCLUDED_FROM_REPHRASING.sample(4) do |status|
+        question = create(:question, conversation:)
+        create(:answer, question:, status:)
+      end
+      latest_question = create(:question, conversation:)
+      context = build(:answer_pipeline_context, question: latest_question)
 
-    anthropic_request = stub_claude_question_rephrasing(
-      Regexp.new(message_history),
-      rephrased,
-    )
-
-    described_class.call(context)
-
-    expect(anthropic_request).to have_been_made
+      expect(described_class.call(context)).to be_nil
+    end
   end
 
-  it "updates the context's question_message with the rephrased question" do
-    described_class.call(context)
-    expect(context.question_message).to eq(rephrased)
-  end
-
-  it "assigns metrics to the answer" do
-    allow(Clock).to receive(:monotonic_time).and_return(100.0, 101.5)
-
-    described_class.call(context)
-
-    expect(context.answer.metrics["question_rephrasing"])
-      .to eq({
-        duration: 1.5,
-        llm_prompt_tokens: 10,
-        llm_completion_tokens: 20,
-        llm_cached_tokens: nil,
-        model: BedrockModels.model_id(described_class::DEFAULT_MODEL),
-      })
-  end
-
-  it "assigns the llm response to the answer" do
-    described_class.call(context)
-
-    expected_llm_response = claude_messages_response(
-      content: [claude_messages_text_block(rephrased)],
-      usage: claude_messages_usage_block(input_tokens: 10, output_tokens: 20),
-      bedrock_model: described_class::DEFAULT_MODEL,
-    ).to_h
-
-    expect(context.answer.llm_responses["question_rephrasing"])
-      .to eq(expected_llm_response)
-  end
-
-  context "when the question is the first in the conversation" do
-    let(:question) { create(:question) }
-    let(:context) { build(:answer_pipeline_context, question:) }
-    let!(:stub) { stub_claude_question_rephrasing(question.message, rephrased) }
-
-    it "calls the llm and rephrases the question" do
+  context "when the question is part of an ongoing chat" do
+    it "includes the current question in the user prompt" do
       described_class.call(context)
-
       expect(stub).to have_been_requested
-      expect(context.question_message).to eq(rephrased)
     end
 
-    it "uses the user_prompt_without_history prompt" do
-      expected_prompt = AnswerComposition::Pipeline::Prompts.config(
-        :question_rephraser, described_class::DEFAULT_MODEL
-      )[:user_prompt_without_history]
-      .sub("{question}", question.message)
+    it "includes the message_history in the user prompt" do
+      message_history = <<~HISTORY.strip
+        user:
+        """
+        How do I pay my tax
+        """
+        assistant:
+        """
+        What type of tax
+        """
+        user:
+        """
+        What types are there
+        """
+        assistant:
+        """
+        Self-assessment, PAYE, Corporation tax
+        """
+      HISTORY
 
       anthropic_request = stub_claude_question_rephrasing(
-        expected_prompt,
+        Regexp.new(message_history),
         rephrased,
       )
 
       described_class.call(context)
 
       expect(anthropic_request).to have_been_made
+    end
+
+    it "updates the context's question_message with the rephrased question" do
+      described_class.call(context)
+      expect(context.question_message).to eq(rephrased)
+    end
+
+    it "assigns metrics to the answer" do
+      allow(Clock).to receive(:monotonic_time).and_return(100.0, 101.5)
+
+      described_class.call(context)
+
+      expect(context.answer.metrics["question_rephrasing"])
+        .to eq({
+          duration: 1.5,
+          llm_prompt_tokens: 10,
+          llm_completion_tokens: 20,
+          llm_cached_tokens: nil,
+          model: BedrockModels.model_id(described_class::DEFAULT_MODEL),
+        })
+    end
+
+    it "assigns the llm response to the answer" do
+      described_class.call(context)
+
+      expected_llm_response = claude_messages_response(
+        content: [claude_messages_text_block(rephrased)],
+        usage: claude_messages_usage_block(input_tokens: 10, output_tokens: 20),
+        bedrock_model: described_class::DEFAULT_MODEL,
+      ).to_h
+
+      expect(context.answer.llm_responses["question_rephrasing"])
+        .to eq(expected_llm_response)
     end
   end
 
@@ -227,62 +223,6 @@ RSpec.describe AnswerComposition::Pipeline::QuestionRephraser, :aws_credentials_
       described_class.call(context)
 
       expect(anthropic_request).to have_been_made
-    end
-  end
-
-  context "when the model is claude_sonnet_4_0" do
-    let!(:stub) do
-      stub_claude_question_rephrasing(
-        question.message, rephrased, chat_options: { bedrock_model: :claude_sonnet_4_0 }
-      )
-    end
-
-    before { stub_const("#{described_class}::DEFAULT_MODEL", :claude_sonnet_4_0) }
-
-    it "uses the system prompt configured for claude_sonnet_4_0" do
-      allow(AnswerComposition::Pipeline::Prompts.config(:question_rephraser, :claude_sonnet_4_0))
-        .to receive(:[]).and_call_original
-
-      described_class.call(context)
-
-      expect(AnswerComposition::Pipeline::Prompts.config(:question_rephraser, :claude_sonnet_4_0))
-        .to have_received(:[]).with(:system_prompt)
-    end
-
-    it "calls the llm when there is message history" do
-      described_class.call(context)
-
-      expect(stub).to have_been_requested
-      expect(context.question_message).to eq(rephrased)
-    end
-
-    context "and all other recent answers have statuses in Answer::STATUSES_EXCLUDED_FROM_REPHRASING" do
-      it "returns nil" do
-        conversation = create(:conversation)
-        create(:question, conversation:)
-        Answer::STATUSES_EXCLUDED_FROM_REPHRASING.sample(4) do |status|
-          question = create(:question, conversation:)
-          create(:answer, question:, status:)
-        end
-        latest_question = create(:question, conversation:)
-        context = build(:answer_pipeline_context, question: latest_question)
-
-        expect(described_class.call(context)).to be_nil
-        expect(stub).not_to have_been_requested
-      end
-    end
-
-    context "and there is no message history" do
-      let(:conversation) { create(:conversation) }
-      let(:question) { create(:question, conversation:) }
-      let(:context) { build(:answer_pipeline_context, question:) }
-
-      it "returns nil" do
-        result = described_class.call(context)
-
-        expect(stub).not_to have_been_requested
-        expect(result).to be_nil
-      end
     end
   end
 end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -35,13 +35,18 @@ module SystemSpecHelpers
 
   def stubs_for_mock_answer(question,
                             answer,
+                            rephrase_question: false,
                             sources_used: [],
                             create_content_chunk: true)
     stub_claude_jailbreak_guardrails(question)
-    rephrased_question = "Rephrased #{question}"
-    stub_claude_question_rephrasing(question, rephrased_question)
 
-    question = rephrased_question
+    if rephrase_question
+      rephrased_question = "Rephrased #{question}"
+
+      stub_claude_question_rephrasing(question, rephrased_question)
+
+      question = rephrased_question
+    end
 
     stub_bedrock_titan_embedding(question)
 

--- a/spec/system/conversation_js_features_spec.rb
+++ b/spec/system/conversation_js_features_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe "Conversation JavaScript features", :aws_credentials_stubbed, :ch
 
     stubs_for_mock_answer(@second_question,
                           @second_answer,
+                          rephrase_question: true,
                           sources_used: %w[link_1],
                           create_content_chunk: false)
 

--- a/spec/system/conversation_with_claude_structured_answer_spec.rb
+++ b/spec/system/conversation_with_claude_structured_answer_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Conversation with Claude with a structured answer", :aws_credent
 
     stubs_for_mock_answer(@second_question,
                           @second_answer,
+                          rephrase_question: true,
                           sources_used: %w[link_1],
                           create_content_chunk: false)
 


### PR DESCRIPTION
Reverts alphagov/govuk-chat#1079

We're reverting this because we have experienced a number of reasoning leaks where additional context is added to the rephrase that wasn't provided by the user.