### PR TITLE
Add rake task to output document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ To test against the frozen OpenSearch instance, see the [govuk-chat-opensearch](
 - [Message queue consumption](docs/message-queue-consumption.md)
 - [Populating search](docs/populating-search.md)
 - [Guardrails](docs/guardrails.md)
+- [Which GOV.UK Content is used in the Chat Search Index?](docs/govuk-content-in-search.md)
 
 ## Licence
 

--- a/docs/govuk-content-in-search.md
+++ b/docs/govuk-content-in-search.md
@@ -1,0 +1,20 @@
+# Which GOV.UK Content is used in Chat Search?
+
+The configuration for which GOV.UK Content is indexed in GOV.UK Chat Search
+index is in [config/search.yml](../config/search.yml).
+
+To present a list of just the document types used we have a rake task:
+
+```
+rake search:print_document_types
+```
+
+which will output just a list of the document types, which is useful for
+stakeholders who struggle with schemas.
+
+This task can be passed an argument of ANNOTATED=true to output annotations
+further config details while still anchoring the list around document types.
+
+```
+rake search:print_document_types ANNOTATED=true
+```

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -93,4 +93,46 @@ namespace :search do
 
     puts "#{count} chunks deleted"
   end
+
+  desc "Print a list of document types that are indexed, use ANNOTATED=true for further details"
+  task print_document_types: :environment do
+    document_types_by_schema = Rails.application.config.search.document_types_by_schema
+    document_type_data = document_types_by_schema.inject([]) do |memo, (schema_name, schema_rules)|
+      memo += schema_rules["document_types"].flat_map do |(document_type, document_type_rules)|
+        document_type_weighting = document_type_rules && document_type_rules[:weight]
+        if document_type_rules && document_type_rules["requires_parent_document_type"]
+          document_type_rules["requires_parent_document_type"].map do |parent_name, parent_rules|
+            weighting = parent_rules && parent_rules[:weight] ? parent_rules[:weight] : document_type_weighting
+            { document_type:, schema_name:, requires_parent_document_type: parent_name, weighting: }
+          end
+        else
+          [{ document_type:, schema_name:, weighting: document_type_weighting }]
+        end
+      end
+
+      next memo
+    end
+
+    if ENV["ANNOTATED"] == "true"
+      puts "Document types (annotated) indexed by GOV.UK Chat:"
+      annotated = document_type_data.map do |rules|
+        annotation = "schema name: #{rules[:schema_name]}"
+
+        if rules[:requires_parent_document_type]
+          annotation += ", required parent document_type: #{rules[:requires_parent_document_type]}"
+        end
+
+        if rules[:weighting]
+          annotation += ", weighting: #{rules[:weighting]}"
+        end
+
+        "- #{rules[:document_type]} (#{annotation})"
+      end
+
+      puts annotated.sort.join("\n")
+    else
+      puts "Document types indexed by GOV.UK Chat:"
+      puts document_type_data.map { "- #{it[:document_type]}" }.uniq.sort.join("\n")
+    end
+  end
 end

--- a/spec/lib/tasks/search_spec.rb
+++ b/spec/lib/tasks/search_spec.rb
@@ -155,4 +155,62 @@ RSpec.describe "rake search tasks" do
         .to output("15 chunks deleted\n").to_stdout
     end
   end
+
+  describe "search:print_document_types" do
+    let(:task_name) { "search:print_document_types" }
+
+    before do
+      Rake::Task[task_name].reenable
+
+      document_types_by_schema = Hashie::Mash.new(
+        "schema_b" => {
+          "document_types" => {
+            "type_c" => {
+              "requires_parent_document_type" => {
+                "parent_a" => { "weight" => 1.1 },
+                "parent_b" => nil,
+              },
+            },
+          },
+        },
+        "schema_a" => {
+          "document_types" => {
+            "type_a" => { "weight" => 2.0 },
+            "type_b" => nil,
+          },
+        },
+      )
+
+      allow(Rails.application.config.search).to receive(:document_types_by_schema)
+        .and_return(document_types_by_schema)
+    end
+
+    it "prints a unique, sorted list of document types when ANNOTATED is not 'true'" do
+      expected = <<~OUTPUT
+        Document types indexed by GOV.UK Chat:
+        - type_a
+        - type_b
+        - type_c
+      OUTPUT
+
+      ClimateControl.modify(ANNOTATED: nil) do
+        expect { Rake::Task[task_name].invoke }
+          .to output(expected).to_stdout
+      end
+    end
+
+    it "prints an annotated, sorted list of document types when ANNOTATED is 'true'" do
+      expected = <<~OUTPUT
+        Document types (annotated) indexed by GOV.UK Chat:
+        - type_a (schema name: schema_a, weighting: 2.0)
+        - type_b (schema name: schema_a)
+        - type_c (schema name: schema_b, required parent document_type: parent_a, weighting: 1.1)
+        - type_c (schema name: schema_b, required parent document_type: parent_b)
+      OUTPUT
+
+      ClimateControl.modify(ANNOTATED: "true") do
+        expect { Rake::Task[task_name].invoke }.to output(expected).to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
Despite previous efforts [1], it's still a struggle to communicate what GOV.UK Content is indexed with non-technical folk.

Following a request for this information on Slack I quickly ran some code to get the data out and have now committed it to the repo so it can be reused.

[1]: https://github.com/alphagov/govuk-chat/pull/701