### PR TITLE
Remove channel from SlackPoster

### DIFF
--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -32,7 +32,6 @@ private
       {
         icon_emoji: ":govukchat:",
         username: "GOV.UK Chat",
-        channel: "#ai-govuk-chat-v1-squad",
         link_names: true,
       },
     )


### PR DESCRIPTION

It seems like this option would specify the channel the message is
posted to, but it doesn't.

The webhook URL created in Slack is tied to a specific channel, so this
override doesn't actually do anything.
