### PR TITLE
[CHAT-705] Update faithfulness to penalise idk verdicts

### DIFF
--- a/lib/auto_evaluation/faithfulness.rb
+++ b/lib/auto_evaluation/faithfulness.rb
@@ -24,7 +24,7 @@ class AutoEvaluation::Faithfulness
 
     return build_error_result("No verdicts were generated for the extracted claims.") if verdicts.empty?
 
-    if verdicts.none? { |verdict| verdict["verdict"].strip.downcase == "no" }
+    if verdicts.all? { |verdict| verdict["verdict"].strip.downcase == "yes" }
       return build_result_with_score(1.0, "The response is fully supported by the retrieval context.")
     end
 
@@ -53,7 +53,7 @@ private
   end
 
   def calculate_score(verdicts)
-    faithful_count = verdicts.count { |verdict| verdict["verdict"].strip.downcase != "no" }
+    faithful_count = verdicts.count { |verdict| verdict["verdict"].strip.downcase == "yes" }
     faithful_count.to_d / verdicts.count
   end
 

--- a/lib/auto_evaluation/faithfulness/reason_generator.rb
+++ b/lib/auto_evaluation/faithfulness/reason_generator.rb
@@ -24,19 +24,23 @@ module AutoEvaluation
 
     def user_message
       sprintf(
-        llm_prompts.fetch(:user_prompt),
+        llm_prompts.fetch(:new_user_prompt),
         score:,
-        contradictions:,
+        unfaithful_claims:,
       )
     end
 
     def tool
-      llm_prompts.fetch(:tool_spec)
+      llm_prompts.fetch(:new_tool_spec)
     end
 
-    def contradictions
-      verdicts.select { |verdict| verdict["verdict"].strip.downcase == "no" }
-              .map { |verdict| verdict["reason"] }
+    def unfaithful_claims
+      verdicts.filter_map do |verdict|
+        status = verdict["verdict"].strip.downcase
+        next if status == "yes"
+
+        status == "idk" ? "(Ambiguous) #{verdict['reason']}" : "(Contradiction) #{verdict['reason']}"
+      end
     end
   end
 end

--- a/spec/lib/auto_evaluation/faithfulness/reason_generator_spec.rb
+++ b/spec/lib/auto_evaluation/faithfulness/reason_generator_spec.rb
@@ -1,26 +1,31 @@
 RSpec.describe AutoEvaluation::Faithfulness::ReasonGenerator, :aws_credentials_stubbed do
   describe ".call" do
-    let(:score) { 0.5 }
+    let(:score) { 0.0 }
     let(:verdicts) do
       [
         { "verdict" => "no", "reason" => "The retrieval context states Einstein won in 1921, not 1968." },
-        { "verdict" => "yes" },
+        { "verdict" => "idk", "reason" => "The retrieval context does not explicitly confirm or deny that Einstein won the Nobel Prize for the photoelectric effect." },
       ]
     end
-    let(:contradictions) { ["The retrieval context states Einstein won in 1921, not 1968."] }
-    let(:reason) { "The score is 0.5 because the answer incorrectly stated the year Einstein won the Nobel Prize." }
+    let(:unfaithful_claims) do
+      [
+        "(Contradiction) #{verdicts.first['reason']}",
+        "(Ambiguous) #{verdicts.second['reason']}",
+      ]
+    end
+    let(:reason) { "The score is 0.0 because the answer incorrectly stated the year Einstein won the Nobel Prize." }
     let(:reason_json) do
       { reason: }.to_json
     end
     let(:prompts) { AutoEvaluation::Prompts.config.faithfulness.fetch(:reason) }
     let(:user_prompt) do
       sprintf(
-        prompts.fetch(:user_prompt),
+        prompts.fetch(:new_user_prompt),
         score:,
-        contradictions:,
+        unfaithful_claims:,
       )
     end
-    let(:tool) { prompts.fetch(:tool_spec) }
+    let(:tool) { prompts.fetch(:new_tool_spec) }
     let!(:stub_bedrock) do
       stub_bedrock_invoke_model_openai_oss_tool_call(
         user_prompt,

--- a/spec/lib/auto_evaluation/faithfulness_spec.rb
+++ b/spec/lib/auto_evaluation/faithfulness_spec.rb
@@ -86,15 +86,15 @@ RSpec.describe AutoEvaluation::Faithfulness, :aws_credentials_stubbed do
         )
     end
 
-    context "when 'idk' verdicts are present alongside 'no' verdicts" do
+    context "when 'idk' verdicts are present" do
       let(:verdicts) do
         [
+          { verdict: "yes", reason: "Einstein won the Nobel Prize for the photoelectric effect." },
           { verdict: "idk", reason: "Cannot determine if correct." },
-          { verdict: "no", reason: "The retrieval context states Einstein won in 1921, not 1968." },
         ]
       end
 
-      it "treats 'idk' verdicts as faithful (not contradictions)" do
+      it "treats 'idk' verdicts as unfaithful (contradictions)" do
         result = described_class.call(answer)
 
         expect(result.score).to eq(0.5)
@@ -143,8 +143,8 @@ RSpec.describe AutoEvaluation::Faithfulness, :aws_credentials_stubbed do
       end
     end
 
-    context "when all verdicts are faithful (no 'no' verdicts)" do
-      let(:verdicts) { [{ verdict: "yes" }, { verdict: "idk" }] }
+    context "when all verdicts are faithful (no 'no' or 'idk' verdicts)" do
+      let(:verdicts) { [{ verdict: "yes" }, { verdict: "yes" }] }
 
       it "returns a result object with with score 1.0 and skips reason LLM call" do
         allow(Clock).to receive(:monotonic_time).and_return(200.0, 202.0, 204.0, 206.0, 208.0, 210.0)

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -201,16 +201,20 @@ module StubBedrock
 
     faithful_count = verdicts.count { |v| v[:verdict].strip.downcase == "yes" }
     score = (faithful_count.to_d / verdicts.count).round(2).to_f
-    contradictions = verdicts.select { |v| v[:verdict].strip.downcase == "no" }
-                             .map { |v| v[:reason] }
+    unfaithful_claims = verdicts.filter_map do |verdict|
+      status = verdict[:verdict].strip.downcase
+      next if status == "yes"
+
+      status == "idk" ? "(Ambiguous) #{verdict[:reason]}" : "(Contradiction) #{verdict[:reason]}"
+    end
 
     reason_user_prompt = sprintf(
-      prompts.fetch(:reason).fetch(:user_prompt),
+      prompts.fetch(:reason).fetch(:new_user_prompt),
       score:,
-      contradictions:,
+      unfaithful_claims:,
     )
 
-    reason_tool = prompts.fetch(:reason).fetch(:tool_spec)
+    reason_tool = prompts.fetch(:reason).fetch(:new_tool_spec)
 
     stubs[:reason] = stub_bedrock_invoke_model_openai_oss_tool_call(
       reason_user_prompt,

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -199,7 +199,7 @@ module StubBedrock
     )
     return stubs if verdicts.empty?
 
-    faithful_count = verdicts.count { |v| v[:verdict].strip.downcase != "no" }
+    faithful_count = verdicts.count { |v| v[:verdict].strip.downcase == "yes" }
     score = (faithful_count.to_d / verdicts.count).round(2).to_f
     contradictions = verdicts.select { |v| v[:verdict].strip.downcase == "no" }
                              .map { |v| v[:reason] }


### PR DESCRIPTION
## Description 

We want to update update the faithfulness metric to deviate from the current implementation of treating 'idk' verdicts as faithful and instead treat them as 'no' values during score calculation.

As part of this the reasoning prompt has been slightly tweaked to indicate that ambiguous and contradictions are being passed with the score for analysis. This was merged [here](https://github.com/alphagov/govuk_chat_private/pull/136).

A couple of follow up PRs will be opened to clean up the old prompt after this is merged.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev%2Cbackend_dev&selectedIssue=CHAT-705