### PR TITLE
[CHAT-705] Use original faithfulness reason prompt keys

### DIFF
--- a/lib/auto_evaluation/faithfulness/reason_generator.rb
+++ b/lib/auto_evaluation/faithfulness/reason_generator.rb
@@ -24,14 +24,14 @@ module AutoEvaluation
 
     def user_message
       sprintf(
-        llm_prompts.fetch(:new_user_prompt),
+        llm_prompts.fetch(:user_prompt),
         score:,
         unfaithful_claims:,
       )
     end
 
     def tool
-      llm_prompts.fetch(:new_tool_spec)
+      llm_prompts.fetch(:tool_spec)
     end
 
     def unfaithful_claims

--- a/spec/lib/auto_evaluation/faithfulness/reason_generator_spec.rb
+++ b/spec/lib/auto_evaluation/faithfulness/reason_generator_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe AutoEvaluation::Faithfulness::ReasonGenerator, :aws_credentials_s
     let(:prompts) { AutoEvaluation::Prompts.config.faithfulness.fetch(:reason) }
     let(:user_prompt) do
       sprintf(
-        prompts.fetch(:new_user_prompt),
+        prompts.fetch(:user_prompt),
         score:,
         unfaithful_claims:,
       )
     end
-    let(:tool) { prompts.fetch(:new_tool_spec) }
+    let(:tool) { prompts.fetch(:tool_spec) }
     let!(:stub_bedrock) do
       stub_bedrock_invoke_model_openai_oss_tool_call(
         user_prompt,

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -209,12 +209,12 @@ module StubBedrock
     end
 
     reason_user_prompt = sprintf(
-      prompts.fetch(:reason).fetch(:new_user_prompt),
+      prompts.fetch(:reason).fetch(:user_prompt),
       score:,
       unfaithful_claims:,
     )
 
-    reason_tool = prompts.fetch(:reason).fetch(:new_tool_spec)
+    reason_tool = prompts.fetch(:reason).fetch(:tool_spec)
 
     stubs[:reason] = stub_bedrock_invoke_model_openai_oss_tool_call(
       reason_user_prompt,


### PR DESCRIPTION
## Description

We've updated the original prompt keys to use the new prompt in the private repo:
https://github.com/alphagov/govuk_chat_private/pull/137

So we can revert this component to use the original prompt keys. The final step will be to remove the new prompt keys from the private repo.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev%2Cbackend_dev&selectedIssue=CHAT-705