### PR TITLE
Add QuestionRephraser to RAG answer generator task

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -58,6 +58,7 @@ namespace :evaluation do
     question = Question.new(message: ENV["INPUT"], conversation: Conversation.new)
 
     answer = AnswerComposition::PipelineRunner.call(question:, pipeline: [
+      AnswerComposition::Pipeline::QuestionRephraser,
       AnswerComposition::Pipeline::SearchResultFetcher,
       AnswerComposition::Pipeline::StructuredAnswerComposer,
     ])

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe "rake evaluation tasks" do
         expect(AnswerComposition::PipelineRunner)
           .to have_received(:call)
           .with(question: instance_of(Question), pipeline: [
+            AnswerComposition::Pipeline::QuestionRephraser,
             AnswerComposition::Pipeline::SearchResultFetcher,
             AnswerComposition::Pipeline::StructuredAnswerComposer,
           ])


### PR DESCRIPTION
Previously the question rephraser only ran when a conversation had multiple messages, making it unnecessary for testing RAG. Now however we use it to rephrase even the first question in a conversation, therefore in order to test a RAG answer correctly we need to include it.