### PR TITLE
Add a rake task to backfill request types

### DIFF
--- a/lib/bigquery/individual_export.rb
+++ b/lib/bigquery/individual_export.rb
@@ -2,6 +2,8 @@ require "google/cloud/bigquery"
 
 module Bigquery
   class IndividualExport
+    BATCH_SIZE = 1_000
+
     Result = Data.define(:tempfile, :count)
 
     def self.remove_nil_values(json)
@@ -18,23 +20,21 @@ module Bigquery
     def self.call(...) = new.call(...)
 
     def call(model, export_from: nil, export_until: nil)
-      records_to_export = model.exportable(export_from, export_until)
-                                .map(&:serialize_for_export)
-      export_data = self.class.remove_nil_values(records_to_export)
+      tempfile = nil
+      count = 0
 
-      save_export_data_to_tempfile(export_data)
-    end
+      model.exportable(export_from, export_until).in_batches(of: BATCH_SIZE) do |batch|
+        export_data = self.class.remove_nil_values(batch.map(&:serialize_for_export))
+        next unless export_data
 
-  private
+        tempfile ||= Tempfile.new
+        export_data.each { |record| tempfile.puts(record.to_json) }
+        count += export_data.count
+      end
 
-    def save_export_data_to_tempfile(export_data)
-      return Result.new(tempfile: nil, count: 0) unless export_data
+      tempfile&.rewind
 
-      tempfile = Tempfile.new
-      export_data.each { |record| tempfile.puts(record.to_json) }
-      tempfile.rewind
-
-      Result.new(tempfile:, count: export_data.count)
+      Result.new(tempfile:, count:)
     end
   end
 end

--- a/lib/tasks/answer_analysis.rake
+++ b/lib/tasks/answer_analysis.rake
@@ -1,0 +1,77 @@
+namespace :answer_analysis do
+  desc "Backfill request types for eligible answers that haven't been tagged"
+  task backfill_request_types: :environment do
+    concurrency = 10
+
+    answers = Answer
+                .where(question_routing_label: Answer::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS)
+                .where.missing(:request_types)
+                .joins(:question)
+
+    total = answers.count
+    counts = { succeeded: 0, errored: 0, failed: 0 }
+    mutex = Mutex.new
+    processed = 0
+
+    puts "Backfilling request types for #{total} #{'answer'.pluralize(total)} " \
+         "with a concurrency of #{concurrency}"
+
+    tag_answer = lambda do |answer_id, question_used|
+      outcome = nil
+      failure = nil
+
+      begin
+        result = AutoEvaluation::RequestTypeTagger.call(question_used)
+
+        request_types = AnswerAnalysis::RequestTypes.new(
+          answer_id:,
+          status: result.status,
+          primary_request_type: result.primary_request_type,
+          secondary_request_type: result.secondary_request_type,
+          confidence: result.confidence,
+          reasoning: result.reasoning,
+          error_message: result.error_message,
+        )
+        request_types.assign_metrics("request_type_tagger", result.metrics)
+        request_types.assign_llm_response("request_type_tagger", result.llm_response)
+        request_types.save!
+
+        outcome = request_types.error? ? :errored : :succeeded
+      rescue StandardError => e
+        outcome = :failed
+        failure = e
+      end
+
+      mutex.synchronize do
+        counts[outcome] += 1
+        processed += 1
+
+        warn "Failed to tag answer #{answer_id}: #{failure.class}, #{failure.message}" if failure
+        puts "(#{processed} / #{total})" if (processed % 100).zero? || processed == total
+      end
+    end
+
+    answers.in_batches(of: 1_000) do |batch|
+      queue = Thread::Queue.new
+      batch.pluck(:id, :rephrased_question, "questions.message").each { queue.push(it) }
+      queue.close
+
+      threads = concurrency.times.map do
+        Thread.new do
+          while (row = queue.pop)
+            answer_id, rephrased_question, question_message = row
+
+            Rails.application.executor.wrap do
+              tag_answer.call(answer_id, rephrased_question || question_message)
+            end
+          end
+        end
+      end
+
+      threads.each(&:join)
+    end
+
+    puts "Tagged #{counts[:succeeded]} #{'answer'.pluralize(counts[:succeeded])}, " \
+         "#{counts[:errored]} tagged with an error status, #{counts[:failed]} failed"
+  end
+end

--- a/spec/lib/bigquery/individual_export_spec.rb
+++ b/spec/lib/bigquery/individual_export_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe Bigquery::IndividualExport do
         expect(result.count).to eq(3)
       end
 
+      it "writes every record to a single tempfile when they span multiple batches" do
+        stub_const("#{described_class}::BATCH_SIZE", 2)
+        create_list(:answer, 5, created_at: 2.hours.ago)
+
+        result = described_class.call(model, export_from:, export_until:)
+
+        expect(result.count).to eq(5)
+      end
+
       it "has a tempfile containing JSON of the models serialized for export with nil values removed" do
         # export timestamp is based on when answer is generated, hence easier to
         # create an answer and look up the question than a question with an

--- a/spec/lib/tasks/answer_analysis_spec.rb
+++ b/spec/lib/tasks/answer_analysis_spec.rb
@@ -1,0 +1,148 @@
+RSpec.describe "rake answer_analysis tasks" do
+  describe "answer_analysis:backfill_request_types" do
+    let(:task_name) { "answer_analysis:backfill_request_types" }
+    let(:eligible_label) { Answer::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS.sample }
+    let(:status) { "success" }
+    let(:error_message) { nil }
+    let(:result) do
+      AutoEvaluation::RequestTypeTagger::Result.new(
+        status:,
+        primary_request_type: "factual_lookup",
+        secondary_request_type: "do_task",
+        confidence: 0.9,
+        reasoning: "The user is asking for a specific figure.",
+        metrics: { "duration" => 1.5, "model" => "some-model" },
+        llm_response: { "model" => "some-model" },
+        error_message:,
+      )
+    end
+
+    def create_eligible_answer(message: nil, **attributes)
+      question = build(:question, message: message || "Message #{SecureRandom.uuid}")
+      create(:answer, question:, question_routing_label: eligible_label, **attributes)
+    end
+
+    before do
+      Rake::Task[task_name].reenable
+      allow(AutoEvaluation::RequestTypeTagger).to receive(:call).and_return(result)
+    end
+
+    it "tags every eligible answer that doesn't have request types" do
+      answers = Array.new(3) { create_eligible_answer }
+
+      expect { Rake::Task[task_name].invoke }
+        .to change(AnswerAnalysis::RequestTypes, :count).by(3)
+        .and output.to_stdout
+
+      answers.each do |answer|
+        expect(answer.reload.request_types)
+          .to have_attributes(
+            status: result.status,
+            primary_request_type: result.primary_request_type,
+            secondary_request_type: result.secondary_request_type,
+            confidence: result.confidence,
+            reasoning: result.reasoning,
+            metrics: { "request_type_tagger" => result.metrics },
+            llm_responses: { "request_type_tagger" => result.llm_response },
+            error_message: nil,
+          )
+      end
+    end
+
+    it "tags every answer exactly once when there are more of them than threads" do
+      Array.new(25) { create_eligible_answer }
+
+      expect { Rake::Task[task_name].invoke }
+        .to change(AnswerAnalysis::RequestTypes, :count).by(25)
+        .and output(a_string_including("Tagged 25 answers, 0 tagged with an error status, 0 failed"))
+        .to_stdout
+    end
+
+    it "tags the answer with the question message" do
+      create_eligible_answer(message: "How do I pay VAT?")
+
+      expect { Rake::Task[task_name].invoke }.to output.to_stdout
+
+      expect(AutoEvaluation::RequestTypeTagger).to have_received(:call).with("How do I pay VAT?")
+    end
+
+    it "tags the answer with the rephrased question when there is one" do
+      create_eligible_answer(message: "How do I pay VAT?", rephrased_question: "What is the VAT rate?")
+
+      expect { Rake::Task[task_name].invoke }.to output.to_stdout
+
+      expect(AutoEvaluation::RequestTypeTagger).to have_received(:call).with("What is the VAT rate?")
+    end
+
+    it "doesn't tag answers that already have request types" do
+      create(:answer, :with_request_types, question_routing_label: eligible_label)
+
+      expect { Rake::Task[task_name].invoke }
+        .to not_change(AnswerAnalysis::RequestTypes, :count)
+        .and output.to_stdout
+
+      expect(AutoEvaluation::RequestTypeTagger).not_to have_received(:call)
+    end
+
+    it "doesn't tag answers that aren't eligible for request type analysis" do
+      ineligible_labels = Answer.question_routing_labels.keys -
+        Answer::QUESTION_ROUTING_LABELS_FOR_REQUEST_TYPE_ANALYSIS
+      create(:answer, question_routing_label: ineligible_labels.sample)
+
+      expect { Rake::Task[task_name].invoke }
+        .to not_change(AnswerAnalysis::RequestTypes, :count)
+        .and output.to_stdout
+
+      expect(AutoEvaluation::RequestTypeTagger).not_to have_received(:call)
+    end
+
+    it "outputs a summary of the outcomes" do
+      create_eligible_answer
+
+      expect { Rake::Task[task_name].invoke }
+        .to output(a_string_including("Tagged 1 answer, 0 tagged with an error status, 0 failed"))
+        .to_stdout
+    end
+
+    context "when the AutoEvaluation::RequestTypeTagger returns an error status" do
+      let(:status) { "error" }
+      let(:error_message) { "An error occurred during request type tagging" }
+
+      it "creates request types with the error status and counts them separately" do
+        answer = create_eligible_answer
+
+        expect { Rake::Task[task_name].invoke }
+          .to output(a_string_including("Tagged 0 answers, 1 tagged with an error status, 0 failed"))
+          .to_stdout
+
+        expect(answer.reload.request_types).to have_attributes(status:, error_message:)
+      end
+    end
+
+    context "when tagging an answer raises an error" do
+      let(:error) { Aws::BedrockRuntime::Errors::ThrottlingException.new({}, "Too many requests") }
+
+      before do
+        allow(AutoEvaluation::RequestTypeTagger).to receive(:call).with("Fails").and_raise(error)
+        allow(AutoEvaluation::RequestTypeTagger).to receive(:call).with("Succeeds").and_return(result)
+      end
+
+      it "warns and carries on tagging the other answers" do
+        create_eligible_answer(message: "Fails")
+        succeeding_answer = create_eligible_answer(message: "Succeeds")
+
+        expect { Rake::Task[task_name].invoke }
+          .to change(AnswerAnalysis::RequestTypes, :count).by(1)
+          .and output(a_string_including("Tagged 1 answer, 0 tagged with an error status, 1 failed")).to_stdout
+          .and output(a_string_including("Aws::BedrockRuntime::Errors::ThrottlingException")).to_stderr
+
+        expect(succeeding_answer.reload.request_types).to be_present
+      end
+    end
+
+    it "doesn't raise when there are no answers to tag" do
+      expect { Rake::Task[task_name].invoke }
+        .to output(a_string_including("Backfilling request types for 0 answers")).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Description 

There are ~62,000 answers eligible for request type analysis that
predate the tagging, and each needs its own LLM call.

This adds a temporary take task that will be removed after we've backfilled
request type.

The task deliberately doesn't enqueue TagRequestTypesJob. That job
shares a 300 per hour auto-evaluation quota with every other analysis
job, so a backfill routed through it would exhaust the quota within
seconds and silently drop the work, stopping live auto-evaluation for
the duration. The logic for persisting a tagger result is duplicated
from the job rather than shared, as this task will be deleted once the
backfill is done.

Answers are read in batches of 1,000 and only their id and question are
selected, to avoid loading the whole backlog, and the large llm_responses
and metrics columns, into memory at once. Batching by id is safe here
even though tagging an answer removes it from the scope, as the rows
that stop matching are always behind the cursor.

Each batch is then tagged by a pool of 10 threads, which brings the
backfill down from around 36 hours to under 4. Bedrock's limits for
gpt-oss-120b are 10k requests and 100M tokens a minute, so this uses a
few percent of the available quota and leaves plenty of head room for
live auto-evaluation, which is capped at 300 evaluations an hour.

Interrupting the task is safe, as answers that already have request
types are excluded, so a later run picks up where it left off. Note that
answers tagged with an error status aren't retried by a later run.

## Testing on integration 

I ran it on 200 records on integration and it took ~35 seconds 1.19% usage of the rate limit.

```
govuk-chat(prod):001> a = AnswerAnalysis::RequestTypes.order(created_at: :desc).limit(200)

govuk-chat(prod):003> a.map(&:status).tally
=> {"success" => 200}
govuk-chat(prod):004> a.map(&:primary_request_type).tally
=>
{"factual_lookup" => 26,
 "verify_identity" => 34,
 "explore_topic" => 12,
 "update_details" => 9,
 "government_issue" => 12,
 "retrieve_own_information" => 26,
 "do_task" => 40,
 "rules_compliance" => 22,
 "eligibility" => 8,
 "track_application_status" => 4,
 "unclassifiable" => 2,
 "rule_or_service_change" => 1,
 "unknown_new_intent" => 1,
 "human_handoff" => 3}
govuk-chat(prod):005>

```

and with batches of 10 to show it works over multiple batches

```
not starting Prometheus metrics server: address already in use
Backfilling request types for 61264 answers with a concurrency of 10
(10 / 61264)
(20 / 61264)
(30 / 61264)

=>
["success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success",
 "success"]
govuk-chat(prod):005> AnswerAnalysis::RequestTypes.order(created_at: :desc).limit(30).map(&:primary_request_type).tally
=>
{"government_issue" => 5,
 "retrieve_own_information" => 6,
 "factual_lookup" => 2,
 "unknown_new_intent" => 1,
 "rules_compliance" => 1,
 "do_task" => 5,
 "track_application_status" => 1,
 "verify_identity" => 4,
 "explore_topic" => 1,
 "update_details" => 3,
 "unclassifiable" => 1}
```

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev

