### PR TITLE
[CHAT-968] Add AnswerFeedback API endpoints

### DIFF
--- a/app/blueprints/answer_blueprint.rb
+++ b/app/blueprints/answer_blueprint.rb
@@ -11,4 +11,18 @@ class AnswerBlueprint < Blueprinter::Base
       { url: source[:href], title: source[:title] }
     end
   end
+
+  field :feedback, if: ->(_field_name, answer, _options) { answer.feedback.present? } do |answer, _options|
+    {
+      reaction: answer.feedback.reaction,
+      created_at: answer.feedback.created_at.iso8601,
+    }
+  end
+
+  field :feedback_url, if: ->(_field_name, answer, _options) { answer.feedback.blank? } do |answer, _options|
+    Rails.application.routes.url_helpers.api_v1_answer_feedback_path(
+      answer.question.conversation_id,
+      answer.id,
+    )
+  end
 end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -7,7 +7,15 @@ class Admin::QuestionsController < Admin::BaseController
   def show
     question_scope = Question.includes(
       conversation: :signon_user,
-      answer: [{ sources: :chunk }, :topics, :answer_relevancy_runs, :coherence_runs, :faithfulness_runs, :context_relevancy_runs],
+      answer: [
+        { sources: :chunk },
+        :topics,
+        :feedback,
+        :answer_relevancy_runs,
+        :coherence_runs,
+        :faithfulness_runs,
+        :context_relevancy_runs,
+      ],
     )
 
     @question = question_scope.find(params[:id])
@@ -36,6 +44,7 @@ private
       :secondary_topic,
       :completeness,
       :conversation_session_id,
+      :reaction,
     )
   end
 end

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::ConversationsController < Api::BaseController
   before_action { authorise_user!(SignonUser::Permissions::CONVERSATION_API) }
-  before_action :find_conversation, only: %i[show update answer questions]
+  before_action :find_conversation, only: %i[show update answer questions answer_feedback]
+
+  FEEDBACK_ALREADY_PROVIDED_MESSAGE = "Feedback already provided for this answer".freeze
 
   def create
     conversation = Conversation.new(
@@ -110,19 +112,40 @@ class Api::V1::ConversationsController < Api::BaseController
     render(json:, status: :ok)
   end
 
+  def answer_feedback
+    answer = @conversation.answers.includes(:feedback).find(params[:answer_id])
+    return render_feedback_already_provided if answer.feedback.present?
+
+    form = Form::CreateAnswerFeedback.new(answer_feedback_params.merge(answer:))
+
+    unless form.valid?
+      return render json: ValidationErrorBlueprint.render(
+        errors: form.errors.messages,
+      ), status: :unprocessable_content
+    end
+
+    form.submit
+
+    render json: {}, status: :created
+  rescue ActiveRecord::RecordNotUnique
+    render_feedback_already_provided
+  end
+
 private
 
   def find_conversation
-    where = { signon_user_id: current_user.id, source: :api, end_user_id: end_user_id_header }
-
     @conversation = Conversation
                     .active
-                    .where(where)
+                    .where(signon_user_id: current_user.id, source: :api, end_user_id: end_user_id_header)
                     .find(params[:conversation_id])
   end
 
   def question_params
     params.permit(:user_question)
+  end
+
+  def answer_feedback_params
+    params.permit(:reaction)
   end
 
   def answer_path(question)
@@ -134,5 +157,11 @@ private
 
   def end_user_id_header
     request.headers.fetch("HTTP_GOVUK_CHAT_END_USER_ID", "").strip.presence
+  end
+
+  def render_feedback_already_provided
+    render json: GenericErrorBlueprint.render(
+      message: FEEDBACK_ALREADY_PROVIDED_MESSAGE,
+    ), status: :conflict
   end
 end

--- a/app/helpers/admin/questions_helper.rb
+++ b/app/helpers/admin/questions_helper.rb
@@ -126,6 +126,10 @@ module Admin
                       ),
                   },
                   {
+                    field: "Feedback",
+                    value: answer.feedback&.reaction&.humanize,
+                  },
+                  {
                     field: "Answer strategy",
                     value: question.answer_strategy.humanize,
                   },

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -12,6 +12,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
   attribute :secondary_topic
   attribute :completeness
   attribute :conversation_session_id
+  attribute :reaction
 
   validate :validate_dates
 
@@ -30,7 +31,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
 
   def results
     @results ||= begin
-      scope = Question.includes(answer: :topics)
+      scope = Question.includes(answer: %i[topics feedback])
                       .left_outer_joins(:answer)
       scope = search_scope(scope)
       scope = status_scope(scope)
@@ -46,6 +47,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
       scope = primary_topic_scope(scope)
       scope = secondary_topic_scope(scope)
       scope = completeness_scope(scope)
+      scope = reaction_scope(scope)
       scope.page(page)
            .per(25)
     end
@@ -81,6 +83,7 @@ private
     filters[:secondary_topic] = secondary_topic if secondary_topic.present?
     filters[:completeness] = completeness if completeness.present?
     filters[:conversation_session_id] = conversation_session_id if conversation_session_id.present?
+    filters[:reaction] = reaction if reaction.present?
 
     filters
   end
@@ -167,6 +170,12 @@ private
     return scope if completeness.blank?
 
     scope.where(answers: { completeness: })
+  end
+
+  def reaction_scope(scope)
+    return scope if reaction.blank?
+
+    scope.joins(answer: :feedback).where(answer_feedback: { reaction: })
   end
 
   def validate_dates

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -54,6 +54,7 @@ class Answer < ApplicationRecord
   after_commit :send_answer_count_to_prometheus, on: :create
 
   belongs_to :question
+  has_one :feedback, class_name: "AnswerFeedback", dependent: :destroy, strict_loading: false
   has_many :sources, -> { order(relevancy: :asc) }, class_name: "AnswerSource"
   has_one :topics, class_name: "AnswerAnalysis::Topics"
   has_many :answer_relevancy_runs,

--- a/app/models/answer_feedback.rb
+++ b/app/models/answer_feedback.rb
@@ -9,4 +9,13 @@ class AnswerFeedback < ApplicationRecord
          negative: "negative",
        },
        prefix: true
+
+  scope :exportable, lambda { |start_date, end_date|
+                       joins(answer: { question: :conversation })
+                       .where(created_at: start_date...end_date)
+                     }
+
+  def serialize_for_export
+    as_json
+  end
 end

--- a/app/models/answer_feedback.rb
+++ b/app/models/answer_feedback.rb
@@ -1,0 +1,12 @@
+class AnswerFeedback < ApplicationRecord
+  self.table_name = "answer_feedback"
+
+  belongs_to :answer
+
+  enum :reaction,
+       {
+         positive: "positive",
+         negative: "negative",
+       },
+       prefix: true
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -24,7 +24,7 @@ class Conversation < ApplicationRecord
 
   def questions_for_showing_conversation(only_answered: false, before_id: nil, after_id: nil, limit: nil)
     scope = Question.where(conversation: self)
-                  .includes(answer: { sources: :chunk })
+                  .includes(answer: [{ sources: :chunk }, :feedback])
                   .active
     scope = scope.joins(:answer) if only_answered
 

--- a/app/models/form/create_answer_feedback.rb
+++ b/app/models/form/create_answer_feedback.rb
@@ -1,0 +1,16 @@
+class Form::CreateAnswerFeedback
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  REACTION_INCLUSION_ERROR_MESSAGE = "Reaction must be either 'positive' or 'negative'".freeze
+
+  attribute :reaction
+  attribute :answer
+
+  validates :reaction, inclusion: { in: AnswerFeedback.reactions.keys, message: REACTION_INCLUSION_ERROR_MESSAGE }
+
+  def submit
+    validate!
+    answer.create_feedback!(reaction:)
+  end
+end

--- a/app/views/admin/questions/_question_filters.html.erb
+++ b/app/views/admin/questions/_question_filters.html.erb
@@ -207,6 +207,21 @@
     end,
   } %>
 
+  <%= render "govuk_publishing_components/components/select", {
+    id: "reaction",
+    name: "reaction",
+    label: "Feedback",
+    heading_size: "s",
+    full_width: true,
+    options: [{ text: "", value: "" }] + AnswerFeedback::reactions.values.map do |value|
+      {
+       text: value.humanize,
+       value: value,
+       selected: params[:reaction] == value,
+      }
+    end,
+  } %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: "Filter",
     margin_bottom: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
       put "/conversation/:conversation_id", to: "conversations#update", as: :update_conversation
       get "/conversation/:conversation_id/questions", to: "conversations#questions", as: :conversation_questions
       get "/conversation/:conversation_id/questions/:question_id/answer", to: "conversations#answer", as: :answer_question
+      post "/conversation/:conversation_id/answers/:answer_id/feedback", to: "conversations#answer_feedback", as: :answer_feedback
     end
   end
 

--- a/db/migrate/20260827090000_create_answer_feedback.rb
+++ b/db/migrate/20260827090000_create_answer_feedback.rb
@@ -1,0 +1,14 @@
+class CreateAnswerFeedback < ActiveRecord::Migration[8.1]
+  def change
+    create_enum :answer_feedback_reaction, %w[positive negative]
+
+    create_table :answer_feedback, id: :uuid do |t|
+      t.references :answer, type: :uuid, null: false, index: { unique: true }, foreign_key: { on_delete: :cascade }
+      t.enum :reaction, null: false, enum_type: "answer_feedback_reaction"
+
+      t.timestamps
+    end
+
+    add_index :answer_feedback, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_093000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_093000) do
   create_enum "answer_analysis_run_status", ["success", "failure", "error"]
   create_enum "answer_analysis_topics_status", ["success", "error"]
   create_enum "answer_completeness", ["complete", "partial", "no_information"]
+  create_enum "answer_feedback_reaction", ["positive", "negative"]
   create_enum "answer_status", ["answered", "clarification", "error_answer_guardrails", "error_answer_service_error", "error_jailbreak_guardrails", "error_non_specific", "error_question_routing_guardrails", "error_timeout", "guardrails_answer", "guardrails_forbidden_terms", "guardrails_jailbreak", "guardrails_question_routing", "unanswerable_llm_cannot_answer", "unanswerable_no_govuk_content", "unanswerable_question_routing"]
   create_enum "conversation_source", ["web", "api"]
   create_enum "guardrails_status", ["pass", "fail", "error"]
@@ -89,6 +90,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_093000) do
     t.enum "status", default: "success", null: false, enum_type: "answer_analysis_topics_status"
     t.datetime "updated_at", null: false
     t.index ["answer_id"], name: "index_answer_analysis_topics_on_answer_id", unique: true
+  end
+
+  create_table "answer_feedback", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "answer_id", null: false
+    t.datetime "created_at", null: false
+    t.enum "reaction", null: false, enum_type: "answer_feedback_reaction"
+    t.datetime "updated_at", null: false
+    t.index ["answer_id"], name: "index_answer_feedback_on_answer_id", unique: true
+    t.index ["created_at"], name: "index_answer_feedback_on_created_at"
   end
 
   create_table "answer_source_chunks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -223,6 +233,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_093000) do
   add_foreign_key "answer_analysis_context_relevancy_runs", "answers", on_delete: :cascade
   add_foreign_key "answer_analysis_faithfulness_runs", "answers", on_delete: :cascade
   add_foreign_key "answer_analysis_topics", "answers", on_delete: :cascade
+  add_foreign_key "answer_feedback", "answers", on_delete: :cascade
   add_foreign_key "answer_sources", "answer_source_chunks", on_delete: :restrict
   add_foreign_key "answer_sources", "answers", on_delete: :cascade
   add_foreign_key "answers", "questions", on_delete: :cascade

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -764,6 +764,31 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AnswerSource"
+        feedback:
+          description: |
+            Feedback that has been given for this answer. Present only once
+            feedback has been given, in which case feedback_url is absent.
+          type: object
+          required:
+            - reaction
+            - created_at
+          properties:
+            reaction:
+              description: An end user's reaction to an answer
+              type: string
+              enum:
+                - positive
+                - negative
+            created_at:
+              type: string
+              format: date-time
+        feedback_url:
+          description: |
+            A relative URL that can be used to give feedback on this answer.
+            Absent once feedback has been given, in which case feedback is
+            provided instead.
+          type: string
+          format: uri
     AnswerSource:
       type: object
       required:

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -23,7 +23,7 @@ info:
     | API User  | 900 RPM             | 10,800 RPM          |
     | End User  | 15 RPM              | 180 RPM            |
 
-  version: "0.5.0"
+  version: "0.6.0"
 servers:
   - url: https://chat.publishing.service.gov.uk/api/v1
 paths:
@@ -425,6 +425,134 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
             Govuk-End-User-Id-Read-RateLimit-Reset:
               $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
+
+  /conversation/{conversation_id}/answers/{answer_id}/feedback:
+    post:
+      summary: Give feedback on an answer
+      description: |
+        Records an end user's reaction to an answer.
+
+        An answer can only be given feedback once. Subsequent attempts to
+        give feedback on the same answer will be rejected with a 409.
+      parameters:
+        - name: conversation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: answer_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/EndUserIdHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reaction:
+                  description: |
+                    The end user's reaction to the answer. Must be either
+                    "positive" or "negative"; any other value, or an absent
+                    value, is rejected with a 422 describing the problem.
+                  type: string
+      responses:
+        "201":
+          description: Successfully recorded the feedback for the answer
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
+            Govuk-Api-User-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+        "404":
+          description: |
+            Conversation or answer do not exist, or do not belong to this end user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
+            Govuk-Api-User-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+        "409":
+          description: |
+            Feedback has already been provided for this answer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
+            Govuk-Api-User-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+        "422":
+          description: |
+            Validation error on feedback submission (such as an unrecognised reaction)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
+            Govuk-Api-User-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+        "429":
+          description: |
+            Too many requests to write endpoints from an API User or End User ID
+          headers:
+            Govuk-Api-User-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
+            Govuk-Api-User-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
+            Govuk-End-User-Id-Write-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
+            Govuk-End-User-Id-Write-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
+            Govuk-End-User-Id-Write-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
 
 security:
   - bearerAuth: []

--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -3,6 +3,7 @@ module Bigquery
 
   TABLES_TO_EXPORT = [
     ExportTable.new(name: "questions", time_partitioning_field: "created_at", model: Question),
+    ExportTable.new(name: "answer_feedback", time_partitioning_field: "created_at", model: AnswerFeedback),
     ExportTable.new(name: "answer_analysis_topics", time_partitioning_field: "created_at", model: AnswerAnalysis::Topics),
     ExportTable.new(name: "answer_analysis_answer_relevancy_runs", time_partitioning_field: "created_at", model: AnswerAnalysis::AnswerRelevancyRun),
     ExportTable.new(name: "answer_analysis_coherence_runs", time_partitioning_field: "created_at", model: AnswerAnalysis::CoherenceRun),

--- a/spec/blueprints/answer_blueprint_spec.rb
+++ b/spec/blueprints/answer_blueprint_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe AnswerBlueprint do
   let(:answer) { create(:answer) }
+  let(:feedback_url) do
+    "/api/v1/conversation/#{answer.question.conversation_id}/answers/#{answer.id}/feedback"
+  end
 
   describe ".render_as_json" do
     it "generates the correct JSON for an Answer with no sources" do
@@ -7,6 +10,7 @@ RSpec.describe AnswerBlueprint do
         id: answer.id,
         created_at: answer.created_at.iso8601,
         message: answer.message,
+        feedback_url:,
       }.as_json
       output_json = described_class.render_as_json(answer)
 
@@ -26,6 +30,7 @@ RSpec.describe AnswerBlueprint do
             url: answer_source_chunk.govuk_url,
           },
         ],
+        feedback_url:,
       }.as_json
       output_json = described_class.render_as_json(answer)
 
@@ -36,6 +41,29 @@ RSpec.describe AnswerBlueprint do
       create(:answer_source, answer:, used: false)
       output_json = described_class.render_as_json(answer)
       expect(output_json.keys).not_to include("sources")
+    end
+
+    it "renders a relative feedback_url for the answer" do
+      output_json = described_class.render_as_json(answer)
+
+      expect(output_json["feedback_url"]).to eq(feedback_url)
+      expect(output_json.keys).not_to include("feedback")
+    end
+
+    context "when the answer has feedback" do
+      it "renders the feedback rather than a feedback_url" do
+        feedback = create(:answer_feedback, answer:, reaction: :negative)
+
+        output_json = described_class.render_as_json(answer.reload)
+
+        expect(output_json["feedback"]).to eq(
+          {
+            reaction: "negative",
+            created_at: feedback.created_at.iso8601,
+          }.as_json,
+        )
+        expect(output_json.keys).not_to include("feedback_url")
+      end
     end
   end
 end

--- a/spec/factories/answer_factory.rb
+++ b/spec/factories/answer_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     status { :answered }
     completeness { :complete }
     sources { [] }
+    feedback { nil }
     topics { nil }
 
     trait :with_sources do
@@ -22,6 +23,10 @@ FactoryBot.define do
                              exact_path: "/vat-tax")),
         ]
       end
+    end
+
+    trait :with_feedback do
+      feedback { build(:answer_feedback) }
     end
 
     trait :with_topics do

--- a/spec/factories/answer_feedback_factory.rb
+++ b/spec/factories/answer_feedback_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :answer_feedback do
+    answer
+    reaction { :positive }
+  end
+end

--- a/spec/helpers/admin/questions_helper_spec.rb
+++ b/spec/helpers/admin/questions_helper_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Admin::QuestionsHelper do
         "Status",
         "Answer created at",
         "Answer",
+        "Feedback",
         "Answer strategy",
         "Completeness",
         "Jailbreak guardrails status",

--- a/spec/lib/tasks/bigquery_spec.rb
+++ b/spec/lib/tasks/bigquery_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "rake bigquery tasks" do
     it "prints what it has exported" do
       previous_export = create(:bigquery_export, exported_until: 2.hours.ago)
       answer = create(:answer, created_at: 1.hour.ago)
+      create(:answer_feedback, created_at: 1.hour.ago, answer:)
       create(:answer_analysis_topics, created_at: 1.hour.ago, answer:)
       %w[answer_relevancy_run coherence_run context_relevancy_run faithfulness_run].each do |run_type|
         create(run_type, created_at: 1.hour.ago, answer:)
@@ -35,6 +36,7 @@ RSpec.describe "rake bigquery tasks" do
 
       expected_counts = {
         "questions" => 1,
+        "answer_feedback" => 1,
         "answer_analysis_topics" => 1,
         "answer_analysis_answer_relevancy_runs" => 1,
         "answer_analysis_coherence_runs" => 1,

--- a/spec/lib/tasks/data_retention_spec.rb
+++ b/spec/lib/tasks/data_retention_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "rake data_retention tasks" do
         context_relevancy_run
         faithfulness_run
         answer_relevancy_run
+        answer_feedback
         answer_analysis_topics
       ].each do |model|
         create(model, answer:)
@@ -28,6 +29,7 @@ RSpec.describe "rake data_retention tasks" do
         .and change(AnswerAnalysis::ContextRelevancyRun, :count).by(-1)
         .and change(AnswerAnalysis::FaithfulnessRun, :count).by(-1)
         .and change(AnswerAnalysis::AnswerRelevancyRun, :count).by(-1)
+        .and change(AnswerFeedback, :count).by(-1)
         .and change(AnswerAnalysis::Topics, :count).by(-1)
         .and not_change(Conversation, :count)
         .and output("\"1 question and associated data deleted\"\n\"0 conversations deleted\"\n").to_stdout

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -295,6 +295,19 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       expect(filter.results).to eq([no_info_question])
     end
 
+    it "filters the results by feedback reaction" do
+      positive_answer = create(:answer)
+      create(:answer_feedback, answer: positive_answer, reaction: :positive)
+      negative_answer = create(:answer)
+      create(:answer_feedback, answer: negative_answer, reaction: :negative)
+
+      filter = described_class.new(reaction: "positive")
+      expect(filter.results).to eq([positive_answer.question])
+
+      filter = described_class.new(reaction: "negative")
+      expect(filter.results).to eq([negative_answer.question])
+    end
+
     it "paginates the results" do
       create_list(:question, 26)
 
@@ -396,6 +409,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
         completeness: "complete",
       )
       create(:answer_analysis_topics, answer:, primary_topic: "business", secondary_topic: "tax")
+      create(:answer_feedback, answer:, reaction: :positive)
     end
 
     today = Date.current
@@ -417,6 +431,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       secondary_topic: "tax",
       completeness: "complete",
       conversation_session_id:,
+      reaction: "positive",
     }.merge(attrs)
 
     described_class.new(**filter_params)

--- a/spec/models/answer_feedback_spec.rb
+++ b/spec/models/answer_feedback_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe AnswerFeedback do
+  it_behaves_like "exportable by start and end date" do
+    let(:conversation) { create(:conversation) }
+    let(:question) { create(:question, conversation:) }
+    let(:answer) { create(:answer, question:) }
+    let(:create_record_lambda) { ->(time) { create(:answer_feedback, created_at: time) } }
+  end
+
+  describe "#serialize_for_export" do
+    it "returns the answer feedback serialized as json" do
+      answer_feedback = create(:answer_feedback)
+
+      expect(answer_feedback.serialize_for_export).to eq(answer_feedback.as_json)
+    end
+  end
+end

--- a/spec/models/form/create_answer_feedback_spec.rb
+++ b/spec/models/form/create_answer_feedback_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Form::CreateAnswerFeedback do
+  describe "validations" do
+    let(:answer) { build(:answer) }
+
+    %w[positive negative].each do |reaction|
+      it "is valid when the reaction is '#{reaction}'" do
+        form = described_class.new(answer:, reaction:)
+        expect(form).to be_valid
+      end
+    end
+
+    it "is invalid when the reaction is nil" do
+      form = described_class.new(answer:)
+      expect(form).to be_invalid
+      expect(form.errors[:reaction]).to eq([described_class::REACTION_INCLUSION_ERROR_MESSAGE])
+    end
+
+    it "is invalid when the reaction is not a recognised value" do
+      form = described_class.new(answer:, reaction: "indifferent")
+      expect(form).to be_invalid
+      expect(form.errors[:reaction]).to eq([described_class::REACTION_INCLUSION_ERROR_MESSAGE])
+    end
+  end
+
+  describe "#submit" do
+    it "raises an error when the form object is invalid" do
+      form = described_class.new
+      expect { form.submit }.to raise_error(ActiveModel::ValidationError)
+    end
+
+    it "creates a feedback record for the answer" do
+      create(:answer)
+      answer = Answer.includes(:feedback).last
+
+      form = described_class.new(answer:, reaction: "negative")
+
+      expect { form.submit }.to change(AnswerFeedback, :count).by(1)
+      expect(answer.reload.feedback.reaction).to eq("negative")
+    end
+
+    it "raises when the answer already has feedback" do
+      answer = create(:answer)
+      create(:answer_feedback, answer:)
+      answer = Answer.includes(:feedback).find(answer.id)
+
+      form = described_class.new(answer:, reaction: "negative")
+
+      expect { form.submit }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "returns the created feedback" do
+      create(:answer)
+      answer = Answer.includes(:feedback).last
+
+      feedback = described_class.new(answer:, reaction: "positive").submit
+
+      expect(feedback).to be_a(AnswerFeedback)
+      expect(feedback.reaction).to eq("positive")
+    end
+  end
+end

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Api::V1::ConversationsController" do
                      api_v1_answer_question_path: %i[get],
                      api_v1_create_conversation_path: %i[post],
                      api_v1_update_conversation_path: %i[put],
+                     api_v1_answer_feedback_path: %i[post],
                    } do
     let(:route_params) do
       {
@@ -666,6 +667,108 @@ RSpec.describe "Api::V1::ConversationsController" do
         answer = question.reload.answer
         expected_response = AnswerBlueprint.render_as_json(answer)
         expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+    end
+  end
+
+  describe "POST :answer_feedback" do
+    let(:answer) { create(:answer, question:) }
+
+    it_behaves_like "limits access based on Signon and end user permissions" do
+      let(:method) { :post }
+      let(:url) { api_v1_answer_feedback_path(conversation, answer) }
+      let(:params) { { reaction: "positive" } }
+    end
+
+    it_behaves_like "limits access based on conversation source" do
+      let(:method) { :post }
+      let(:url) { api_v1_answer_feedback_path(conversation, answer) }
+      let(:params) { { reaction: "positive" } }
+    end
+
+    it "records the feedback and returns a created status" do
+      expect {
+        post api_v1_answer_feedback_path(conversation, answer),
+             params: { reaction: "positive" },
+             headers:,
+             as: :json
+      }.to change(AnswerFeedback, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body).to eq({})
+      expect(answer.reload.feedback).to be_reaction_positive
+    end
+
+    it "records a negative reaction" do
+      post api_v1_answer_feedback_path(conversation, answer),
+           params: { reaction: "negative" },
+           headers:,
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(answer.reload.feedback).to be_reaction_negative
+    end
+
+    context "when the reaction is not recognised" do
+      it "returns an unprocessable content status with the validation error" do
+        expect {
+          post api_v1_answer_feedback_path(conversation, answer),
+               params: { reaction: "indifferent" },
+               headers:,
+               as: :json
+        }.not_to change(AnswerFeedback, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to eq(
+          { "reaction" => [Form::CreateAnswerFeedback::REACTION_INCLUSION_ERROR_MESSAGE] },
+        )
+      end
+    end
+
+    context "when the reaction is missing" do
+      it "returns an unprocessable content status with the validation error" do
+        post api_v1_answer_feedback_path(conversation, answer),
+             params: {},
+             headers:,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to eq(
+          { "reaction" => [Form::CreateAnswerFeedback::REACTION_INCLUSION_ERROR_MESSAGE] },
+        )
+      end
+    end
+
+    context "when the answer already has feedback" do
+      before { create(:answer_feedback, answer:, reaction: :positive) }
+
+      it "returns a conflict status and leaves the existing feedback unchanged" do
+        expect {
+          post api_v1_answer_feedback_path(conversation, answer),
+               params: { reaction: "negative" },
+               headers:,
+               as: :json
+        }.not_to change(AnswerFeedback, :count)
+
+        expect(response).to have_http_status(:conflict)
+        expect(response.parsed_body["message"])
+          .to eq(Api::V1::ConversationsController::FEEDBACK_ALREADY_PROVIDED_MESSAGE)
+        expect(answer.reload.feedback).to be_reaction_positive
+      end
+    end
+
+    context "when a conflicting record is inserted concurrently" do
+      it "returns a conflict status" do
+        form = instance_double(Form::CreateAnswerFeedback, valid?: true)
+        allow(form).to receive(:submit).and_raise(ActiveRecord::RecordNotUnique)
+        allow(Form::CreateAnswerFeedback).to receive(:new).and_return(form)
+
+        post api_v1_answer_feedback_path(conversation, answer),
+             params: { reaction: "positive" },
+             headers:,
+             as: :json
+
+        expect(response).to have_http_status(:conflict)
       end
     end
   end

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe "Admin user filters questions" do
 
     when_i_filter_questions_by_partialy_complete_answers
     then_i_see_the_question_with_a_partially_complete_answer
+
+    when_i_clear_the_filters
+    and_i_filter_questions_by_positive_feedback
+    then_i_see_the_question_with_positive_feedback
+
+    when_i_filter_questions_by_negative_feedback
+    then_i_see_the_question_with_negative_feedback
   end
 
   scenario "filtered by a signon user" do
@@ -74,6 +81,8 @@ RSpec.describe "Admin user filters questions" do
     @question3 = create(:question, conversation: api_conversation, message: "Greetings world", created_at: 1.minute.ago)
     create(:answer, question: @question2, question_routing_label: "non_english", completeness: :partial)
     create(:answer, status: :clarification, question: @question3)
+    create(:answer_feedback, answer: @question2.answer, reaction: :positive)
+    create(:answer_feedback, answer: @question3.answer, reaction: :negative)
   end
 
   def and_there_are_questions_associated_with_signon_users
@@ -270,5 +279,25 @@ RSpec.describe "Admin user filters questions" do
     expect(page).to have_content(@question2.message)
     expect(page).not_to have_content(@question1.message)
     expect(page).not_to have_content(@question3.message)
+  end
+
+  def and_i_filter_questions_by_positive_feedback
+    select "Positive", from: "reaction"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_positive_feedback
+    expect(page).to have_content(@question2.message)
+    expect(page).not_to have_content(@question3.message)
+  end
+
+  def when_i_filter_questions_by_negative_feedback
+    select "Negative", from: "reaction"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_negative_feedback
+    expect(page).to have_content(@question3.message)
+    expect(page).not_to have_content(@question2.message)
   end
 end


### PR DESCRIPTION
## Description 

This largely re-implements the feedback mechanism we had in place and removed in this [PR](https://github.com/alphagov/govuk-chat/pull/1067). There are some notable exceptions. We've gone with a `reason` enum instead of a `useful` boolean to capture the response. Also i've made a couple of small tweaks which i'll leave comments on.

This PR:

1. re-adds the table via a migration
2. adds the model & factory
3. adds the POST feedback endpoint (also re-adds the form for validation)
4. extends the answer blueprint to also include feedback so that it's sent as part of the GET conversation and messages response payload
5. Re-adds it to the big query export

It should be noted that there won't be any issues with clashing values in the BigQuery tables because they integration and production tables were dropped prior to us going live. 

## Out of scope

I've not looked into reworking the way we do rate limiting as part of this PR. I'll look at that in a follow up bit of work.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-968