### PR TITLE
Remove legacy config attributes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,8 +61,6 @@ module GovukChat
       answer_timeout_in_seconds: 120,
       max_question_age_days: 90,
       max_question_count: 500,
-      max_questions_per_user: 70,
-      question_warning_threshold: 20,
       api_questions_per_page: 50,
     )
 


### PR DESCRIPTION
These config variables no longer have any usage since we removed the early access users functionality.

This was flagged by an LLM security scan as unenforced restrictions. These are unenforced because they are no longer relevant.