### PR TITLE
[CHAT-904] Add request type to the admin area

### DIFF
--- a/app/controllers/admin/metrics_controller.rb
+++ b/app/controllers/admin/metrics_controller.rb
@@ -128,6 +128,31 @@ class Admin::MetricsController < Admin::BaseController
     render json: combined_counts.chart_json
   end
 
+  def request_types
+    scope = AnswerAnalysis::RequestTypes.joins(:answer)
+                                        .where(answer: { created_at: start_time.. })
+
+    primary_request_type_scope = scope.where.not(primary_request_type: nil)
+                                      .group(:primary_request_type)
+
+    secondary_request_type_scope = scope.where.not(secondary_request_type: nil)
+                                        .group(:secondary_request_type)
+
+    if @period == :last_7_days
+      primary_request_type_counts = group_by_period(primary_request_type_scope, "answer.created_at").count
+      secondary_request_type_counts = group_by_period(secondary_request_type_scope, "answer.created_at").count
+    else
+      primary_request_type_counts = primary_request_type_scope.count
+      secondary_request_type_counts = secondary_request_type_scope.count
+    end
+
+    combined_counts = primary_request_type_counts.merge(secondary_request_type_counts) do |_name, primary_count, secondary_count|
+      primary_count + secondary_count
+    end
+
+    render json: combined_counts.chart_json
+  end
+
   def answer_completeness
     scope = Answer.where(created_at: start_time..)
                   .where.not(completeness: nil)

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -10,6 +10,7 @@ class Admin::QuestionsController < Admin::BaseController
       answer: [
         { sources: :chunk },
         :topics,
+        :request_types,
         :feedback,
         :answer_relevancy_runs,
         :coherence_runs,

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -43,6 +43,8 @@ private
       :end_user_id,
       :primary_topic,
       :secondary_topic,
+      :primary_request_type,
+      :secondary_request_type,
       :completeness,
       :conversation_session_id,
       :reaction,

--- a/app/models/admin/filters/questions_filter.rb
+++ b/app/models/admin/filters/questions_filter.rb
@@ -10,6 +10,8 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
   attribute :end_user_id
   attribute :primary_topic
   attribute :secondary_topic
+  attribute :primary_request_type
+  attribute :secondary_request_type
   attribute :completeness
   attribute :conversation_session_id
   attribute :reaction
@@ -31,7 +33,7 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
 
   def results
     @results ||= begin
-      scope = Question.includes(answer: %i[topics feedback])
+      scope = Question.includes(answer: %i[topics request_types feedback])
                       .left_outer_joins(:answer)
       scope = search_scope(scope)
       scope = status_scope(scope)
@@ -46,6 +48,8 @@ class Admin::Filters::QuestionsFilter < Admin::Filters::BaseFilter
       scope = conversation_session_id_scope(scope)
       scope = primary_topic_scope(scope)
       scope = secondary_topic_scope(scope)
+      scope = primary_request_type_scope(scope)
+      scope = secondary_request_type_scope(scope)
       scope = completeness_scope(scope)
       scope = reaction_scope(scope)
       scope.page(page)
@@ -81,6 +85,8 @@ private
     filters[:question_routing_label] = question_routing_label if question_routing_label.present?
     filters[:primary_topic] = primary_topic if primary_topic.present?
     filters[:secondary_topic] = secondary_topic if secondary_topic.present?
+    filters[:primary_request_type] = primary_request_type if primary_request_type.present?
+    filters[:secondary_request_type] = secondary_request_type if secondary_request_type.present?
     filters[:completeness] = completeness if completeness.present?
     filters[:conversation_session_id] = conversation_session_id if conversation_session_id.present?
     filters[:reaction] = reaction if reaction.present?
@@ -164,6 +170,20 @@ private
 
     scope.joins(answer: :topics)
          .where(answer_analysis_topics: { secondary_topic: secondary_topic })
+  end
+
+  def primary_request_type_scope(scope)
+    return scope if primary_request_type.blank?
+
+    scope.joins(answer: :request_types)
+         .where(answer_analysis_request_types: { primary_request_type: primary_request_type })
+  end
+
+  def secondary_request_type_scope(scope)
+    return scope if secondary_request_type.blank?
+
+    scope.joins(answer: :request_types)
+         .where(answer_analysis_request_types: { secondary_request_type: secondary_request_type })
   end
 
   def completeness_scope(scope)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -240,6 +240,7 @@ class Answer < ApplicationRecord
 
   def has_analysis?
     topics.present? ||
+      request_types.present? ||
       answer_relevancy_runs.present? ||
       faithfulness_runs.present? ||
       coherence_runs.present? ||

--- a/app/views/admin/metrics/index.html.erb
+++ b/app/views/admin/metrics/index.html.erb
@@ -57,6 +57,17 @@ common_chart_options = { refresh: 30 }
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
 <% end %>
 
+  <div class="<%= column_class %>" id="request-types">
+    <h2 class="govuk-heading-l">Request types</h2>
+    <% if @period == :last_7_days %>
+      <%= column_chart admin_metrics_request_types_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% else %>
+      <%= pie_chart admin_metrics_request_types_path(period: @period), **common_chart_options.merge(legend: legend_position) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="<%= column_class %>" id="answers-with-error-status">
     <h2 class="govuk-heading-l">Answers with error status</h2>
     <% if @period == :last_7_days %>

--- a/app/views/admin/questions/_analysis_tab.html.erb
+++ b/app/views/admin/questions/_analysis_tab.html.erb
@@ -27,45 +27,47 @@
               end
   %>
 
-  <%= render "govuk_publishing_components/components/summary_list", {
-    title: "Topics",
-    heading_size: "l",
-    heading_level: 2,
-    margin_bottom: 4,
-    items: items,
-  } %>
+  <%= render "tagging_analysis", title: "Topics", tagging: topics, items: %>
+<% end %>
 
-  <% if topics.llm_responses.present? %>
-    <%= render "govuk_publishing_components/components/details", {
-      title: "LLM responses",
-    } do %>
-      <% topics.llm_responses.each do |namespace, response| %>
-        <h3 class="govuk-heading-m"><%= namespace %></h3>
-        <p class="govuk-body">
-          <%= render("components/code_snippet", content: JSON.pretty_generate(response)) %>
-        </p>
-      <% end %>
-    <% end %>
-  <% end %>
+<% if request_types.present? %>
+  <%
+    items = [
+      {
+        field: "Status",
+        value: request_types.status.humanize,
+      },
+    ]
+    items +=  if request_types.success?
+                [
+                  {
+                    field: "Primary request type",
+                    value: request_types.primary_request_type.humanize,
+                  },
+                  {
+                    field: "Secondary request type",
+                    value: request_types.secondary_request_type&.humanize,
+                  },
+                  {
+                    field: "Confidence",
+                    value: request_types.confidence,
+                  },
+                  {
+                    field: "Reasoning",
+                    value: request_types.reasoning,
+                  },
+                ]
+              else
+                [
+                  {
+                    field: "Error",
+                    value: request_types.error_message,
+                  },
+                ]
+              end
+  %>
 
-  <% if topics.metrics.present? %>
-    <%= render "govuk_publishing_components/components/details", {
-      title: "Metrics",
-    } do %>
-      <% topics.metrics.sort.each do |namespace, metrics| %>
-        <%= render "govuk_publishing_components/components/summary_list", {
-          title: namespace,
-          items: metrics.map do |metric, value|
-            {
-              field: metric,
-              value: value,
-            }
-          end,
-          borderless: true,
-        } %>
-      <% end %>
-    <% end %>
-  <% end %>
+  <%= render "tagging_analysis", title: "Request types", tagging: request_types, items: %>
 <% end %>
 
 <% if answer_relevancy_runs.present? %>

--- a/app/views/admin/questions/_question_filters.html.erb
+++ b/app/views/admin/questions/_question_filters.html.erb
@@ -193,6 +193,36 @@
   } %>
 
   <%= render "govuk_publishing_components/components/select", {
+    id: "primary_request_type",
+    name: "primary_request_type",
+    label: "Primary request type",
+    heading_size: "s",
+    full_width: true,
+    options: [{text: "", value: ""}] + Rails.configuration.question_request_types.map do |request_type|
+      {
+       text: request_type.humanize,
+       value: request_type,
+       selected: params[:primary_request_type] == request_type,
+      }
+    end,
+  } %>
+
+  <%= render "govuk_publishing_components/components/select", {
+    id: "secondary_request_type",
+    name: "secondary_request_type",
+    label: "Secondary request type",
+    heading_size: "s",
+    full_width: true,
+    options: [{text: "", value: ""}] + Rails.configuration.question_request_types.map do |request_type|
+      {
+       text: request_type.humanize,
+       value: request_type,
+       selected: params[:secondary_request_type] == request_type,
+      }
+    end,
+  } %>
+
+  <%= render "govuk_publishing_components/components/select", {
     id: "completeness",
     name: "completeness",
     label: "Completeness",

--- a/app/views/admin/questions/_tagging_analysis.html.erb
+++ b/app/views/admin/questions/_tagging_analysis.html.erb
@@ -1,0 +1,39 @@
+<%= render "govuk_publishing_components/components/summary_list", {
+  title:,
+  heading_size: "l",
+  heading_level: 2,
+  margin_bottom: 4,
+  items: items,
+} %>
+
+<% if tagging.llm_responses.present? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "LLM responses",
+  } do %>
+    <% tagging.llm_responses.each do |namespace, response| %>
+      <h3 class="govuk-heading-m"><%= namespace %></h3>
+      <p class="govuk-body">
+        <%= render("components/code_snippet", content: JSON.pretty_generate(response)) %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if tagging.metrics.present? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Metrics",
+  } do %>
+    <% tagging.metrics.sort.each do |namespace, metrics| %>
+      <%= render "govuk_publishing_components/components/summary_list", {
+        title: namespace,
+        items: metrics.map do |metric, value|
+          {
+            field: metric,
+            value: value,
+          }
+        end,
+        borderless: true,
+      } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/questions/show.html.erb
+++ b/app/views/admin/questions/show.html.erb
@@ -39,6 +39,7 @@ content_for(:active_navigation_item, admin_questions_path)
     content: render(
       "analysis_tab",
       topics: @answer.topics,
+      request_types: @answer.request_types,
       answer_relevancy_runs: @answer.answer_relevancy_runs,
       coherence_runs: @answer.coherence_runs,
       faithfulness_runs: @answer.faithfulness_runs,

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,6 +91,15 @@ module GovukChat
                                              .topic_tagger
                                              .dig("tool_spec", "function", "parameters", "properties", "primary_topic", "enum")
                                              .sort
+
+    config.question_request_types = GovukChatPrivate.config
+                                                    .llm_prompts
+                                                    .auto_evaluation
+                                                    .request_type
+                                                    .dig("tool_spec", "function", "parameters", "properties", "primary_label", "enum")
+                                                    .map(&:downcase)
+                                                    .sort
+
     config.max_auto_evaluations_per_hour = 300
 
     config.titan_aws_region = ENV["TITAN_AWS_REGION"] || ENV.fetch("AWS_REGION", "eu-west-1")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
         get "question-routing-guardrails-failures", to: "metrics#question_routing_guardrails_failures",
                                                     as: :metrics_question_routing_guardrails_failures
         get "topics", to: "metrics#topics", as: :metrics_topics
+        get "request-types", to: "metrics#request_types", as: :metrics_request_types
         get "answer-completeness", to: "metrics#answer_completeness", as: :metrics_answer_completeness
       end
     end

--- a/spec/config/question_request_types_spec.rb
+++ b/spec/config/question_request_types_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "Question request type configuration" do
+  it "can locate the question request types in the private repo configuration" do
+    config = Rails.configuration.question_request_types
+
+    expect(config)
+      .to be_an(Array)
+      .and be_present
+  end
+end

--- a/spec/models/admin/filters/questions_filter_spec.rb
+++ b/spec/models/admin/filters/questions_filter_spec.rb
@@ -277,6 +277,32 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       expect(filter.results).to eq([tax_question])
     end
 
+    it "filters the results by primary request type" do
+      factual_lookup_answer = build(:answer, request_types: build(:answer_analysis_request_types, primary_request_type: "factual_lookup"))
+      factual_lookup_question = create(:question, answer: factual_lookup_answer)
+      do_task_answer = build(:answer, request_types: build(:answer_analysis_request_types, primary_request_type: "do_task"))
+      do_task_question = create(:question, answer: do_task_answer)
+
+      filter = described_class.new(primary_request_type: "factual_lookup")
+      expect(filter.results).to eq([factual_lookup_question])
+
+      filter = described_class.new(primary_request_type: "do_task")
+      expect(filter.results).to eq([do_task_question])
+    end
+
+    it "filters the results by secondary request type" do
+      factual_lookup_answer = build(:answer, request_types: build(:answer_analysis_request_types, secondary_request_type: "factual_lookup"))
+      factual_lookup_question = create(:question, answer: factual_lookup_answer)
+      do_task_answer = build(:answer, request_types: build(:answer_analysis_request_types, secondary_request_type: "do_task"))
+      do_task_question = create(:question, answer: do_task_answer)
+
+      filter = described_class.new(secondary_request_type: "factual_lookup")
+      expect(filter.results).to eq([factual_lookup_question])
+
+      filter = described_class.new(secondary_request_type: "do_task")
+      expect(filter.results).to eq([do_task_question])
+    end
+
     it "filters the results by completeness" do
       complete_answer = create(:answer, completeness: "complete")
       complete_question = create(:question, answer: complete_answer)
@@ -409,6 +435,7 @@ RSpec.describe Admin::Filters::QuestionsFilter do
         completeness: "complete",
       )
       create(:answer_analysis_topics, answer:, primary_topic: "business", secondary_topic: "tax")
+      create(:answer_analysis_request_types, answer:, primary_request_type: "factual_lookup", secondary_request_type: "do_task")
       create(:answer_feedback, answer:, reaction: :positive)
     end
 
@@ -429,6 +456,8 @@ RSpec.describe Admin::Filters::QuestionsFilter do
       question_routing_label: Answer.question_routing_labels.keys.first,
       primary_topic: "business",
       secondary_topic: "tax",
+      primary_request_type: "factual_lookup",
+      secondary_request_type: "do_task",
       completeness: "complete",
       conversation_session_id:,
       reaction: "positive",

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -426,6 +426,11 @@ RSpec.describe Answer do
       expect(answer.has_analysis?).to be(true)
     end
 
+    it "returns true if request types are present" do
+      answer = build(:answer, :with_request_types)
+      expect(answer.has_analysis?).to be(true)
+    end
+
     %i[answer_relevancy_runs coherence_runs faithfulness_runs context_relevancy_runs].each do |run_association|
       it "returns true if #{run_association} are present" do
         answer = build(

--- a/spec/requests/admin/metrics_spec.rb
+++ b/spec/requests/admin/metrics_spec.rb
@@ -535,6 +535,76 @@ RSpec.describe "Admin::MetricsController" do
     end
   end
 
+  describe "GET :request_types" do
+    it "renders a successful JSON response" do
+      get admin_metrics_request_types_path
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Type"]).to match("application/json")
+      expect(JSON.parse(response.body)).to eq([])
+    end
+
+    it "returns data of tagged request types for answers generated over the last 24 hours" do
+      2.times do
+        create(:answer_analysis_request_types,
+               answer: create(:answer, created_at: 2.hours.ago),
+               primary_request_type: "factual_lookup",
+               secondary_request_type: "do_task")
+      end
+      2.times do
+        create(:answer_analysis_request_types,
+               answer: create(:answer, created_at: 10.hours.ago),
+               primary_request_type: "do_task",
+               secondary_request_type: "eligibility")
+      end
+
+      create(
+        :answer_analysis_request_types,
+        answer: create(:answer, created_at: 26.hours.ago),
+        primary_request_type: "factual_lookup",
+        secondary_request_type: "do_task",
+      )
+
+      get admin_metrics_request_types_path
+
+      expect(JSON.parse(response.body)).to contain_exactly(
+        ["factual_lookup", 2],
+        ["do_task", 4],
+        ["eligibility", 2],
+      )
+    end
+
+    context "when period is last_7_days" do
+      it "returns data of the tagged request types for answers by day" do
+        2.times do
+          create(:answer_analysis_request_types,
+                 answer: create(:answer, created_at: 3.days.ago),
+                 primary_request_type: "factual_lookup",
+                 secondary_request_type: "do_task")
+        end
+        2.times do
+          create(:answer_analysis_request_types,
+                 answer: create(:answer, created_at: 4.days.ago),
+                 primary_request_type: "do_task",
+                 secondary_request_type: "eligibility")
+        end
+        create(
+          :answer_analysis_request_types,
+          answer: create(:answer, created_at: 8.days.ago),
+          primary_request_type: "factual_lookup",
+          secondary_request_type: "do_task",
+        )
+
+        get admin_metrics_request_types_path(period: "last_7_days")
+
+        expect(JSON.parse(response.body)).to contain_exactly(
+          { "name" => "factual_lookup", "data" => counts_for_last_7_days(days_ago_3: 2) },
+          { "name" => "do_task", "data" => counts_for_last_7_days(days_ago_3: 2, days_ago_4: 2) },
+          { "name" => "eligibility", "data" => counts_for_last_7_days(days_ago_4: 2) },
+        )
+      end
+    end
+  end
+
   describe "GET :answer_completeness" do
     it "renders a successful JSON response" do
       get admin_metrics_answer_completeness_path

--- a/spec/requests/admin/questions_spec.rb
+++ b/spec/requests/admin/questions_spec.rb
@@ -491,6 +491,88 @@ RSpec.describe "Admin::QuestionsController" do
          .and have_selector("#analysis-tab", text: topics.secondary_topic.capitalize)
       end
     end
+
+    context "when request types are present" do
+      let!(:request_types) do
+        create(
+          :answer_analysis_request_types,
+          primary_request_type: "factual_lookup",
+          secondary_request_type: "do_task",
+          confidence: 0.9,
+          reasoning: "The user is asking for a specific figure.",
+          metrics: {
+            request_type_tagger: {
+              duration: 1.5,
+              llm_prompt_tokens: 30,
+              llm_completion_tokens: 20,
+              llm_cached_tokens: 20,
+              model: BedrockModels.model_id(:openai_gpt_oss_120b),
+            },
+          },
+          llm_responses: {
+            "request_type_tagger" => {
+              "tool_calls": [
+                { "id": "request_type_tool_call" },
+              ],
+            },
+          },
+        )
+      end
+      let(:question) { request_types.answer.question }
+
+      it "renders the request types, confidence, reasoning and status" do
+        get admin_show_question_path(question)
+
+        expect(response.body)
+          .to have_content("Factual lookup")
+          .and have_content("Do task")
+          .and have_content("0.9")
+          .and have_content("The user is asking for a specific figure.")
+          .and have_content(request_types.status.humanize)
+      end
+
+      it "renders the error message and error status when the request type analysis errored" do
+        request_types.update!(
+          status: :error,
+          error_message: "An error occurred while analysing the request types.",
+        )
+
+        get admin_show_question_path(question)
+
+        expect(response.body)
+          .to have_content("Error")
+          .and have_content("An error occurred while analysing the request types.")
+      end
+
+      it "renders the request type metrics" do
+        get admin_show_question_path(question)
+
+        expect(response.body.squish)
+          .to have_content("request_type_tagger")
+          .and have_content(/duration.*1\.5/)
+          .and have_content(/llm_prompt_tokens.*30/)
+          .and have_content(/llm_completion_tokens.*20/)
+          .and have_content(/llm_cached_tokens.*20/)
+          .and have_content(/model.*#{BedrockModels.model_id(:openai_gpt_oss_120b)}/)
+      end
+
+      it "renders the request types LLM responses" do
+        get admin_show_question_path(question)
+
+        expect(response.body.squish)
+          .to have_content("request_type_tagger")
+          .and have_content("tool_calls")
+          .and have_content('"id": "request_type_tool_call"')
+      end
+
+      it "renders the request types in the analysis tab" do
+        get admin_show_question_path(question)
+
+        expect(response.body)
+         .to have_selector("#analysis-tab", text: request_types.primary_request_type.humanize)
+         .and have_selector("#analysis-tab", text: request_types.secondary_request_type.humanize)
+      end
+    end
   end
 
   def expect_unprocessable_content_with_date_errors

--- a/spec/system/admin/user_filters_questions_spec.rb
+++ b/spec/system/admin/user_filters_questions_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe "Admin user filters questions" do
     and_i_filter_by_questions_with_a_specific_question_routing_label
     then_i_see_the_question_with_that_routing_label
 
+    when_i_clear_the_filters
+    and_i_filter_by_questions_with_a_specific_primary_topic
+    then_i_see_the_question_with_that_primary_topic
+
+    when_i_clear_the_filters
+    and_i_filter_by_questions_with_a_specific_secondary_topic
+    then_i_see_the_question_with_that_secondary_topic
+
+    when_i_clear_the_filters
+    and_i_filter_by_questions_with_a_specific_primary_request_type
+    then_i_see_the_question_with_that_primary_request_type
+
+    when_i_clear_the_filters
+    and_i_filter_by_questions_with_a_specific_secondary_request_type
+    then_i_see_the_question_with_that_secondary_request_type
+
+    when_i_clear_the_filters
     when_i_view_the_questions_conversation
     and_i_filter_on_the_pending_status
     then_i_see_the_pending_question
@@ -81,6 +98,10 @@ RSpec.describe "Admin user filters questions" do
     @question3 = create(:question, conversation: api_conversation, message: "Greetings world", created_at: 1.minute.ago)
     create(:answer, question: @question2, question_routing_label: "non_english", completeness: :partial)
     create(:answer, status: :clarification, question: @question3)
+    create(:answer_analysis_topics, answer: @question2.answer, primary_topic: "business", secondary_topic: "tax")
+    create(:answer_analysis_topics, answer: @question3.answer, primary_topic: "tax", secondary_topic: "business")
+    create(:answer_analysis_request_types, answer: @question2.answer, primary_request_type: "factual_lookup", secondary_request_type: "do_task")
+    create(:answer_analysis_request_types, answer: @question3.answer, primary_request_type: "do_task", secondary_request_type: "factual_lookup")
     create(:answer_feedback, answer: @question2.answer, reaction: :positive)
     create(:answer_feedback, answer: @question3.answer, reaction: :negative)
   end
@@ -248,6 +269,50 @@ RSpec.describe "Admin user filters questions" do
     expect(page).to have_content(@question2.message)
     expect(page).not_to have_content(@question1.message)
     expect(page).not_to have_content(@question3.message)
+  end
+
+  def and_i_filter_by_questions_with_a_specific_primary_topic
+    select "Business", from: "primary_topic"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_that_primary_topic
+    expect(page).to have_content(@question2.message)
+    expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question3.message)
+  end
+
+  def and_i_filter_by_questions_with_a_specific_secondary_topic
+    select "Business", from: "secondary_topic"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_that_secondary_topic
+    expect(page).to have_content(@question3.message)
+    expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question2.message)
+  end
+
+  def and_i_filter_by_questions_with_a_specific_primary_request_type
+    select "Factual lookup", from: "primary_request_type"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_that_primary_request_type
+    expect(page).to have_content(@question2.message)
+    expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question3.message)
+  end
+
+  def and_i_filter_by_questions_with_a_specific_secondary_request_type
+    select "Factual lookup", from: "secondary_request_type"
+    click_button "Filter"
+  end
+
+  def then_i_see_the_question_with_that_secondary_request_type
+    expect(page).to have_content(@question3.message)
+    expect(page).not_to have_content(@question1.message)
+    expect(page).not_to have_content(@question2.message)
   end
 
   def when_i_view_the_questions_conversation

--- a/spec/system/admin/user_views_metrics_spec.rb
+++ b/spec/system/admin/user_views_metrics_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Admin user views metrics", :js do
     create_list(:question, 2)
     api_conversation = build(:conversation, source: :api, end_user_id: SecureRandom.uuid)
     create(:question, conversation: api_conversation)
-    create_list(:answer, 2, :with_topics, created_at: 6.hours.ago, status: :unanswerable_llm_cannot_answer)
+    create_list(:answer, 2, :with_topics, :with_request_types, created_at: 6.hours.ago, status: :unanswerable_llm_cannot_answer)
     create_list(:answer, 3, created_at: 4.hours.ago, status: :error_timeout)
     create_list(:answer, 1, created_at: 20.hours.ago, question_routing_label: :genuine_rag)
     create_list(:answer,
@@ -51,6 +51,7 @@ RSpec.describe "Admin user views metrics", :js do
     expect(page).to have_selector("#answer-guardrails-failures canvas")
     expect(page).to have_selector("#question-routing-guardrails-failures canvas")
     expect(page).to have_selector("#topics canvas")
+    expect(page).to have_selector("#request-types canvas")
     expect(page).to have_selector("#answer-completeness canvas")
   end
 

--- a/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
+++ b/spec/system/user_conversation_activity_is_shown_in_admin_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Users interactions with chat are shown in admin area", :aws_cred
 
     when_i_click_the_analysis_tab
     then_i_see_the_topics_have_been_tagged
+    and_i_see_the_request_types_have_been_tagged
     and_i_see_the_answer_relevancy_statistics
     and_i_dont_see_the_answer
   end
@@ -70,6 +71,12 @@ RSpec.describe "Users interactions with chat are shown in admin area", :aws_cred
     expect(page)
       .to have_content("Business")
       .and have_content("Benefits")
+  end
+
+  def and_i_see_the_request_types_have_been_tagged
+    expect(page)
+      .to have_content("Factual lookup")
+      .and have_content("Do task")
   end
 
   def and_i_dont_see_the_answer


### PR DESCRIPTION
## Description 

This follows on from #1276 which added some new answer analysis for the request type of the users question. This PR focusses on adding the results of the new metric to the Admin UI. It closely mirrors the topics implementation and:

- Updates the analysis tab on the question show page to include the records details when present
- Updates the questions index page to be filterable based on the primary and secondary request type
-  Adds request type to the admin metrics page (the one with graphs) that shows the results over the last 24hrs and week.

## Screenshots

<img width="367" height="656" alt="image" src="https://github.com/user-attachments/assets/edcef8bb-a597-4ae2-99e0-147b9771b2f5" />

<img width="615" height="602" alt="image" src="https://github.com/user-attachments/assets/0d11ebca-3208-4d69-9e5c-5e0416e478b6" />

<img width="545" height="351" alt="image" src="https://github.com/user-attachments/assets/cedb24b0-437b-4836-ad2c-f35e28a33599" />


## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-904