### PR TITLE
[CHAT-968] Update rate limiting strategy

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,22 +6,16 @@ Rails.application.config.middleware.insert_after ActionDispatch::Executor, Api::
 Rails.application.config.middleware.insert_before Rack::Attack, Api::AuthMiddleware
 
 class Rack::Attack
-  CONVERSATION_API_PATH_REGEX = /^\/api\/v\d+\/conversation/
-
-  throttle(Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME, limit: 10_800, period: 1.minute) do |request|
-    if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
-      signon_uid(request)
-    end
+  throttle(Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME, limit: 10_800, period: 1.minute) do |request|
+    signon_uid(request) if Api::RateLimit.default?(request)
   end
 
-  throttle(Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME, limit: 900, period: 1.minute) do |request|
-    if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
-      signon_uid(request)
-    end
+  throttle(Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME, limit: 900, period: 1.minute) do |request|
+    signon_uid(request) if Api::RateLimit.conversation_write?(request)
   end
 
-  throttle(Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME, limit: 180, period: 1.minute) do |request|
-    if request.path.match?(CONVERSATION_API_PATH_REGEX) && read_method?(request)
+  throttle(Api::RateLimit::GOVUK_END_USER_DEFAULT_THROTTLE_NAME, limit: 180, period: 1.minute) do |request|
+    if Api::RateLimit.default?(request)
       user_id = end_user_id(request)
 
       next if user_id.nil?
@@ -30,18 +24,14 @@ class Rack::Attack
     end
   end
 
-  throttle(Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME, limit: 15, period: 1.minute) do |request|
-    if request.path.match?(CONVERSATION_API_PATH_REGEX) && !read_method?(request)
+  throttle(Api::RateLimit::GOVUK_END_USER_CONVERSATION_WRITE_THROTTLE_NAME, limit: 15, period: 1.minute) do |request|
+    if Api::RateLimit.conversation_write?(request)
       user_id = end_user_id(request)
 
       next if user_id.nil?
 
       "#{signon_uid(request)}-#{user_id}"
     end
-  end
-
-  def self.read_method?(request)
-    request.get? || request.head? || request.options?
   end
 
   def self.signon_uid(request)

--- a/docs/api_openapi_specification.yml
+++ b/docs/api_openapi_specification.yml
@@ -14,16 +14,26 @@ info:
     Usage of this API is rate-limited on a requests per minute (RPM) basis.
     There are rate limits applied to individual clients (Signon users). A
     client may also send a header `Govuk-Chat-End-User-Id` for an
-    additional rate limit to be applied to an end user. There are distinct
-    rate limits for read requests (GET, HEAD) and write requests (POST, PATCH,
-    PUT, DELETE).
+    additional rate limit to be applied to an end user.
 
-    | User type | Write request limit | Read request limit |
-    |-----------|---------------------|--------------------|
-    | API User  | 900 RPM             | 10,800 RPM          |
-    | End User  | 15 RPM              | 180 RPM            |
+    Requests are split across two limits according to how expensive they are
+    to serve. Starting a conversation and adding a question an existing one
+    both trigger multiple model invocations while composing an answer.
+    This is expensive, so they are limited far more tightly under the conversation
+    write limit. Every other request, including reading conversations, questions and
+    answers and giving feedback on an answer, shares the more generous default limit.
 
-  version: "0.6.0"
+    | User type | Conversation write limit | Default limit |
+    |-----------|--------------------------|---------------|
+    | API User  | 900 RPM                  | 10,800 RPM    |
+    | End User  | 15 RPM                   | 180 RPM       |
+
+    The response headers reporting these limits keep the `Read` and `Write`
+    names they were given when the limits were split by HTTP method instead.
+    `Write` headers report the conversation write limit and `Read` headers
+    report the default limit, regardless of the HTTP method the request used.
+
+  version: "0.6.1"
 servers:
   - url: https://chat.publishing.service.gov.uk/api/v1
 paths:
@@ -81,7 +91,7 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or End User ID
+            Too many requests against the conversation write limit from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -155,10 +165,10 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or End User ID
+            Too many requests against the default limit from an API User or End User ID
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
             Govuk-Api-User-Read-RateLimit-Remaining:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
@@ -232,7 +242,7 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or End User ID
+            Too many requests against the conversation write limit from an API User or End User ID
           headers:
             Govuk-Api-User-Write-RateLimit-Limit:
               $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
@@ -320,10 +330,10 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or End User ID
+            Too many requests against the default limit from an API User or End User ID
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
             Govuk-Api-User-Read-RateLimit-Remaining:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
@@ -411,10 +421,10 @@ paths:
               $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to read endpoints from an API User or End User ID
+            Too many requests against the default limit from an API User or End User ID
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
             Govuk-Api-User-Read-RateLimit-Remaining:
               $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
             Govuk-Api-User-Read-RateLimit-Reset:
@@ -465,18 +475,18 @@ paths:
         "201":
           description: Successfully recorded the feedback for the answer
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
-            Govuk-Api-User-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
-            Govuk-Api-User-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-End-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
-            Govuk-End-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
-            Govuk-End-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "404":
           description: |
             Conversation or answer do not exist, or do not belong to this end user
@@ -485,18 +495,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/GenericError"
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
-            Govuk-Api-User-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
-            Govuk-Api-User-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-End-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
-            Govuk-End-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
-            Govuk-End-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "409":
           description: |
             Feedback has already been provided for this answer
@@ -505,18 +515,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/GenericError"
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
-            Govuk-Api-User-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
-            Govuk-Api-User-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-End-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
-            Govuk-End-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
-            Govuk-End-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "422":
           description: |
             Validation error on feedback submission (such as an unrecognised reaction)
@@ -525,34 +535,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationError"
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
-            Govuk-Api-User-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
-            Govuk-Api-User-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-End-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
-            Govuk-End-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
-            Govuk-End-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
         "429":
           description: |
-            Too many requests to write endpoints from an API User or End User ID
+            Too many requests against the default limit from an API User or End User ID
           headers:
-            Govuk-Api-User-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitLimit'
-            Govuk-Api-User-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitRemaining'
-            Govuk-Api-User-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukApiUserWriteRateLimitReset'
-            Govuk-End-User-Id-Write-RateLimit-Limit:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitLimit'
-            Govuk-End-User-Id-Write-RateLimit-Remaining:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitRemaining'
-            Govuk-End-User-Id-Write-RateLimit-Reset:
-              $ref: '#/components/headers/GovukEndUserIdWriteRateLimitReset'
+            Govuk-Api-User-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitLimit'
+            Govuk-Api-User-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitRemaining'
+            Govuk-Api-User-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukApiUserReadRateLimitReset'
+            Govuk-End-User-Id-Read-RateLimit-Limit:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitLimit'
+            Govuk-End-User-Id-Read-RateLimit-Remaining:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitRemaining'
+            Govuk-End-User-Id-Read-RateLimit-Reset:
+              $ref: '#/components/headers/GovukEndUserIdReadRateLimitReset'
 
 security:
   - bearerAuth: []
@@ -582,61 +592,61 @@ components:
         pattern: '\S'
   headers:
     GovukApiUserReadRateLimitLimit:
-      description: The request limit for the API user in the current period.
+      description: The default request limit for the API user in the current period.
       schema:
         type: string
     GovukApiUserReadRateLimitRemaining:
-      description: The number of remaining requests for the API user in the current period.
+      description: The number of remaining default requests for the API user in the current period.
       schema:
         type: string
     GovukApiUserReadRateLimitReset:
       description: |
-        Time remaining in seconds until the read request limit is reset for the API User.
+        Time remaining in seconds until the default request limit is reset for the API User.
         If the api user is currently at the limit, this is the time until next request can be made without returning
         a 429 Too Many Requests response.
       schema:
         type: string
     GovukEndUserIdReadRateLimitLimit:
-      description: The request limit for the User ID in the current period.
+      description: The default request limit for the User ID in the current period.
       schema:
         type: string
     GovukEndUserIdReadRateLimitRemaining:
-      description: The number of remaining requests for the User ID in the current period.
+      description: The number of remaining default requests for the User ID in the current period.
       schema:
         type: string
     GovukEndUserIdReadRateLimitReset:
       description: |
-        Time remaining in seconds until the read request limit is reset for the User ID.
+        Time remaining in seconds until the default request limit is reset for the User ID.
         If the User ID is currently at the limit, this is the time until next request can be made without returning
         a 429 Too Many Requests response.
       schema:
         type: string
     GovukApiUserWriteRateLimitLimit:
-      description: The request limit for API User writes in the current period.
+      description: The conversation write request limit for the API User in the current period.
       schema:
         type: string
     GovukApiUserWriteRateLimitRemaining:
-      description: The number of remaining API User write requests in the current period.
+      description: The number of remaining conversation write requests for the API User in the current period.
       schema:
         type: string
     GovukApiUserWriteRateLimitReset:
       description: |
-        Time remaining in seconds until the write request limit is reset for the API User.
+        Time remaining in seconds until the conversation write request limit is reset for the API User.
         If the api user is currently at the limit, this is the time until next request can be made without returning
         a 429 Too Many Requests response.
       schema:
         type: string
     GovukEndUserIdWriteRateLimitLimit:
-      description: The request limit for User ID writes in the current period.
+      description: The conversation write request limit for the User ID in the current period.
       schema:
         type: string
     GovukEndUserIdWriteRateLimitRemaining:
-      description: The number of remaining User ID write requests in the current period.
+      description: The number of remaining conversation write requests for the User ID in the current period.
       schema:
         type: string
     GovukEndUserIdWriteRateLimitReset:
       description: |
-        Time remaining in seconds until the write request limit is reset for the User ID.
+        Time remaining in seconds until the conversation write request limit is reset for the User ID.
         If the User ID is currently at the limit, this is the time until next request can be made without returning
         a 429 Too Many Requests response.
       schema:

--- a/lib/api/rate_limit.rb
+++ b/lib/api/rate_limit.rb
@@ -1,6 +1,30 @@
 class Api::RateLimit
-  GOVUK_API_USER_READ_THROTTLE_NAME = "read requests to Conversations API with token".freeze
-  GOVUK_API_USER_WRITE_THROTTLE_NAME = "write method requests to Conversations API with token".freeze
-  GOVUK_END_USER_READ_THROTTLE_NAME = "read requests to Conversations API with user id".freeze
-  GOVUK_END_USER_WRITE_THROTTLE_NAME = "write requests to Conversations API with user id".freeze
+  GOVUK_API_USER_DEFAULT_THROTTLE_NAME = "default requests to Conversations API with token".freeze
+  GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME = "conversation write requests to Conversations API with token".freeze
+  GOVUK_END_USER_DEFAULT_THROTTLE_NAME = "default requests to Conversations API with user id".freeze
+  GOVUK_END_USER_CONVERSATION_WRITE_THROTTLE_NAME = "conversation write requests to Conversations API with user id".freeze
+
+  CONVERSATION_API_PATH_REGEX = /^\/api\/v\d+\/conversation/
+  CONVERSATION_API_CREATE_PATH_REGEX = /^\/api\/v\d+\/conversation$/
+  CONVERSATION_API_UPDATE_PATH_REGEX = /^\/api\/v\d+\/conversation\/[^\/]+$/
+
+  def self.conversation_write?(request)
+    create_conversation?(request) || update_conversation?(request)
+  end
+
+  def self.default?(request)
+    conversation_api_request?(request) && !conversation_write?(request)
+  end
+
+  def self.conversation_api_request?(request)
+    request.path.match?(CONVERSATION_API_PATH_REGEX)
+  end
+
+  def self.create_conversation?(request)
+    request.post? && request.path.match?(CONVERSATION_API_CREATE_PATH_REGEX)
+  end
+
+  def self.update_conversation?(request)
+    request.put? && request.path.match?(CONVERSATION_API_UPDATE_PATH_REGEX)
+  end
 end

--- a/lib/api/rate_limit/middleware.rb
+++ b/lib/api/rate_limit/middleware.rb
@@ -1,9 +1,15 @@
 class Api::RateLimit::Middleware
+  # The "Read" and "Write" header prefixes, and the Prometheus and Slack names
+  # derived from them below, date from when these throttles were split by HTTP
+  # method. They're kept so API clients don't have to change update their integration.
+  # "Write" now means that a question is persisted and an answer is generated. Answer
+  # generation is expensive as it involves multiple model invocations.
+  # "Read" captures everything else including answer feedback being persisted.
   THROTTLE_TO_PREFIX_MAPPING = {
-    Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME => "Govuk-Api-User-Read",
-    Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME => "Govuk-Api-User-Write",
-    Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME => "Govuk-End-User-Id-Read",
-    Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME => "Govuk-End-User-Id-Write",
+    Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME => "Govuk-Api-User-Read",
+    Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME => "Govuk-Api-User-Write",
+    Api::RateLimit::GOVUK_END_USER_DEFAULT_THROTTLE_NAME => "Govuk-End-User-Id-Read",
+    Api::RateLimit::GOVUK_END_USER_CONVERSATION_WRITE_THROTTLE_NAME => "Govuk-End-User-Id-Write",
   }.freeze
   SLACK_NOTIFICATION_THRESHOLD_PERCENTAGE = 75
   SLACK_NOTIFICATION_PERIOD = 15.minutes

--- a/spec/lib/api/rate_limit/middleware_spec.rb
+++ b/spec/lib/api/rate_limit/middleware_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe Api::RateLimit::Middleware do
     let(:env) do
       {
         "rack.attack.throttle_data" => {
-          Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME => {
+          Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME => {
             limit: 10,
             count: 3,
             period: 60,
             epoch_time: current_time,
           },
-          Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME => {
+          Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME => {
             limit: 6,
             count: 1,
             period: 60,
             epoch_time: current_time,
           },
-          Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME => {
+          Api::RateLimit::GOVUK_END_USER_DEFAULT_THROTTLE_NAME => {
             limit: 5,
             count: 5,
             period: 60,
@@ -57,14 +57,14 @@ RSpec.describe Api::RateLimit::Middleware do
     end
 
     it "does not allow negative remaining requests" do
-      env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:count] = 15
+      env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:count] = 15
 
       _, headers = middleware.call(env)
 
       expect(headers["Govuk-Api-User-Read-RateLimit-Remaining"]).to eq("0")
     end
 
-    context "with read requests" do
+    context "with default requests" do
       it "sends the metrics to Prometheus for the requests used" do
         travel_to(Time.zone.local(2000, 1, 1)) do
           allow(PrometheusMetrics).to receive(:gauge)
@@ -80,8 +80,8 @@ RSpec.describe Api::RateLimit::Middleware do
 
       context "when notifying Slack" do
         it "notifies if the requests exceed the threshold" do
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:limit] = 50
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:count] = 49
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:limit] = 50
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:count] = 49
 
           travel_to(Time.zone.local(2000, 1, 1)) do
             expect(NotifySlackApiUserRateLimitWarningJob).to receive(:perform_later).with(
@@ -92,12 +92,12 @@ RSpec.describe Api::RateLimit::Middleware do
         end
 
         it "only enqueues one Slack notification per window", :memory_cache do
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:limit] = 50
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:count] = 48
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:limit] = 50
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:count] = 48
 
           travel_to(Time.zone.local(2000, 1, 1)) do
             3.times do
-              env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME][:count] += 1
+              env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME][:count] += 1
               middleware.call(env)
             end
 
@@ -107,7 +107,7 @@ RSpec.describe Api::RateLimit::Middleware do
       end
     end
 
-    context "with write requests" do
+    context "with conversation write requests" do
       it "sends the metrics to Prometheur for the requests used" do
         travel_to(Time.zone.local(2000, 1, 1)) do
           allow(PrometheusMetrics).to receive(:gauge)
@@ -122,9 +122,9 @@ RSpec.describe Api::RateLimit::Middleware do
       end
 
       context "when notifying Slack" do
-        it "notifies if the write requests exceed the threshold" do
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME][:limit] = 50
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME][:count] = 49
+        it "notifies if the conversation write requests exceed the threshold" do
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME][:limit] = 50
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME][:count] = 49
 
           travel_to(Time.zone.local(2000, 1, 1)) do
             expect(NotifySlackApiUserRateLimitWarningJob).to receive(:perform_later).with(
@@ -135,12 +135,12 @@ RSpec.describe Api::RateLimit::Middleware do
         end
 
         it "only enqueues one Slack notification per window", :memory_cache do
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME][:limit] = 50
-          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME][:count] = 48
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME][:limit] = 50
+          env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME][:count] = 48
 
           travel_to(Time.zone.local(2000, 1, 1)) do
             3.times do
-              env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME][:count] += 1
+              env["rack.attack.throttle_data"][Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME][:count] += 1
               middleware.call(env)
             end
 

--- a/spec/lib/api/rate_limit_spec.rb
+++ b/spec/lib/api/rate_limit_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe Api::RateLimit do
+  describe ".conversation_write?" do
+    it "returns true for creating a conversation" do
+      expect(described_class.conversation_write?(request("POST", "/api/v1/conversation")))
+        .to be(true)
+    end
+
+    it "returns true for updating a conversation" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}"
+
+      expect(described_class.conversation_write?(request("PUT", path))).to be(true)
+    end
+
+    it "returns true for any API version" do
+      expect(described_class.conversation_write?(request("POST", "/api/v2/conversation")))
+        .to be(true)
+    end
+
+    %i[GET PUT PATCH DELETE].each do |method|
+      it "returns false for a #{method} request to the create conversation path" do
+        expect(described_class.conversation_write?(request(method, "/api/v1/conversation")))
+          .to be(false)
+      end
+    end
+
+    %i[GET POST PATCH DELETE].each do |method|
+      it "returns false for a #{method} request to the update conversation path" do
+        path = "/api/v1/conversation/#{SecureRandom.uuid}"
+
+        expect(described_class.conversation_write?(request(method, path))).to be(false)
+      end
+    end
+
+    it "returns false for reading the questions in a conversation" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}/questions"
+
+      expect(described_class.conversation_write?(request("GET", path))).to be(false)
+    end
+
+    it "returns false for giving feedback on an answer" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}/answers/#{SecureRandom.uuid}/feedback"
+
+      expect(described_class.conversation_write?(request("POST", path))).to be(false)
+    end
+
+    it "returns false for requests outside the conversations API" do
+      expect(described_class.conversation_write?(request("POST", "/api/v1/something-else")))
+        .to be(false)
+    end
+  end
+
+  describe ".default?" do
+    it "returns true for reading a conversation" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}"
+
+      expect(described_class.default?(request("GET", path))).to be(true)
+    end
+
+    it "returns true for reading the questions in a conversation" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}/questions"
+
+      expect(described_class.default?(request("GET", path))).to be(true)
+    end
+
+    it "returns true for giving feedback on an answer" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}/answers/#{SecureRandom.uuid}/feedback"
+
+      expect(described_class.default?(request("POST", path))).to be(true)
+    end
+
+    it "returns false for creating a conversation" do
+      expect(described_class.default?(request("POST", "/api/v1/conversation"))).to be(false)
+    end
+
+    it "returns false for updating a conversation" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}"
+
+      expect(described_class.default?(request("PUT", path))).to be(false)
+    end
+
+    it "returns true for a conversation write path used with an unexpected method" do
+      path = "/api/v1/conversation/#{SecureRandom.uuid}"
+
+      expect(described_class.default?(request("POST", path))).to be(true)
+    end
+
+    it "returns false for requests outside the conversations API" do
+      expect(described_class.default?(request("GET", "/api/v1/something-else"))).to be(false)
+    end
+  end
+
+  def request(method, path)
+    Rack::Request.new(Rack::MockRequest.env_for(path, method:))
+  end
+end

--- a/spec/requests/api/middleware_spec.rb
+++ b/spec/requests/api/middleware_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe "API middleware" do
   end
 
   describe "rate limits", :rack_attack do
-    describe "/api/v1/conversations read rate limits" do
-      it "treats get, head and options as read requests with rate limits" do
-        %i[get head options].each do |method|
+    describe "default rate limits" do
+      it "applies to reads and to writes that don't create or update a conversation" do
+        %i[get head options post].each do |method|
           public_send(method, "/api/v1/conversations/404")
 
           expect(response).to have_http_status(:not_found)
@@ -76,8 +76,8 @@ RSpec.describe "API middleware" do
 
       context "when an API user has exhausted their limit" do
         before do
-          read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME]
-          allow(read_throttle).to receive(:limit).and_return(1)
+          default_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME]
+          allow(default_throttle).to receive(:limit).and_return(1)
 
           get "/api/v1/conversations/404"
         end
@@ -89,8 +89,8 @@ RSpec.describe "API middleware" do
         headers = { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-123" }
 
         before do
-          read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_READ_THROTTLE_NAME]
-          allow(read_throttle).to receive(:limit).and_return(1)
+          default_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_DEFAULT_THROTTLE_NAME]
+          allow(default_throttle).to receive(:limit).and_return(1)
 
           get "/api/v1/conversations/404", headers:
         end
@@ -99,52 +99,52 @@ RSpec.describe "API middleware" do
       end
     end
 
-    describe "/api/v1/conversations write rate limits" do
-      it "treats non read requests as write requests with rate limits" do
-        %i[post put patch delete].each do |method|
-          public_send(method, "/api/v1/conversations/404")
+    describe "conversation write rate limits" do
+      it "applies to creating and updating a conversation" do
+        { post: "/api/v1/conversation", put: "/api/v1/conversation/404" }.each do |method, path|
+          public_send(method, path)
 
-          expect(response).to have_http_status(:not_found)
+          expect(response).to have_http_status(:bad_request)
           expect(response.headers).to include_rate_limit_headers("api-user-write")
         end
       end
 
       it "doesn't return end user rate limits in the headers by default" do
-        post "/api/v1/conversations/404"
+        post "/api/v1/conversation"
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:bad_request)
         expect(response.headers).not_to include_rate_limit_headers("end-user-id-write")
       end
 
       it "does return end user rate limits if an end user id is provided" do
-        post "/api/v1/conversations/404", headers: { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-456" }
+        post "/api/v1/conversation", headers: { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-456" }
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:bad_request)
         expect(response.headers).to include_rate_limit_headers("end-user-id-write")
       end
 
       context "when an API user has exhausted their limit" do
         before do
-          write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME]
-          allow(write_throttle).to receive(:limit).and_return(1)
+          conversation_write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME]
+          allow(conversation_write_throttle).to receive(:limit).and_return(1)
 
-          post "/api/v1/conversations/404"
+          post "/api/v1/conversation"
         end
 
-        include_examples "rate limit applied", :post, "/api/v1/conversations/404", "api-user-write"
+        include_examples "rate limit applied", :post, "/api/v1/conversation", "api-user-write"
       end
 
       context "when an end user has exhausted their limit" do
         headers = { "HTTP_GOVUK_CHAT_END_USER_ID" => "test-user-123" }
 
         before do
-          write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_WRITE_THROTTLE_NAME]
-          allow(write_throttle).to receive(:limit).and_return(1)
+          conversation_write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_END_USER_CONVERSATION_WRITE_THROTTLE_NAME]
+          allow(conversation_write_throttle).to receive(:limit).and_return(1)
 
-          post "/api/v1/conversations/404", headers:
+          post "/api/v1/conversation", headers:
         end
 
-        include_examples "rate limit applied", :post, "/api/v1/conversations/404", "end-user-id-write", headers:
+        include_examples "rate limit applied", :post, "/api/v1/conversation", "end-user-id-write", headers:
       end
     end
   end

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Api::V1::ConversationsController" do
     let(:route_params) { {} }
 
     before do
-      read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_READ_THROTTLE_NAME]
+      read_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_DEFAULT_THROTTLE_NAME]
       allow(read_throttle).to receive(:limit).and_return(1)
-      write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_WRITE_THROTTLE_NAME]
+      write_throttle = Rack::Attack.throttles[Api::RateLimit::GOVUK_API_USER_CONVERSATION_WRITE_THROTTLE_NAME]
       allow(write_throttle).to receive(:limit).and_return(1)
     end
 


### PR DESCRIPTION
## Description 

This PR updates our rate limiting strategy for the API. Previously, we used HTTP methods to implement read and write rate limits.

Instead we now use conversation write ad default limits. The conversation write covers interactions that trigger model inference as part of the requests since those are the expensive requests. All other requests now fall under the default rate limits.

The motivation for this change was that we added feedback endpoints to the API and if a user rapidly gave feedback there was a slightly concern they could hit the write rate limit and stop answer generation. 

The feedback endpoints don't invoke models and while they do interact with the DB, our Postgres instance has been load tested sufficiently for it not be an attack vector of concern.

In terms of implementation the Jira ticket calls out that the App team shouldn't be affected by this change. Due to this
constraint we've retained the same header names (read and write) which could be slightly misleading.

I did consider sending additional headers (`conversation-write` and `default`) so that we could do something like:

1. send duplicate headers
2. allow the app team to migrate to using the new headers
3. removing the older headers

In reality we're going to be moving to Chat V2 which will likely move to new headers so for now it makes sense not to cause any integration issues and retain the existing header structure.

Our codebase has been updated to reflect the change (naming of methods etc.) and the OpenAPI spec has documented the changes to the rate limits though.


## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-968