### PR TITLE
[CHAT-904] Add answer analysis request type

### DIFF
--- a/app/jobs/answer_analysis/tag_request_types_job.rb
+++ b/app/jobs/answer_analysis/tag_request_types_job.rb
@@ -1,0 +1,31 @@
+module AnswerAnalysis
+  class TagRequestTypesJob < BaseJob
+    def perform(answer_id)
+      answer = Answer.includes(:request_types, question: :conversation).find_by(id: answer_id)
+
+      return logger.warn("No answer found for #{answer_id}") unless answer
+      if answer.request_types.present?
+        return logger.warn("Answer #{answer_id} has already been tagged with request types")
+      end
+      unless answer.eligible_for_request_type_analysis?
+        return logger.info("Answer #{answer_id} is not eligible for request type analysis")
+      end
+      return if quota_limit_reached?
+
+      result = AutoEvaluation::RequestTypeTagger.call(answer.question_used)
+
+      request_types = answer.build_request_types(
+        status: result.status,
+        primary_request_type: result.primary_request_type,
+        secondary_request_type: result.secondary_request_type,
+        confidence: result.confidence,
+        reasoning: result.reasoning,
+        error_message: result.error_message,
+      )
+      request_types.assign_metrics("request_type_tagger", result.metrics)
+      request_types.assign_llm_response("request_type_tagger", result.llm_response)
+
+      request_types.save!
+    end
+  end
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -49,6 +49,13 @@ class Answer < ApplicationRecord
     guardrails_jailbreak
   ].freeze
 
+  QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS = %w[
+    advice_opinions_predictions
+    genuine_rag
+    requires_account_data
+    unclear_intent
+  ].freeze
+
   scope :aggregate_status, ->(status) { where("SPLIT_PART(status::TEXT, '_', 1) = ?", status) }
 
   after_commit :send_answer_count_to_prometheus, on: :create
@@ -189,6 +196,10 @@ class Answer < ApplicationRecord
 
   def eligible_for_topic_analysis?
     STATUSES_EXCLUDED_FROM_TOPIC_ANALYSIS.exclude?(status)
+  end
+
+  def eligible_for_request_type_analysis?
+    question_routing_label.in?(QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS)
   end
 
   def set_sources_as_unused

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -57,6 +57,7 @@ class Answer < ApplicationRecord
   has_one :feedback, class_name: "AnswerFeedback", dependent: :destroy, strict_loading: false
   has_many :sources, -> { order(relevancy: :asc) }, class_name: "AnswerSource"
   has_one :topics, class_name: "AnswerAnalysis::Topics"
+  has_one :request_types, class_name: "AnswerAnalysis::RequestTypes"
   has_many :answer_relevancy_runs,
            -> { order(:created_at) },
            class_name: "AnswerAnalysis::AnswerRelevancyRun"

--- a/app/models/answer_analysis/request_types.rb
+++ b/app/models/answer_analysis/request_types.rb
@@ -1,0 +1,10 @@
+class AnswerAnalysis::RequestTypes < ApplicationRecord
+  include LlmCallsRecordable
+  include AutoEvaluationResultsExportable
+
+  self.table_name = "answer_analysis_request_types"
+
+  belongs_to :answer
+
+  enum :status, { success: "success", error: "error" }
+end

--- a/db/migrate/20260902102436_create_answer_analysis_request_types.rb
+++ b/db/migrate/20260902102436_create_answer_analysis_request_types.rb
@@ -1,0 +1,19 @@
+class CreateAnswerAnalysisRequestTypes < ActiveRecord::Migration[8.1]
+  def change
+    create_enum :answer_analysis_request_types_status, %w[success error]
+
+    create_table :answer_analysis_request_types, id: :uuid do |t|
+      t.references :answer, type: :uuid, null: false, index: { unique: true }, foreign_key: { on_delete: :cascade }
+      t.string :primary_request_type
+      t.string :secondary_request_type
+      t.decimal :confidence
+      t.string :reasoning
+      t.enum :status, default: "success", null: false, enum_type: "answer_analysis_request_types_status"
+      t.string :error_message
+      t.jsonb :metrics, default: {}, null: false
+      t.jsonb :llm_responses, default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_102436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -18,6 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_090000) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "answer_analysis_request_types_status", ["success", "error"]
   create_enum "answer_analysis_run_status", ["success", "failure", "error"]
   create_enum "answer_analysis_topics_status", ["success", "error"]
   create_enum "answer_completeness", ["complete", "partial", "no_information"]
@@ -77,6 +78,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_090000) do
     t.enum "status", default: "success", null: false, enum_type: "answer_analysis_run_status"
     t.datetime "updated_at", null: false
     t.index ["answer_id"], name: "index_answer_analysis_faithfulness_runs_on_answer_id"
+  end
+
+  create_table "answer_analysis_request_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "answer_id", null: false
+    t.decimal "confidence"
+    t.datetime "created_at", null: false
+    t.string "error_message"
+    t.jsonb "llm_responses", default: {}, null: false
+    t.jsonb "metrics", default: {}, null: false
+    t.string "primary_request_type"
+    t.string "reasoning"
+    t.string "secondary_request_type"
+    t.enum "status", default: "success", null: false, enum_type: "answer_analysis_request_types_status"
+    t.datetime "updated_at", null: false
+    t.index ["answer_id"], name: "index_answer_analysis_request_types_on_answer_id", unique: true
   end
 
   create_table "answer_analysis_topics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -232,6 +248,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_090000) do
   add_foreign_key "answer_analysis_coherence_runs", "answers", on_delete: :cascade
   add_foreign_key "answer_analysis_context_relevancy_runs", "answers", on_delete: :cascade
   add_foreign_key "answer_analysis_faithfulness_runs", "answers", on_delete: :cascade
+  add_foreign_key "answer_analysis_request_types", "answers", on_delete: :cascade
   add_foreign_key "answer_analysis_topics", "answers", on_delete: :cascade
   add_foreign_key "answer_feedback", "answers", on_delete: :cascade
   add_foreign_key "answer_sources", "answer_source_chunks", on_delete: :restrict

--- a/lib/answer_analysis.rb
+++ b/lib/answer_analysis.rb
@@ -1,6 +1,7 @@
 module AnswerAnalysis
   def self.enqueue_async_analysis(answer)
     TagTopicsJob.perform_later(answer.id)
+    TagRequestTypesJob.perform_later(answer.id)
     AnswerRelevancyJob.perform_later(answer.id)
     CoherenceJob.perform_later(answer.id)
     FaithfulnessJob.perform_later(answer.id)

--- a/lib/auto_evaluation/request_type_tagger.rb
+++ b/lib/auto_evaluation/request_type_tagger.rb
@@ -1,0 +1,71 @@
+module AutoEvaluation
+  class RequestTypeTagger
+    Result = Data.define(
+      :status,
+      :primary_request_type,
+      :secondary_request_type,
+      :confidence,
+      :reasoning,
+      :metrics,
+      :llm_response,
+      :error_message,
+    ) do
+      def initialize(status:,
+                     primary_request_type:,
+                     secondary_request_type:,
+                     confidence:,
+                     reasoning:,
+                     metrics:,
+                     llm_response:,
+                     error_message: nil)
+        super
+      end
+    end
+
+    def self.call(...) = new(...).call
+
+    def initialize(user_question)
+      @user_question = user_question
+    end
+
+    def call
+      result = BedrockOpenAIOssInvoke.call(user_message: user_question, tool:, system_prompt:)
+      Result.new(
+        status: "success",
+        primary_request_type: result.evaluation_data.fetch("primary_label").downcase,
+        secondary_request_type: result.evaluation_data.fetch("secondary_label")&.downcase,
+        confidence: result.evaluation_data.fetch("confidence"),
+        reasoning: result.evaluation_data.fetch("reasoning"),
+        metrics: result.metrics,
+        llm_response: result.llm_response,
+      )
+    rescue AutoEvaluation::BedrockOpenAIOssInvoke::InvalidLlmResponseError => e
+      Result.new(
+        status: "error",
+        primary_request_type: nil,
+        secondary_request_type: nil,
+        confidence: nil,
+        reasoning: nil,
+        metrics: {},
+        llm_response: {},
+        error_message: e.message,
+      )
+    end
+
+  private
+
+    attr_reader :user_question
+
+    def request_type_config
+      Prompts.config.request_type
+    end
+
+    def system_prompt
+      request_type_config.fetch("system_prompt")
+    end
+
+    def tool
+      request_type_config.fetch("tool_spec")
+    end
+  end
+end

--- a/lib/bigquery.rb
+++ b/lib/bigquery.rb
@@ -5,6 +5,7 @@ module Bigquery
     ExportTable.new(name: "questions", time_partitioning_field: "created_at", model: Question),
     ExportTable.new(name: "answer_feedback", time_partitioning_field: "created_at", model: AnswerFeedback),
     ExportTable.new(name: "answer_analysis_topics", time_partitioning_field: "created_at", model: AnswerAnalysis::Topics),
+    ExportTable.new(name: "answer_analysis_request_types", time_partitioning_field: "created_at", model: AnswerAnalysis::RequestTypes),
     ExportTable.new(name: "answer_analysis_answer_relevancy_runs", time_partitioning_field: "created_at", model: AnswerAnalysis::AnswerRelevancyRun),
     ExportTable.new(name: "answer_analysis_coherence_runs", time_partitioning_field: "created_at", model: AnswerAnalysis::CoherenceRun),
     ExportTable.new(name: "answer_analysis_context_relevancy_runs", time_partitioning_field: "created_at", model: AnswerAnalysis::ContextRelevancyRun),

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -96,6 +96,14 @@ namespace :evaluation do
     puts(result.to_json)
   end
 
+  desc "Produce request types for a user question"
+  task generate_request_types_for_question: :environment do
+    raise "Requires an INPUT env var" if ENV["INPUT"].blank?
+
+    result = AutoEvaluation::RequestTypeTagger.call(ENV["INPUT"])
+    puts(result.to_json)
+  end
+
   desc "Batch process a YAML file of questions using any single-input rake task"
   task :batch_process, %i[task_name] => :environment do |task, args|
     input_path, output_path, concurrency = ENV.values_at("INPUT_PATH", "OUTPUT_PATH", "CONCURRENCY")

--- a/spec/factories/answer_analysis_request_types.rb
+++ b/spec/factories/answer_analysis_request_types.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :answer_analysis_request_types, class: "AnswerAnalysis::RequestTypes" do
+    answer
+    primary_request_type { "factual_lookup" }
+    secondary_request_type { "do_task" }
+    confidence { 0.9 }
+    reasoning { "The user is asking for a specific figure." }
+  end
+end

--- a/spec/factories/answer_factory.rb
+++ b/spec/factories/answer_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     sources { [] }
     feedback { nil }
     topics { nil }
+    request_types { nil }
 
     trait :with_sources do
       sources do
@@ -31,6 +32,10 @@ FactoryBot.define do
 
     trait :with_topics do
       topics { build(:answer_analysis_topics) }
+    end
+
+    trait :with_request_types do
+      request_types { build(:answer_analysis_request_types) }
     end
   end
 end

--- a/spec/jobs/answer_analysis/tag_request_types_job_spec.rb
+++ b/spec/jobs/answer_analysis/tag_request_types_job_spec.rb
@@ -1,0 +1,127 @@
+RSpec.describe AnswerAnalysis::TagRequestTypesJob do
+  include ActiveJob::TestHelper
+  let(:eligible_question_routing_label) { Answer::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS.sample }
+  let(:answer) { create(:answer, question_routing_label: eligible_question_routing_label) }
+  let(:question) { answer.question }
+  let(:request_type_tagger_result) do
+    AutoEvaluation::RequestTypeTagger::Result.new(
+      status: status,
+      primary_request_type: "factual_lookup",
+      secondary_request_type: "do_task",
+      confidence: 0.9,
+      reasoning: "The user is asking for a specific figure.",
+      metrics: {
+        "duration" => 1.5,
+        "model" => "some-model",
+      },
+      llm_response: {
+        "model" => "some-model",
+      },
+      error_message:,
+    )
+  end
+  let(:status) { "success" }
+  let(:error_message) { nil }
+
+  before do
+    allow(AutoEvaluation::RequestTypeTagger).to receive(:call).and_return(request_type_tagger_result)
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  it_behaves_like "a job in queue", "default"
+  it_behaves_like "a job that adheres to the auto_evaluation quota",
+                  AutoEvaluation::RequestTypeTagger,
+                  { question_routing_label: :genuine_rag }
+  it_behaves_like "a job that retries on aws sdk errors",
+                  AutoEvaluation::RequestTypeTagger,
+                  { question_routing_label: :genuine_rag }
+
+  describe "#perform" do
+    it "calls the AutoEvaluation::RequestTypeTagger with the answer message" do
+      described_class.new.perform(answer.id)
+      expect(AutoEvaluation::RequestTypeTagger).to have_received(:call).with(question.message)
+    end
+
+    it "creates request types for the answer based of the returned result" do
+      expect {
+        described_class.new.perform(answer.id)
+      }.to change(AnswerAnalysis::RequestTypes, :count).by(1)
+      expect(answer.reload.request_types)
+        .to have_attributes(
+          status: request_type_tagger_result.status,
+          primary_request_type: request_type_tagger_result.primary_request_type,
+          secondary_request_type: request_type_tagger_result.secondary_request_type,
+          confidence: request_type_tagger_result.confidence,
+          reasoning: request_type_tagger_result.reasoning,
+          metrics: { "request_type_tagger" => request_type_tagger_result.metrics },
+          llm_responses: { "request_type_tagger" => request_type_tagger_result.llm_response },
+          error_message: nil,
+        )
+    end
+
+    context "when the AutoEvaluation::RequestTypeTagger returns an error status and error message" do
+      let(:status) { "error" }
+      let(:error_message) { "An error occurred during request type tagging" }
+
+      it "creates request types with the error status and error message" do
+        described_class.new.perform(answer.id)
+        expect(answer.reload.request_types)
+          .to have_attributes(
+            status: status,
+            error_message: error_message,
+          )
+      end
+    end
+
+    context "when the answer does not exist" do
+      let(:answer_id) { 999 }
+
+      it "logs a warning" do
+        expect(described_class.logger)
+          .to receive(:warn)
+          .with("No answer found for #{answer_id}")
+
+        described_class.new.perform(answer_id)
+      end
+
+      it "doesn't call the AutoEvaluation::RequestTypeTagger" do
+        described_class.new.perform(answer_id)
+        expect(AutoEvaluation::RequestTypeTagger).not_to have_received(:call)
+      end
+    end
+
+    context "when request types have been tagged" do
+      let(:answer) do
+        create(:answer, :with_request_types, question_routing_label: eligible_question_routing_label)
+      end
+
+      it "logs a warning" do
+        expect(described_class.logger)
+          .to receive(:warn)
+          .with("Answer #{answer.id} has already been tagged with request types")
+
+        described_class.new.perform(answer.id)
+      end
+    end
+
+    context "when the answer is not eligible for request type analysis" do
+      let(:ineligible_question_routing_labels) do
+        Answer.question_routing_labels.keys - Answer::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS
+      end
+      let(:answer) { create(:answer, question_routing_label: ineligible_question_routing_labels.sample) }
+
+      it "logs an info message" do
+        expect(described_class.logger)
+          .to receive(:info)
+          .with("Answer #{answer.id} is not eligible for request type analysis")
+
+        described_class.new.perform(answer.id)
+      end
+
+      it "does not call the AutoEvaluation::RequestTypeTagger" do
+        expect(AutoEvaluation::RequestTypeTagger).not_to receive(:call)
+        described_class.new.perform(answer.id)
+      end
+    end
+  end
+end

--- a/spec/lib/answer_analysis_spec.rb
+++ b/spec/lib/answer_analysis_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe AnswerAnalysis do
     it "enqueues the analysis jobs" do
       answer = build(:answer)
       expect(described_class::TagTopicsJob).to receive(:perform_later).with(answer.id)
+      expect(described_class::TagRequestTypesJob).to receive(:perform_later).with(answer.id)
       expect(described_class::AnswerRelevancyJob).to receive(:perform_later).with(answer.id)
       expect(described_class::CoherenceJob).to receive(:perform_later).with(answer.id)
       expect(described_class::FaithfulnessJob).to receive(:perform_later).with(answer.id)

--- a/spec/lib/auto_evaluation/request_type_tagger_spec.rb
+++ b/spec/lib/auto_evaluation/request_type_tagger_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe AutoEvaluation::RequestTypeTagger, :aws_credentials_stubbed do
+  describe ".call" do
+    let(:user_question) { "This is a test message." }
+    let!(:request_type_tagger_stub) { stub_bedrock_invoke_model_openai_oss_request_type_tagger(user_question) }
+
+    it "returns a results object with the expected request types" do
+      result = described_class.call(user_question)
+      expect(result)
+        .to be_a(AutoEvaluation::RequestTypeTagger::Result)
+        .and have_attributes(
+          status: "success",
+          primary_request_type: "factual_lookup",
+          secondary_request_type: "do_task",
+          confidence: 0.9,
+          reasoning: "reason",
+        )
+    end
+
+    context "when the LLM does not return a secondary label" do
+      let!(:request_type_tagger_stub) do
+        stub_bedrock_invoke_model_openai_oss_request_type_tagger(
+          user_question,
+          llm_response: {
+            primary_label: "FACTUAL_LOOKUP",
+            secondary_label: nil,
+            confidence: 0.9,
+            reasoning: "reason",
+          },
+        )
+      end
+
+      it "returns a results object without a secondary request type" do
+        result = described_class.call(user_question)
+        expect(result).to have_attributes(
+          primary_request_type: "factual_lookup",
+          secondary_request_type: nil,
+        )
+      end
+    end
+
+    it "returns a results object with the LLM response" do
+      result = described_class.call(user_question)
+      expected_llm_response = JSON.parse(request_type_tagger_stub.response.body)
+      expect(result.llm_response).to eq(expected_llm_response.to_h)
+    end
+
+    it "returns a results object with the metrics" do
+      allow(Clock).to receive(:monotonic_time).and_return(100.0, 101.5)
+      result = described_class.call(user_question)
+
+      expect(result.metrics)
+        .to eq({
+          duration: 1.5,
+          llm_prompt_tokens: 25,
+          llm_completion_tokens: 35,
+          llm_cached_tokens: 10,
+          model: BedrockModels.model_id(:openai_gpt_oss_120b),
+        })
+    end
+
+    it "returns an error result if an InvalidLlmResponseError is raised" do
+      allow(AutoEvaluation::BedrockOpenAIOssInvoke)
+        .to receive(:call)
+        .and_raise(AutoEvaluation::BedrockOpenAIOssInvoke::InvalidLlmResponseError.new("invalid tool output"))
+
+      result = described_class.call(user_question)
+
+      expect(result).to have_attributes(
+        status: "error",
+        error_message: "invalid tool output",
+        primary_request_type: nil,
+        secondary_request_type: nil,
+        confidence: nil,
+        reasoning: nil,
+        metrics: {},
+        llm_response: {},
+      )
+    end
+  end
+end

--- a/spec/lib/tasks/bigquery_spec.rb
+++ b/spec/lib/tasks/bigquery_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "rake bigquery tasks" do
       answer = create(:answer, created_at: 1.hour.ago)
       create(:answer_feedback, created_at: 1.hour.ago, answer:)
       create(:answer_analysis_topics, created_at: 1.hour.ago, answer:)
+      create(:answer_analysis_request_types, created_at: 1.hour.ago, answer:)
       %w[answer_relevancy_run coherence_run context_relevancy_run faithfulness_run].each do |run_type|
         create(run_type, created_at: 1.hour.ago, answer:)
       end
@@ -38,6 +39,7 @@ RSpec.describe "rake bigquery tasks" do
         "questions" => 1,
         "answer_feedback" => 1,
         "answer_analysis_topics" => 1,
+        "answer_analysis_request_types" => 1,
         "answer_analysis_answer_relevancy_runs" => 1,
         "answer_analysis_coherence_runs" => 1,
         "answer_analysis_context_relevancy_runs" => 1,

--- a/spec/lib/tasks/data_retention_spec.rb
+++ b/spec/lib/tasks/data_retention_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "rake data_retention tasks" do
         answer_relevancy_run
         answer_feedback
         answer_analysis_topics
+        answer_analysis_request_types
       ].each do |model|
         create(model, answer:)
       end
@@ -31,6 +32,7 @@ RSpec.describe "rake data_retention tasks" do
         .and change(AnswerAnalysis::AnswerRelevancyRun, :count).by(-1)
         .and change(AnswerFeedback, :count).by(-1)
         .and change(AnswerAnalysis::Topics, :count).by(-1)
+        .and change(AnswerAnalysis::RequestTypes, :count).by(-1)
         .and not_change(Conversation, :count)
         .and output("\"1 question and associated data deleted\"\n\"0 conversations deleted\"\n").to_stdout
     end

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -383,6 +383,33 @@ RSpec.describe "rake evaluation tasks" do
     end
   end
 
+  describe "generate_request_types_for_question" do
+    let(:task_name) { "evaluation:generate_request_types_for_question" }
+    let(:input) { "User question" }
+
+    before { Rake::Task[task_name].reenable }
+
+    it_behaves_like "a task requiring an input"
+
+    it "outputs the response as JSON to stdout" do
+      ClimateControl.modify(INPUT: input) do
+        result = AutoEvaluation::RequestTypeTagger::Result.new(
+          status: "success",
+          primary_request_type: "factual_lookup",
+          secondary_request_type: "do_task",
+          confidence: 0.9,
+          reasoning: "The user is asking for a specific figure.",
+          metrics: {},
+          llm_response: {},
+        )
+        allow(AutoEvaluation::RequestTypeTagger).to receive(:call).with(input).and_return(result)
+
+        expect { Rake::Task[task_name].invoke }
+          .to output("#{result.to_json}\n").to_stdout
+      end
+    end
+  end
+
   describe "batch_process" do
     let(:task_name) { "evaluation:batch_process" }
     let(:usage_regex) { /#{Regexp.escape('Usage: evaluation:batch_process[task_name, *task_args]')}/ }

--- a/spec/models/answer_analysis/request_types_spec.rb
+++ b/spec/models/answer_analysis/request_types_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe AnswerAnalysis::RequestTypes do
+  include_examples "llm calls recordable" do
+    let(:model) { build(:answer_analysis_request_types) }
+  end
+
+  it_behaves_like "exportable by start and end date" do
+    let(:conversation) { create(:conversation) }
+    let(:question) { create(:question, conversation:) }
+    let(:answer) { create(:answer, question:) }
+    let(:create_record_lambda) { ->(time) { create(:answer_analysis_request_types, created_at: time) } }
+  end
+
+  describe "#serialize for export" do
+    it "returns a request type serialized as json" do
+      request_types = create(:answer_analysis_request_types)
+      expect(request_types.serialize_for_export).to eq(request_types.as_json)
+    end
+
+    it "converts the llm_responses to unparsed JSON" do
+      llm_responses = { "some" => "response" }
+      request_types = create(:answer_analysis_request_types, llm_responses:)
+      expected_response = request_types.as_json.merge("llm_responses" => llm_responses.to_json)
+      expect(request_types.serialize_for_export).to eq(expected_response)
+    end
+  end
+end

--- a/spec/models/answer_analysis/request_types_spec.rb
+++ b/spec/models/answer_analysis/request_types_spec.rb
@@ -16,11 +16,8 @@ RSpec.describe AnswerAnalysis::RequestTypes do
       expect(request_types.serialize_for_export).to eq(request_types.as_json)
     end
 
-    it "converts the llm_responses to unparsed JSON" do
-      llm_responses = { "some" => "response" }
-      request_types = create(:answer_analysis_request_types, llm_responses:)
-      expected_response = request_types.as_json.merge("llm_responses" => llm_responses.to_json)
-      expect(request_types.serialize_for_export).to eq(expected_response)
+    it_behaves_like "serializes llm_responses as unparsed JSON" do
+      let(:factory_name) { :answer_analysis_request_types }
     end
   end
 end

--- a/spec/models/answer_analysis/topics_spec.rb
+++ b/spec/models/answer_analysis/topics_spec.rb
@@ -16,11 +16,8 @@ RSpec.describe AnswerAnalysis::Topics do
       expect(topics.serialize_for_export).to eq(topics.as_json)
     end
 
-    it "converts the llm_responses to unparsed JSON" do
-      llm_responses = { "some" => "response" }
-      topics = create(:answer_analysis_topics, llm_responses:)
-      expected_response = topics.as_json.merge("llm_responses" => llm_responses.to_json)
-      expect(topics.serialize_for_export).to eq(expected_response)
+    it_behaves_like "serializes llm_responses as unparsed JSON" do
+      let(:factory_name) { :answer_analysis_topics }
     end
   end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -188,20 +188,8 @@ RSpec.describe Answer do
         .and include("sources" => answer.sources.map(&:serialize_for_export))
     end
 
-    it "converts the llm_responses to unparsed JSON" do
-      answer = create(
-        :answer,
-        llm_responses: {
-          "question_routing" => { some: "hash" },
-          "structured_answer" => { another: "hash" },
-        },
-      )
-
-      expected_response = answer.as_json.merge(
-        "llm_responses" => answer.llm_responses.to_json,
-        "sources" => [],
-      )
-      expect(answer.serialize_for_export).to eq(expected_response)
+    it_behaves_like "serializes llm_responses as unparsed JSON" do
+      let(:factory_name) { :answer }
     end
   end
 

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -396,6 +396,30 @@ RSpec.describe Answer do
     end
   end
 
+  describe "#eligible_for_request_type_analysis?" do
+    described_class::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS.each do |label|
+      it "returns true for answers with the #{label} question routing label" do
+        answer = build(:answer, question_routing_label: label)
+        expect(answer.eligible_for_request_type_analysis?).to be(true)
+      end
+    end
+
+    ineligible_labels = described_class.question_routing_labels.keys -
+      described_class::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS
+
+    ineligible_labels.each do |label|
+      it "returns false for answers with the #{label} question routing label" do
+        answer = build(:answer, question_routing_label: label)
+        expect(answer.eligible_for_request_type_analysis?).to be(false)
+      end
+    end
+
+    it "returns false for answers without a question routing label" do
+      answer = build(:answer, question_routing_label: nil)
+      expect(answer.eligible_for_request_type_analysis?).to be(false)
+    end
+  end
+
   describe "#has_analysis?" do
     it "returns true if topics are present" do
       answer = build(:answer, :with_topics)

--- a/spec/support/auto_evaluation_examples.rb
+++ b/spec/support/auto_evaluation_examples.rb
@@ -7,19 +7,8 @@ shared_examples "auto evaluation exportable runs" do
       expect(record.serialize_for_export).to eq(record.as_json)
     end
 
-    it "converts the llm_responses to unparsed JSON when present" do
-      record = build(
-        run_factory_name,
-        llm_responses: {
-          "verdicts" => { "verdicts" => [{ "verdict" => "yes" }] },
-          "reason" => { "reason" => "This is the reason for the score." },
-        },
-      )
-
-      expected = record.as_json.merge(
-        "llm_responses" => record.llm_responses.to_json,
-      )
-      expect(record.serialize_for_export).to eq(expected)
+    it_behaves_like "serializes llm_responses as unparsed JSON" do
+      let(:factory_name) { run_factory_name }
     end
   end
 

--- a/spec/support/exportable_model_examples.rb
+++ b/spec/support/exportable_model_examples.rb
@@ -17,4 +17,14 @@ module ExportableModelExamples
       expect(exportable_records).to eq([])
     end
   end
+
+  shared_examples "serializes llm_responses as unparsed JSON" do
+    it "converts the llm_responses to unparsed JSON" do
+      llm_responses = { "some" => { "llm" => "response" } }
+      record = build(factory_name, llm_responses:)
+
+      expect(record.serialize_for_export)
+        .to include("llm_responses" => llm_responses.to_json)
+    end
+  end
 end

--- a/spec/support/job_examples.rb
+++ b/spec/support/job_examples.rb
@@ -5,8 +5,8 @@ module JobExamples
     end
   end
 
-  shared_examples "a job that adheres to the auto_evaluation quota" do |evaluation_class|
-    let(:answer) { create(:answer) }
+  shared_examples "a job that adheres to the auto_evaluation quota" do |evaluation_class, answer_attributes = {}|
+    let(:answer) { create(:answer, **answer_attributes) }
     let(:beginning_of_current_hour) { Time.current.beginning_of_hour }
 
     it "writes the auto_evaluations_count cache key on the first evaluation" do
@@ -51,14 +51,14 @@ module JobExamples
       end
 
       travel_to(beginning_of_current_hour + 30.minutes) do
-        answer_in_same_hour = create(:answer)
+        answer_in_same_hour = create(:answer, **answer_attributes)
         described_class.new.perform(answer_in_same_hour.id)
         key = "auto_evaluations_count_#{beginning_of_current_hour.to_i}"
         expect(Rails.cache.read(key)).to eq(2)
       end
 
       travel_to(beginning_of_current_hour + 1.hour) do
-        answer_in_next_hour = create(:answer)
+        answer_in_next_hour = create(:answer, **answer_attributes)
         described_class.new.perform(answer_in_next_hour.id)
         key = "auto_evaluations_count_#{(beginning_of_current_hour + 1.hour).to_i}"
         expect(Rails.cache.read(key)).to eq(1)
@@ -76,8 +76,8 @@ module JobExamples
     end
   end
 
-  shared_examples "a job that retries on aws sdk errors" do |evaluation_class|
-    let(:answer) { create(:answer) }
+  shared_examples "a job that retries on aws sdk errors" do |evaluation_class, answer_attributes = {}|
+    let(:answer) { create(:answer, **answer_attributes) }
     errors = [
       Aws::Errors::ServiceError.new(nil, "error"),
       Seahorse::Client::NetworkingError.new(StandardError.new),

--- a/spec/support/stub_bedrock.rb
+++ b/spec/support/stub_bedrock.rb
@@ -333,6 +333,31 @@ module StubBedrock
     )
   end
 
+  def stub_bedrock_invoke_model_openai_oss_request_type_tagger(user_question,
+                                                               llm_response: {
+                                                                 primary_label: "FACTUAL_LOOKUP",
+                                                                 secondary_label: "DO_TASK",
+                                                                 confidence: 0.9,
+                                                                 reasoning: "reason",
+                                                               })
+    prompts = AutoEvaluation::Prompts.config.request_type
+
+    system_prompt = prompts.fetch(:system_prompt)
+    tool = prompts.fetch(:tool_spec)
+
+    stub_bedrock_invoke_model_openai_oss_tool_call(
+      user_question,
+      tool,
+      llm_response.to_json,
+      system_prompt:,
+      usage: {
+        completion_tokens: 35,
+        prompt_tokens: 25,
+        prompt_tokens_details: { cached_tokens: 10, total_tokens: 60 },
+      },
+    )
+  end
+
   def stub_bedrock_invoke_model_openai_oss_topic_tagger(user_question,
                                                         llm_response: {
                                                           primary_topic: "business",

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -56,6 +56,7 @@ module SystemSpecHelpers
 
     stub_claude_output_guardrails(answer)
     stub_bedrock_invoke_model_openai_oss_topic_tagger(question)
+    stub_bedrock_invoke_model_openai_oss_request_type_tagger(question)
     stub_bedrock_invoke_model_openai_oss_answer_relevancy(
       question_message: question,
       answer_message: answer,


### PR DESCRIPTION
## Description

This PR adds a new evaluation type to the answer analysis workflow. This captures the request type (intent). The implementation of this closely mirrors the topics one. The structure of the response we want to capture is pretty similar:

- There is a primary type and an optional secondary type
- It only runs once directly after an answer is generated
- It's association with answer in the same has_one/belongs_to
- We export it to BigQuery
- It was a similar rake task that can be used to generate the object
- It'll rendered in the admin UI in essentially the same way as topics

This PR adds all of the above with the exception of the Admin UI  work. That'll be handled in a follow-up PR.

## Example object

<img width="1728" height="395" alt="image" src="https://github.com/user-attachments/assets/fd97dd73-8626-4015-a2f8-5fa5c4249d9c" />

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-904